### PR TITLE
ADD: ability to adjust graph model, not only reset it.

### DIFF
--- a/src/main/java/org/mastodon/mamut/importer/ModelImporter.java
+++ b/src/main/java/org/mastodon/mamut/importer/ModelImporter.java
@@ -13,6 +13,30 @@ public class ModelImporter extends AbstractModelImporter< Model >
 		this.model = model;
 	}
 
+	/**
+	 * Pauses listeners attached to graph and tags. Graph and tags can be updated silently.
+	 * Unpause with {@link #finishUpdate()}.
+	 */
+	@Override
+	protected void startUpdate()
+	{
+		super.startUpdate();
+		model.getTagSetModel().pauseListeners();
+	}
+
+	/**
+	 * A counter action to {@link #startUpdate()}.
+	 */
+	protected void finishUpdate()
+	{
+	    //this is only an alias...
+		finishImport();
+	}
+
+	/**
+	 * Pauses listeners attached to graph and tags. Graph and tags are cleared allowing
+	 * for a rebuilt from scratch (aka import). Unpause with {@link #finishImport()}.
+	 */
 	@Override
 	protected void startImport()
 	{
@@ -21,6 +45,9 @@ public class ModelImporter extends AbstractModelImporter< Model >
 		model.getTagSetModel().clear();
 	}
 
+	/**
+	 * A counter action to {@link #startImport()}.
+	 */
 	@Override
 	protected void finishImport()
 	{

--- a/src/main/java/org/mastodon/model/AbstractModelImporter.java
+++ b/src/main/java/org/mastodon/model/AbstractModelImporter.java
@@ -20,8 +20,13 @@ public abstract class AbstractModelImporter< M extends AbstractModel< ?, ?, ? > 
 
 	protected void startImport()
 	{
-		model.modelGraph.pauseListeners();
+		startUpdate();
 		model.modelGraph.clear();
+	}
+
+	protected void startUpdate()
+	{
+		model.modelGraph.pauseListeners();
 	}
 
 	protected void finishImport()


### PR DESCRIPTION
The standard way to pause model listeners and "lock" the model for changes is via
```
new AbstractModelImporter< Model >(pluginAppModel.getAppModel().getModel()) {{ startImport(); }};
//my code here
new AbstractModelImporter< Model >(pluginAppModel.getAppModel().getModel()) {{ finishImport(); }};
```
But `startImport` involves cleaning of the model... since I was blind to find how to only *update* the model without cleaning it first, I propose this PR.