### PR TITLE
Harness 2D datasets in BDV views.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		</dependency>
 
 		<!-- Test dependencies -->
-		
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -79,9 +79,9 @@
 					<groupId> net.sf.jgrapht</groupId>
 					<artifactId>jgrapht</artifactId>
 				</exclusion>
-			</exclusions> 
+			</exclusions>
 		</dependency>
-				
+
 	</dependencies>
 
 	<build>
@@ -130,6 +130,9 @@
 		<license.projectName>Mastodon</license.projectName>
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
+
+		<bigdataviewer-core.version>9.0.1</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-19</bigdataviewer-vistools.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
@@ -44,29 +44,29 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 	private static final String KEY_ZOOM_OUT_SLOW = "2d zoom out slow";
 
 	private static final String[] DRAG_TRANSLATE_KEYS = new String[] { "button2", "button3" };
-	private static final String[] ZOOM_NORMAL_KEYS = new String[] { "scroll" };
+	private static final String[] ZOOM_NORMAL_KEYS = new String[] { "meta scroll", "ctrl shift scroll" };
 	private static final String[] ZOOM_FAST_KEYS = new String[] { "shift scroll" };
 	private static final String[] ZOOM_SLOW_KEYS = new String[] { "ctrl scroll" };
 	private static final String[] DRAG_ROTATE_KEYS = new String[] { "button1" };
 	private static final String[] SCROLL_TRANSLATE_KEYS = new String[] { "not mapped" };
 	private static final String[] SCROLL_TRANSLATE_FAST_KEYS = new String[] { "not mapped" };
 	private static final String[] SCROLL_TRANSLATE_SLOW_KEYS = new String[] { "not mapped" };
-	private static final String[] SCROLL_ROTATE_KEYS = new String[] { "not mapped" };
-	private static final String[] SCROLL_ROTATE_FAST_KEYS = new String[] { "not mapped" };
-	private static final String[] SCROLL_ROTATE_SLOW_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_LEFT_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_RIGHT_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_LEFT_FAST_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_RIGHT_FAST_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_LEFT_SLOW_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_RIGHT_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_ROTATE_KEYS = new String[] { "scroll" };
+	private static final String[] SCROLL_ROTATE_FAST_KEYS = new String[] { "shift scroll" };
+	private static final String[] SCROLL_ROTATE_SLOW_KEYS = new String[] { "ctrl scroll" };
+	private static final String[] ROTATE_LEFT_KEYS = new String[] { "LEFT" };
+	private static final String[] ROTATE_RIGHT_KEYS = new String[] { "RIGHT" };
+	private static final String[] ROTATE_LEFT_FAST_KEYS = new String[] { "shift LEFT" };
+	private static final String[] ROTATE_RIGHT_FAST_KEYS = new String[] { "shift RIGHT" };
+	private static final String[] ROTATE_LEFT_SLOW_KEYS = new String[] { "ctrl LEFT" };
+	private static final String[] ROTATE_RIGHT_SLOW_KEYS = new String[] { "ctrl RIGHT" };
 
-	private static final String[] KEY_ZOOM_IN_KEYS = new String[] { "not mapped" };
-	private static final String[] KEY_ZOOM_OUT_KEYS = new String[] { "not mapped" };
-	private static final String[] KEY_ZOOM_IN_FAST_KEYS = new String[] { "not mapped" };
-	private static final String[] KEY_ZOOM_OUT_FAST_KEYS = new String[] { "not mapped" };
-	private static final String[] KEY_ZOOM_IN_SLOW_KEYS = new String[] { "not mapped" };
-	private static final String[] KEY_ZOOM_OUT_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_IN_KEYS = new String[] { "UP" };
+	private static final String[] KEY_ZOOM_OUT_KEYS = new String[] { "DOWN" };
+	private static final String[] KEY_ZOOM_IN_FAST_KEYS = new String[] { "shift UP" };
+	private static final String[] KEY_ZOOM_OUT_FAST_KEYS = new String[] { "shift DOWN" };
+	private static final String[] KEY_ZOOM_IN_SLOW_KEYS = new String[] { "ctrl UP" };
+	private static final String[] KEY_ZOOM_OUT_SLOW_KEYS = new String[] { "ctrl DOWN" };
 
 	private static final double[] SPEED = { 1.0, 10.0, 0.1 };
 
@@ -244,7 +244,6 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 		behaviours.behaviour( keyZoomOutFast, KEY_ZOOM_OUT_FAST, KEY_ZOOM_OUT_FAST_KEYS );
 		behaviours.behaviour( keyZoomOutSlow, KEY_ZOOM_OUT_SLOW, KEY_ZOOM_OUT_SLOW_KEYS );
 	}
-
 
 	@Override
 	public AffineTransform3D getTransform()

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
@@ -42,7 +42,7 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 	private static final String KEY_ZOOM_OUT = "2d zoom out";
 	private static final String KEY_ZOOM_OUT_FAST = "2d zoom out fast";
 	private static final String KEY_ZOOM_OUT_SLOW = "2d zoom out slow";
-	
+
 	private static final String[] DRAG_TRANSLATE_KEYS = new String[] { "button2", "button3" };
 	private static final String[] ZOOM_NORMAL_KEYS = new String[] { "scroll" };
 	private static final String[] ZOOM_FAST_KEYS = new String[] { "shift scroll" };
@@ -54,19 +54,19 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 	private static final String[] SCROLL_ROTATE_KEYS = new String[] { "not mapped" };
 	private static final String[] SCROLL_ROTATE_FAST_KEYS = new String[] { "not mapped" };
 	private static final String[] SCROLL_ROTATE_SLOW_KEYS = new String[] { "not mapped" };
-	private static final String[] ROTATE_LEFT_KEYS = new String[] { "LEFT" };
-	private static final String[] ROTATE_RIGHT_KEYS = new String[] { "RIGHT" };
-	private static final String[] ROTATE_LEFT_FAST_KEYS = new String[] { "shift LEFT" };
-	private static final String[] ROTATE_RIGHT_FAST_KEYS = new String[] { "shift RIGHT" };
-	private static final String[] ROTATE_LEFT_SLOW_KEYS = new String[] { "ctrl LEFT" };
-	private static final String[] ROTATE_RIGHT_SLOW_KEYS = new String[] { "ctrl RIGHT" };
-	
-	private static final String[] KEY_ZOOM_IN_KEYS = new String[] { "UP" };
-	private static final String[] KEY_ZOOM_OUT_KEYS = new String[] { "DOWN" };
-	private static final String[] KEY_ZOOM_IN_FAST_KEYS = new String[] { "shift UP" };
-	private static final String[] KEY_ZOOM_OUT_FAST_KEYS = new String[] { "shift DOWN" };
-	private static final String[] KEY_ZOOM_IN_SLOW_KEYS = new String[] { "ctrl UP" };
-	private static final String[] KEY_ZOOM_OUT_SLOW_KEYS = new String[] { "ctrl DOWN" };
+	private static final String[] ROTATE_LEFT_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_RIGHT_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_LEFT_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_RIGHT_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_LEFT_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_RIGHT_SLOW_KEYS = new String[] { "not mapped" };
+
+	private static final String[] KEY_ZOOM_IN_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_OUT_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_IN_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_OUT_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_IN_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] KEY_ZOOM_OUT_SLOW_KEYS = new String[] { "not mapped" };
 
 	private static final double[] SPEED = { 1.0, 10.0, 0.1 };
 
@@ -217,11 +217,11 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 	{
 		behaviours.behaviour( dragTranslate, DRAG_TRANSLATE, DRAG_TRANSLATE_KEYS );
 		behaviours.behaviour( dragRotate, DRAG_ROTATE,  DRAG_ROTATE_KEYS );
-		
+
 		behaviours.behaviour( scrollTranslateNormal, SCROLL_TRANSLATE, SCROLL_TRANSLATE_KEYS );
 		behaviours.behaviour( scrollTranslateFast, SCROLL_TRANSLATE_FAST, SCROLL_TRANSLATE_FAST_KEYS );
 		behaviours.behaviour( scrollTranslateSlow, SCROLL_TRANSLATE_SLOW, SCROLL_TRANSLATE_SLOW_KEYS );
-		
+
 		behaviours.behaviour( zoom, ZOOM_NORMAL, ZOOM_NORMAL_KEYS );
 		behaviours.behaviour( zoomFast, ZOOM_FAST, ZOOM_FAST_KEYS );
 		behaviours.behaviour( zoomSlow, ZOOM_SLOW, ZOOM_SLOW_KEYS );

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
@@ -1,0 +1,538 @@
+package org.mastodon.revised.bdv;
+
+import org.mastodon.revised.mamut.KeyConfigContexts;
+import org.mastodon.revised.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.revised.ui.keymap.CommandDescriptions;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.ClickBehaviour;
+import org.scijava.ui.behaviour.DragBehaviour;
+import org.scijava.ui.behaviour.ScrollBehaviour;
+import org.scijava.ui.behaviour.util.Behaviours;
+
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.ui.TransformListener;
+
+/**
+ * Adapted from BehaviourTransformEventHandlerPlanar in BDV-vistools, by Tobias
+ * Pietzsch.
+ */
+public class BehaviourTransformEventHandler2DMamut implements BehaviourTransformEventHandlerMamut
+{
+
+	private static final String DRAG_TRANSLATE = "2d drag translate";
+	private static final String DRAG_ROTATE = "2d drag rotate";
+	private static final String ZOOM_NORMAL = "2d scroll zoom";
+	private static final String ZOOM_FAST = "2d scroll zoom fast";
+	private static final String ZOOM_SLOW = "2d scroll zoom slow";
+	private static final String SCROLL_TRANSLATE = "2d scroll translate";
+	private static final String SCROLL_TRANSLATE_FAST = "2d scroll translate fast";
+	private static final String SCROLL_TRANSLATE_SLOW = "2d scroll translate slow";
+	private static final String SCROLL_ROTATE = "2d scroll rotate";
+	private static final String SCROLL_ROTATE_FAST = "2d scroll rotate fast";
+	private static final String SCROLL_ROTATE_SLOW = "2d scroll rotate slow";
+	private static final String ROTATE_LEFT = "2d rotate left";
+	private static final String ROTATE_LEFT_FAST = "2d rotate left fast";
+	private static final String ROTATE_LEFT_SLOW = "2d rotate left slow";
+	private static final String ROTATE_RIGHT = "2d rotate right";
+	private static final String ROTATE_RIGHT_FAST = "2d rotate right fast";
+	private static final String ROTATE_RIGHT_SLOW = "2d rotate right slow";
+	private static final String KEY_ZOOM_IN = "2d zoom in";
+	private static final String KEY_ZOOM_IN_FAST = "2d zoom in fast";
+	private static final String KEY_ZOOM_IN_SLOW = "2d zoom in slow";
+	private static final String KEY_ZOOM_OUT = "2d zoom out";
+	private static final String KEY_ZOOM_OUT_FAST = "2d zoom out fast";
+	private static final String KEY_ZOOM_OUT_SLOW = "2d zoom out slow";
+	
+	private static final String[] DRAG_TRANSLATE_KEYS = new String[] { "button2", "button3" };
+	private static final String[] ZOOM_NORMAL_KEYS = new String[] { "scroll" };
+	private static final String[] ZOOM_FAST_KEYS = new String[] { "shift scroll" };
+	private static final String[] ZOOM_SLOW_KEYS = new String[] { "ctrl scroll" };
+	private static final String[] DRAG_ROTATE_KEYS = new String[] { "button1" };
+	private static final String[] SCROLL_TRANSLATE_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_TRANSLATE_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_TRANSLATE_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_ROTATE_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_ROTATE_FAST_KEYS = new String[] { "not mapped" };
+	private static final String[] SCROLL_ROTATE_SLOW_KEYS = new String[] { "not mapped" };
+	private static final String[] ROTATE_LEFT_KEYS = new String[] { "LEFT" };
+	private static final String[] ROTATE_RIGHT_KEYS = new String[] { "RIGHT" };
+	private static final String[] ROTATE_LEFT_FAST_KEYS = new String[] { "shift LEFT" };
+	private static final String[] ROTATE_RIGHT_FAST_KEYS = new String[] { "shift RIGHT" };
+	private static final String[] ROTATE_LEFT_SLOW_KEYS = new String[] { "ctrl LEFT" };
+	private static final String[] ROTATE_RIGHT_SLOW_KEYS = new String[] { "ctrl RIGHT" };
+	
+	private static final String[] KEY_ZOOM_IN_KEYS = new String[] { "UP" };
+	private static final String[] KEY_ZOOM_OUT_KEYS = new String[] { "DOWN" };
+	private static final String[] KEY_ZOOM_IN_FAST_KEYS = new String[] { "shift UP" };
+	private static final String[] KEY_ZOOM_OUT_FAST_KEYS = new String[] { "shift DOWN" };
+	private static final String[] KEY_ZOOM_IN_SLOW_KEYS = new String[] { "ctrl UP" };
+	private static final String[] KEY_ZOOM_OUT_SLOW_KEYS = new String[] { "ctrl DOWN" };
+
+	private static final double[] SPEED = { 1.0, 10.0, 0.1 };
+
+	/*
+	 * Command descriptions for all provided commands
+	 */
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigContexts.BIGDATAVIEWER );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( DRAG_TRANSLATE, DRAG_TRANSLATE_KEYS, "Pan the view by mouse-dragging." );
+			descriptions.add( DRAG_ROTATE, DRAG_ROTATE_KEYS, "Rotate the view by mouse-dragging." );
+
+			descriptions.add( ZOOM_NORMAL, ZOOM_NORMAL_KEYS, "Zoom in by scrolling." );
+			descriptions.add( ZOOM_FAST, ZOOM_FAST_KEYS, "Zoom in by scrolling (fast)." );
+			descriptions.add( ZOOM_SLOW, ZOOM_SLOW_KEYS, "Zoom in by scrolling (slow)." );
+
+			descriptions.add( SCROLL_TRANSLATE, SCROLL_TRANSLATE_KEYS, "Translate by scrolling." );
+			descriptions.add( SCROLL_TRANSLATE_FAST, SCROLL_TRANSLATE_FAST_KEYS, "Translate by scrolling (fast)." );
+			descriptions.add( SCROLL_TRANSLATE_SLOW, SCROLL_TRANSLATE_SLOW_KEYS, "Translate by scrolling (slow)." );
+
+			descriptions.add( ROTATE_LEFT, ROTATE_LEFT_KEYS, "Rotate left (counter-clockwise) by 1 degree." );
+			descriptions.add( ROTATE_RIGHT, ROTATE_RIGHT_KEYS, "Rotate right (clockwise) by 1 degree." );
+			descriptions.add( KEY_ZOOM_IN, KEY_ZOOM_IN_KEYS, "Zoom in." );
+			descriptions.add( KEY_ZOOM_OUT, KEY_ZOOM_OUT_KEYS, "Zoom out." );
+
+			descriptions.add( ROTATE_LEFT_FAST, ROTATE_LEFT_FAST_KEYS, "Rotate left (counter-clockwise) by 10 degrees." );
+			descriptions.add( ROTATE_RIGHT_FAST, ROTATE_RIGHT_FAST_KEYS, "Rotate right (clockwise) by 10 degrees." );
+			descriptions.add( KEY_ZOOM_IN_FAST, KEY_ZOOM_IN_FAST_KEYS, "Zoom in (fast)." );
+			descriptions.add( KEY_ZOOM_OUT_FAST, KEY_ZOOM_OUT_FAST_KEYS, "Zoom out (fast)." );
+
+			descriptions.add( ROTATE_LEFT_SLOW, ROTATE_LEFT_SLOW_KEYS, "Rotate left (counter-clockwise) by 0.1 degree." );
+			descriptions.add( ROTATE_RIGHT_SLOW, ROTATE_RIGHT_SLOW_KEYS, "Rotate right (clockwise) by 0.1 degree." );
+			descriptions.add( KEY_ZOOM_IN_SLOW, KEY_ZOOM_IN_SLOW_KEYS, "Zoom in (slow)." );
+			descriptions.add( KEY_ZOOM_OUT_SLOW, KEY_ZOOM_OUT_SLOW_KEYS, "Zoom out (slow)." );
+
+			descriptions.add( SCROLL_ROTATE, SCROLL_ROTATE_KEYS, "Rotate by scrolling." );
+			descriptions.add( SCROLL_ROTATE_FAST, SCROLL_ROTATE_FAST_KEYS, "Rotate by scrolling (fast)." );
+			descriptions.add( SCROLL_ROTATE_SLOW, SCROLL_ROTATE_SLOW_KEYS, "Rotate by scrolling (slow)." );
+		}
+	}
+
+	private final DragTranslate dragTranslate;
+	private final DragRotate dragRotate;
+	private final Zoom zoom;
+	private final Zoom zoomFast;
+	private final Zoom zoomSlow;
+	private final ScrollTranslate scrollTranslateNormal;
+	private final ScrollTranslate scrollTranslateFast;
+	private final ScrollTranslate scrollTranslateSlow;
+	private final ScrollRotate scrollRotateNormal;
+	private final ScrollRotate scrollRotateFast;
+	private final ScrollRotate scrollRotateSlow;
+	private final KeyRotate keyRotateLeftNormal;
+	private final KeyRotate keyRotateLeftFast;
+	private final KeyRotate keyRotateLeftSlow;
+	private final KeyRotate keyRotateRightNormal;
+	private final KeyRotate keyRotateRightFast;
+	private final KeyRotate keyRotateRightSlow;
+	private final KeyZoom keyZoomInNormal;
+	private final KeyZoom keyZoomInFast;
+	private final KeyZoom keyZoomInSlow;
+	private final KeyZoom keyZoomOutNormal;
+	private final KeyZoom keyZoomOutFast;
+	private final KeyZoom keyZoomOutSlow;
+
+	/**
+	 * Current source to screen transform.
+	 */
+	private final AffineTransform3D affine = new AffineTransform3D();
+
+	/**
+	 * Whom to notify when the {@link #affine current transform} is changed.
+	 */
+	private TransformListener< AffineTransform3D > listener;
+
+	/**
+	 * Copy of {@link #affine current transform} when mouse dragging started.
+	 */
+	private final AffineTransform3D affineDragStart = new AffineTransform3D();
+
+	/**
+	 * Coordinates where mouse dragging started.
+	 */
+	private double oX;
+
+	private double oY;
+
+	/**
+	 * The screen size of the canvas (the component displaying the image and
+	 * generating mouse events).
+	 */
+	private int canvasW = 1;
+
+	private int canvasH = 1;
+
+	/**
+	 * Screen coordinates to keep centered while zooming or rotating with the
+	 * keyboard. These are set to <em>(canvasW/2, canvasH/2)</em>
+	 */
+	private int centerX = 0;
+
+	private int centerY = 0;
+
+	public BehaviourTransformEventHandler2DMamut( final TransformListener< AffineTransform3D > listener )
+	{
+		this.listener = listener;
+
+		dragTranslate = new DragTranslate();
+		dragRotate = new DragRotate();
+
+		scrollTranslateNormal = new ScrollTranslate( SPEED[ 0 ] );
+		scrollTranslateFast = new ScrollTranslate( SPEED[ 1 ] );
+		scrollTranslateSlow = new ScrollTranslate( SPEED[ 2 ] );
+
+		zoom = new Zoom( SPEED[ 0 ] );
+		zoomFast = new Zoom( SPEED[ 1 ] );
+		zoomSlow = new Zoom( SPEED[ 2 ] );
+
+		scrollRotateNormal = new ScrollRotate( 2 * SPEED[ 0 ] );
+		scrollRotateFast = new ScrollRotate( 2 * SPEED[ 1 ] );
+		scrollRotateSlow = new ScrollRotate( 2 * SPEED[ 2 ] );
+
+		keyRotateLeftNormal = new KeyRotate( SPEED[ 0 ] );
+		keyRotateLeftFast = new KeyRotate( SPEED[ 1 ] );
+		keyRotateLeftSlow = new KeyRotate( SPEED[ 2 ] );
+		keyRotateRightNormal = new KeyRotate( -SPEED[ 0 ] );
+		keyRotateRightFast = new KeyRotate( -SPEED[ 1 ] );
+		keyRotateRightSlow = new KeyRotate( -SPEED[ 2 ] );
+
+		keyZoomInNormal = new KeyZoom( SPEED[ 0 ] );
+		keyZoomInFast = new KeyZoom( SPEED[ 1 ] );
+		keyZoomInSlow = new KeyZoom( SPEED[ 2 ] );
+		keyZoomOutNormal = new KeyZoom( -SPEED[ 0 ] );
+		keyZoomOutFast = new KeyZoom( -SPEED[ 1 ] );
+		keyZoomOutSlow = new KeyZoom( -SPEED[ 2 ] );
+	}
+
+	@Override
+	public void install( final Behaviours behaviours )
+	{
+		behaviours.behaviour( dragTranslate, DRAG_TRANSLATE, DRAG_TRANSLATE_KEYS );
+		behaviours.behaviour( dragRotate, DRAG_ROTATE,  DRAG_ROTATE_KEYS );
+		
+		behaviours.behaviour( scrollTranslateNormal, SCROLL_TRANSLATE, SCROLL_TRANSLATE_KEYS );
+		behaviours.behaviour( scrollTranslateFast, SCROLL_TRANSLATE_FAST, SCROLL_TRANSLATE_FAST_KEYS );
+		behaviours.behaviour( scrollTranslateSlow, SCROLL_TRANSLATE_SLOW, SCROLL_TRANSLATE_SLOW_KEYS );
+		
+		behaviours.behaviour( zoom, ZOOM_NORMAL, ZOOM_NORMAL_KEYS );
+		behaviours.behaviour( zoomFast, ZOOM_FAST, ZOOM_FAST_KEYS );
+		behaviours.behaviour( zoomSlow, ZOOM_SLOW, ZOOM_SLOW_KEYS );
+
+		behaviours.behaviour( scrollRotateNormal, SCROLL_ROTATE, SCROLL_ROTATE_KEYS );
+		behaviours.behaviour( scrollRotateFast, SCROLL_ROTATE_FAST, SCROLL_ROTATE_FAST_KEYS );
+		behaviours.behaviour( scrollRotateSlow, SCROLL_ROTATE_SLOW, SCROLL_ROTATE_SLOW_KEYS );
+
+		behaviours.behaviour( keyRotateLeftNormal, ROTATE_LEFT, ROTATE_LEFT_KEYS );
+		behaviours.behaviour( keyRotateLeftFast, ROTATE_LEFT_FAST, ROTATE_LEFT_FAST_KEYS );
+		behaviours.behaviour( keyRotateLeftSlow, ROTATE_LEFT_SLOW, ROTATE_LEFT_SLOW_KEYS );
+		behaviours.behaviour( keyRotateRightNormal, ROTATE_RIGHT, ROTATE_RIGHT_KEYS );
+		behaviours.behaviour( keyRotateRightFast, ROTATE_RIGHT_FAST, ROTATE_RIGHT_FAST_KEYS );
+		behaviours.behaviour( keyRotateRightSlow, ROTATE_RIGHT_SLOW, ROTATE_RIGHT_SLOW_KEYS );
+
+		behaviours.behaviour( keyZoomInNormal,  KEY_ZOOM_IN, KEY_ZOOM_IN_KEYS );
+		behaviours.behaviour( keyZoomInFast, KEY_ZOOM_IN_FAST, KEY_ZOOM_IN_FAST_KEYS );
+		behaviours.behaviour( keyZoomInSlow, KEY_ZOOM_IN_SLOW, KEY_ZOOM_IN_SLOW_KEYS );
+		behaviours.behaviour( keyZoomOutNormal, KEY_ZOOM_OUT, KEY_ZOOM_OUT_KEYS );
+		behaviours.behaviour( keyZoomOutFast, KEY_ZOOM_OUT_FAST, KEY_ZOOM_OUT_FAST_KEYS );
+		behaviours.behaviour( keyZoomOutSlow, KEY_ZOOM_OUT_SLOW, KEY_ZOOM_OUT_SLOW_KEYS );
+	}
+
+
+	@Override
+	public AffineTransform3D getTransform()
+	{
+		synchronized ( affine )
+		{
+			return affine.copy();
+		}
+	}
+
+	@Override
+	public void setTransform( final AffineTransform3D transform )
+	{
+		synchronized ( affine )
+		{
+			affine.set( transform );
+		}
+	}
+
+	@Override
+	public void setCanvasSize( final int width, final int height, final boolean updateTransform )
+	{
+		if ( updateTransform )
+		{
+			synchronized ( affine )
+			{
+				affine.set( affine.get( 0, 3 ) - canvasW / 2, 0, 3 );
+				affine.set( affine.get( 1, 3 ) - canvasH / 2, 1, 3 );
+				affine.scale( ( double ) width / canvasW );
+				affine.set( affine.get( 0, 3 ) + width / 2, 0, 3 );
+				affine.set( affine.get( 1, 3 ) + height / 2, 1, 3 );
+				notifyListener();
+			}
+		}
+		canvasW = width;
+		canvasH = height;
+		centerX = width / 2;
+		centerY = height / 2;
+	}
+
+	@Override
+	public void setTransformListener( final TransformListener< AffineTransform3D > transformListener )
+	{
+		listener = transformListener;
+	}
+
+	@Override
+	public String getHelpString()
+	{
+		return null;
+	}
+
+	/**
+	 * notifies {@link #listener} that the current transform changed.
+	 */
+	private void notifyListener()
+	{
+		if ( listener != null )
+			listener.transformChanged( affine );
+	}
+
+	/**
+	 * One step of rotation (radian).
+	 */
+	final private static double step = Math.PI / 180;
+
+	private void scale( final double s, final double x, final double y )
+	{
+		// center shift
+		affine.set( affine.get( 0, 3 ) - x, 0, 3 );
+		affine.set( affine.get( 1, 3 ) - y, 1, 3 );
+
+		// scale
+		affine.scale( s );
+
+		// center un-shift
+		affine.set( affine.get( 0, 3 ) + x, 0, 3 );
+		affine.set( affine.get( 1, 3 ) + y, 1, 3 );
+	}
+
+	/**
+	 * Rotate by d radians around axis. Keep screen coordinates (
+	 * {@link #centerX}, {@link #centerY}) fixed.
+	 */
+	private void rotate( final int axis, final double d )
+	{
+		// center shift
+		affine.set( affine.get( 0, 3 ) - centerX, 0, 3 );
+		affine.set( affine.get( 1, 3 ) - centerY, 1, 3 );
+
+		// rotate
+		affine.rotate( axis, d );
+
+		// center un-shift
+		affine.set( affine.get( 0, 3 ) + centerX, 0, 3 );
+		affine.set( affine.get( 1, 3 ) + centerY, 1, 3 );
+	}
+
+	private class DragRotate implements DragBehaviour
+	{
+		@Override
+		public void init( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				oX = x;
+				oY = y;
+				affineDragStart.set( affine );
+			}
+		}
+
+		@Override
+		public void drag( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				final double dX = x - centerX;
+				final double dY = y - centerY;
+				final double odX = oX - centerX;
+				final double odY = oY - centerY;
+				final double theta = Math.atan2( dY, dX ) - Math.atan2( odY, odX );
+
+				affine.set( affineDragStart );
+				rotate( 2, theta );
+				notifyListener();
+			}
+		}
+
+		@Override
+		public void end( final int x, final int y )
+		{}
+	}
+
+	private class ScrollRotate implements ScrollBehaviour
+	{
+		private final double speed;
+
+		public ScrollRotate( final double speed )
+		{
+			this.speed = speed;
+		}
+
+		@Override
+		public void scroll( final double wheelRotation, final boolean isHorizontal, final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				final double theta = speed * wheelRotation * Math.PI / 180.0;
+
+				// center shift
+				affine.set( affine.get( 0, 3 ) - x, 0, 3 );
+				affine.set( affine.get( 1, 3 ) - y, 1, 3 );
+
+				affine.rotate( 2, theta );
+
+				// center un-shift
+				affine.set( affine.get( 0, 3 ) + x, 0, 3 );
+				affine.set( affine.get( 1, 3 ) + y, 1, 3 );
+
+				notifyListener();
+			}
+		}
+	}
+
+	private class DragTranslate implements DragBehaviour
+	{
+		@Override
+		public void init( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				oX = x;
+				oY = y;
+				affineDragStart.set( affine );
+			}
+		}
+
+		@Override
+		public void drag( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				final double dX = oX - x;
+				final double dY = oY - y;
+
+				affine.set( affineDragStart );
+				affine.set( affine.get( 0, 3 ) - dX, 0, 3 );
+				affine.set( affine.get( 1, 3 ) - dY, 1, 3 );
+				notifyListener();
+			}
+		}
+
+		@Override
+		public void end( final int x, final int y )
+		{}
+	}
+
+	private class ScrollTranslate implements ScrollBehaviour
+	{
+
+		private final double speed;
+
+		public ScrollTranslate( final double speed )
+		{
+			this.speed = speed;
+		}
+
+		@Override
+		public void scroll( final double wheelRotation, final boolean isHorizontal, final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				final double d = -wheelRotation * 10 * speed;
+				if ( isHorizontal )
+					affine.translate( d, 0, 0 );
+				else
+					affine.translate( 0, d, 0 );
+				notifyListener();
+			}
+		}
+	}
+
+	private class Zoom implements ScrollBehaviour
+	{
+
+		private final double speed;
+
+		public Zoom( final double speed )
+		{
+			this.speed = speed;
+		}
+
+		@Override
+		public void scroll( final double wheelRotation, final boolean isHorizontal, final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				final double s = speed * wheelRotation;
+				final double dScale = 1.0 + 0.05 * Math.abs( s );
+				if ( s > 0 )
+					scale( 1.0 / dScale, x, y );
+				else
+					scale( dScale, x, y );
+				notifyListener();
+			}
+		}
+	}
+
+	private class KeyRotate implements ClickBehaviour
+	{
+		private final double speed;
+
+		public KeyRotate( final double speed )
+		{
+			this.speed = speed;
+		}
+
+		@Override
+		public void click( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				rotate( 2, step * speed );
+				notifyListener();
+			}
+		}
+	}
+
+	private class KeyZoom implements ClickBehaviour
+	{
+		private final double dScale;
+
+		public KeyZoom( final double speed )
+		{
+			if ( speed > 0 )
+				dScale = 1.0 + 0.1 * speed;
+			else
+				dScale = 1.0 / ( 1.0 - 0.1 * speed );
+		}
+
+		@Override
+		public void click( final int x, final int y )
+		{
+			synchronized ( affine )
+			{
+				scale( dScale, centerX, centerY );
+				notifyListener();
+			}
+		}
+	}
+}

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler3DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler3DMamut.java
@@ -51,7 +51,7 @@ import net.imglib2.ui.TransformListener;
  * @author Stephan Saalfeld
  * @author Tobias Pietzsch
  */
-public class BehaviourTransformEventHandler3DMamut implements TransformEventHandler< AffineTransform3D >
+public class BehaviourTransformEventHandler3DMamut implements BehaviourTransformEventHandlerMamut
 {
 	public static final String DRAG_TRANSLATE = "drag translate";
 	public static final String ZOOM_NORMAL = "scroll zoom";
@@ -281,6 +281,7 @@ public class BehaviourTransformEventHandler3DMamut implements TransformEventHand
 		keyBackwardZSlowBehaviour = new KeyTranslateZ( KEY_BACKWARD_Z_SLOW, -speed[ 2 ] );
 	}
 
+	@Override
 	public void install( final Behaviours behaviours )
 	{
 		behaviours.namedBehaviour( drageTranslateBehaviour, DRAG_TRANSLATE_KEYS );

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandlerMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandlerMamut.java
@@ -1,46 +1,10 @@
 package org.mastodon.revised.bdv;
 
-import java.util.List;
-
-import org.scijava.ui.behaviour.util.Behaviours;
-
-import bdv.viewer.Source;
-import bdv.viewer.SourceAndConverter;
-import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.ui.TransformEventHandler;
+import org.scijava.ui.behaviour.util.Behaviours;
 
 public interface BehaviourTransformEventHandlerMamut extends TransformEventHandler< AffineTransform3D >
 {
-
-	public void install( Behaviours behaviours );
-
-	/**
-	 * Utility that returns <code>true</code> if all the sources specified are 2D.
-	 * 
-	 * @param sources
-	 *                          the list of sources to test.
-	 * @param numTimepoints
-	 *                          the number of time-points in the dataset.
-	 * @return <code>true</code> if all the sources specified are 2D.
-	 */
-	public static boolean is2D( final List< SourceAndConverter< ? > > sources, final int numTimepoints )
-	{
-		for ( final SourceAndConverter< ? > sac : sources )
-		{
-			final Source< ? > source = sac.getSpimSource();
-			for ( int t = 0; t < numTimepoints; t++ )
-			{
-				if ( source.isPresent( t ) )
-				{
-					final RandomAccessibleInterval< ? > level = source.getSource( t, 0 );
-					if ( level.dimension( 2 ) > 1 )
-						return false;
-
-					break;
-				}
-			}
-		}
-		return true;
-	}
+	void install( Behaviours behaviours );
 }

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandlerMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandlerMamut.java
@@ -1,0 +1,46 @@
+package org.mastodon.revised.bdv;
+
+import java.util.List;
+
+import org.scijava.ui.behaviour.util.Behaviours;
+
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.ui.TransformEventHandler;
+
+public interface BehaviourTransformEventHandlerMamut extends TransformEventHandler< AffineTransform3D >
+{
+
+	public void install( Behaviours behaviours );
+
+	/**
+	 * Utility that returns <code>true</code> if all the sources specified are 2D.
+	 * 
+	 * @param sources
+	 *                          the list of sources to test.
+	 * @param numTimepoints
+	 *                          the number of time-points in the dataset.
+	 * @return <code>true</code> if all the sources specified are 2D.
+	 */
+	public static boolean is2D( final List< SourceAndConverter< ? > > sources, final int numTimepoints )
+	{
+		for ( final SourceAndConverter< ? > sac : sources )
+		{
+			final Source< ? > source = sac.getSpimSource();
+			for ( int t = 0; t < numTimepoints; t++ )
+			{
+				if ( source.isPresent( t ) )
+				{
+					final RandomAccessibleInterval< ? > level = source.getSource( t, 0 );
+					if ( level.dimension( 2 ) > 1 )
+						return false;
+
+					break;
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/src/main/java/org/mastodon/revised/bdv/NavigationActionsMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/NavigationActionsMamut.java
@@ -106,12 +106,12 @@ public class NavigationActionsMamut
 		this.vg = viewer.getVisibilityAndGrouping();
 	}
 
-	public static void install( final Actions actions, final ViewerPanelMamut viewer )
+	public static void install( final Actions actions, final ViewerPanelMamut viewer, final boolean is2D )
 	{
-		new NavigationActionsMamut( viewer ).install( actions );
+		new NavigationActionsMamut( viewer ).install( actions, is2D );
 	}
 
-	public void install( final Actions actions )
+	public void install( final Actions actions, final boolean is2D )
 	{
 		actions.runnableAction( viewer::toggleInterpolation, TOGGLE_INTERPOLATION, TOGGLE_INTERPOLATION_KEYS );
 		actions.runnableAction(	this::toggleFusedMode, TOGGLE_FUSED_MODE, TOGGLE_FUSED_MODE_KEYS );
@@ -127,8 +127,11 @@ public class NavigationActionsMamut
 		actions.runnableAction( viewer::previousTimePoint, PREVIOUS_TIMEPOINT, PREVIOUS_TIMEPOINT_KEYS );
 
 		actions.runnableAction( () -> viewer.align( AlignPlane.XY ), ALIGN_XY_PLANE, ALIGN_XY_PLANE_KEYS );
-		actions.runnableAction( () -> viewer.align( AlignPlane.ZY ), ALIGN_ZY_PLANE, ALIGN_ZY_PLANE_KEYS );
-		actions.runnableAction( () -> viewer.align( AlignPlane.XZ ), ALIGN_XZ_PLANE, ALIGN_XZ_PLANE_KEYS );
+		if ( !is2D )
+		{
+			actions.runnableAction( () -> viewer.align( AlignPlane.ZY ), ALIGN_ZY_PLANE, ALIGN_ZY_PLANE_KEYS );
+			actions.runnableAction( () -> viewer.align( AlignPlane.XZ ), ALIGN_XZ_PLANE, ALIGN_XZ_PLANE_KEYS );
+		}
 	}
 
 	private void toggleFusedMode()

--- a/src/main/java/org/mastodon/revised/bdv/ViewerPanelMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/ViewerPanelMamut.java
@@ -15,13 +15,9 @@ public class ViewerPanelMamut extends ViewerPanel
 
 	public ViewerPanelMamut( final List< SourceAndConverter< ? > > sources, final int numTimepoints, final CacheControl cacheControl, final ViewerOptions optional )
 	{
-		super( sources, numTimepoints, cacheControl,
-				BehaviourTransformEventHandlerMamut.is2D( sources, numTimepoints )
-						? optional.transformEventHandlerFactory( BehaviourTransformEventHandler2DMamut::new )
-						: optional.transformEventHandlerFactory( BehaviourTransformEventHandler3DMamut::new ) );
+		super( sources, numTimepoints, cacheControl, optional );
 		transformEventHandler = ( BehaviourTransformEventHandlerMamut ) display.getTransformEventHandler();
 	}
-
 
 	public BehaviourTransformEventHandlerMamut getTransformEventHandler()
 	{

--- a/src/main/java/org/mastodon/revised/bdv/ViewerPanelMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/ViewerPanelMamut.java
@@ -11,15 +11,19 @@ public class ViewerPanelMamut extends ViewerPanel
 {
 	private static final long serialVersionUID = 1L;
 
-	private final BehaviourTransformEventHandler3DMamut transformEventHandler;
+	private final BehaviourTransformEventHandlerMamut transformEventHandler;
 
 	public ViewerPanelMamut( final List< SourceAndConverter< ? > > sources, final int numTimepoints, final CacheControl cacheControl, final ViewerOptions optional )
 	{
-		super( sources, numTimepoints, cacheControl, optional.transformEventHandlerFactory( BehaviourTransformEventHandler3DMamut::new ) );
-		transformEventHandler = ( BehaviourTransformEventHandler3DMamut ) display.getTransformEventHandler();
+		super( sources, numTimepoints, cacheControl,
+				BehaviourTransformEventHandlerMamut.is2D( sources, numTimepoints )
+						? optional.transformEventHandlerFactory( BehaviourTransformEventHandler2DMamut::new )
+						: optional.transformEventHandlerFactory( BehaviourTransformEventHandler3DMamut::new ) );
+		transformEventHandler = ( BehaviourTransformEventHandlerMamut ) display.getTransformEventHandler();
 	}
 
-	public BehaviourTransformEventHandler3DMamut getTransformEventHandler()
+
+	public BehaviourTransformEventHandlerMamut getTransformEventHandler()
 	{
 		return transformEventHandler;
 	}

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
@@ -8,9 +8,6 @@ import static org.mastodon.revised.mamut.MamutMenuBuilder.fileMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.viewMenu;
 
-import java.awt.event.ActionEvent;
-
-import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 
 import org.mastodon.app.ui.MastodonFrameViewActions;
@@ -49,7 +46,6 @@ import org.mastodon.revised.ui.coloring.GraphColorGeneratorAdapter;
 import org.mastodon.views.context.ContextProvider;
 
 import bdv.tools.InitializeViewerState;
-import net.imglib2.realtransform.AffineTransform3D;
 
 public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > >
 {
@@ -167,7 +163,10 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
 
-		NavigationActionsMamut.install( viewActions, viewer );
+		// TODO
+		final boolean is2D = BehaviourTransformEventHandlerMamut.is2D( sharedBdvData.getSources(), sharedBdvData.getNumTimepoints() );
+
+		NavigationActionsMamut.install( viewActions, viewer, is2D );
 		viewer.getTransformEventHandler().install( viewBehaviours );
 
 		viewer.addTimePointListener( timePointIndex -> timepointModel.setTimepoint( timePointIndex ) );
@@ -184,31 +183,6 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 
 //		if ( !bdv.tryLoadSettings( bdvFile ) ) // TODO
 //			InitializeViewerState.initBrightness( 0.001, 0.999, bdv.getViewer(), bdv.getSetupAssignments() );
-
-		// Fine-tune 2D data case.
-		if ( BehaviourTransformEventHandlerMamut.is2D( sharedBdvData.getSources(), sharedBdvData.getNumTimepoints() ) )
-		{
-			// Move transform at exactly z = 0.
-			final AffineTransform3D t = new AffineTransform3D();
-			viewer.getState().getViewerTransform( t );
-			t.set( 0., 2, 3 );
-			viewer.setCurrentViewerTransform( t );
-
-			// Blocks some actions that make no sense for 2D data.
-			final AbstractAction blockerAction =
-					new AbstractAction( "Do nothing" )
-					{
-
-						private static final long serialVersionUID = 1L;
-
-						@Override
-						public void actionPerformed( final ActionEvent e )
-						{
-						}
-					};
-			viewActions.getActionMap().put( "align ZY plane", blockerAction );
-			viewActions.getActionMap().put( "align XZ plane", blockerAction );
-		}
 	}
 
 	public ContextProvider< Spot > getContextProvider()

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
@@ -8,6 +8,9 @@ import static org.mastodon.revised.mamut.MamutMenuBuilder.fileMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.viewMenu;
 
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 
 import org.mastodon.app.ui.MastodonFrameViewActions;
@@ -16,6 +19,7 @@ import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.model.AutoNavigateFocusModel;
 import org.mastodon.revised.bdv.BdvContextProvider;
+import org.mastodon.revised.bdv.BehaviourTransformEventHandlerMamut;
 import org.mastodon.revised.bdv.BigDataViewerActionsMamut;
 import org.mastodon.revised.bdv.BigDataViewerMamut;
 import org.mastodon.revised.bdv.NavigationActionsMamut;
@@ -45,6 +49,7 @@ import org.mastodon.revised.ui.coloring.GraphColorGeneratorAdapter;
 import org.mastodon.views.context.ContextProvider;
 
 import bdv.tools.InitializeViewerState;
+import net.imglib2.realtransform.AffineTransform3D;
 
 public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > >
 {
@@ -179,6 +184,31 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 
 //		if ( !bdv.tryLoadSettings( bdvFile ) ) // TODO
 //			InitializeViewerState.initBrightness( 0.001, 0.999, bdv.getViewer(), bdv.getSetupAssignments() );
+
+		// Fine-tune 2D data case.
+		if ( BehaviourTransformEventHandlerMamut.is2D( sharedBdvData.getSources(), sharedBdvData.getNumTimepoints() ) )
+		{
+			// Move transform at exactly z = 0.
+			final AffineTransform3D t = new AffineTransform3D();
+			viewer.getState().getViewerTransform( t );
+			t.set( 0., 2, 3 );
+			viewer.setCurrentViewerTransform( t );
+
+			// Blocks some actions that make no sense for 2D data.
+			final AbstractAction blockerAction =
+					new AbstractAction( "Do nothing" )
+					{
+
+						private static final long serialVersionUID = 1L;
+
+						@Override
+						public void actionPerformed( final ActionEvent e )
+						{
+						}
+					};
+			viewActions.getActionMap().put( "align ZY plane", blockerAction );
+			viewActions.getActionMap().put( "align XZ plane", blockerAction );
+		}
 	}
 
 	public ContextProvider< Spot > getContextProvider()

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
@@ -16,7 +16,6 @@ import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.model.AutoNavigateFocusModel;
 import org.mastodon.revised.bdv.BdvContextProvider;
-import org.mastodon.revised.bdv.BehaviourTransformEventHandlerMamut;
 import org.mastodon.revised.bdv.BigDataViewerActionsMamut;
 import org.mastodon.revised.bdv.BigDataViewerMamut;
 import org.mastodon.revised.bdv.NavigationActionsMamut;
@@ -163,10 +162,7 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
 
-		// TODO
-		final boolean is2D = BehaviourTransformEventHandlerMamut.is2D( sharedBdvData.getSources(), sharedBdvData.getNumTimepoints() );
-
-		NavigationActionsMamut.install( viewActions, viewer, is2D );
+		NavigationActionsMamut.install( viewActions, viewer, sharedBdvData.is2D() );
 		viewer.getTransformEventHandler().install( viewBehaviours );
 
 		viewer.addTimePointListener( timePointIndex -> timepointModel.setTimepoint( timePointIndex ) );

--- a/src/main/resources/org/mastodon/revised/mamut/keyconf_fullbdv.yaml
+++ b/src/main/resources/org/mastodon/revised/mamut/keyconf_fullbdv.yaml
@@ -480,6 +480,98 @@
   contexts: [ts]
   triggers: [meta scroll, shift ctrl scroll]
 - !mapping
+  action: 2d drag translate
+  contexts: [bdv]
+  triggers: [button2, button3]
+- !mapping
+  action: 2d rotate left
+  contexts: [bdv]
+  triggers: [LEFT]
+- !mapping
+  action: 2d zoom in
+  contexts: [bdv]
+  triggers: [UP]
+- !mapping
+  action: 2d rotate right
+  contexts: [bdv]
+  triggers: [RIGHT]
+- !mapping
+  action: 2d zoom out
+  contexts: [bdv]
+  triggers: [DOWN]
+- !mapping
+  action: 2d drag rotate
+  contexts: [bdv]
+  triggers: [button1]
+- !mapping
+  action: 2d scroll zoom
+  contexts: [bdv]
+  triggers: [meta scroll, shift ctrl scroll]
+- !mapping
+  action: 2d rotate right slow
+  contexts: [bdv]
+  triggers: [ctrl RIGHT]
+- !mapping
+  action: 2d zoom out slow
+  contexts: [bdv]
+  triggers: [ctrl DOWN]
+- !mapping
+  action: 2d zoom out fast
+  contexts: [bdv]
+  triggers: [shift DOWN]
+- !mapping
+  action: 2d rotate right fast
+  contexts: [bdv]
+  triggers: [shift RIGHT]
+- !mapping
+  action: 2d scroll zoom slow
+  contexts: [bdv]
+  triggers: [ctrl scroll]
+- !mapping
+  action: 2d scroll rotate slow
+  contexts: [bdv]
+  triggers: [ctrl scroll]
+- !mapping
+  action: 2d zoom in fast
+  contexts: [bdv]
+  triggers: [shift UP]
+- !mapping
+  action: 2d rotate left fast
+  contexts: [bdv]
+  triggers: [shift LEFT]
+- !mapping
+  action: 2d rotate left slow
+  contexts: [bdv]
+  triggers: [ctrl LEFT]
+- !mapping
+  action: 2d scroll zoom fast
+  contexts: [bdv]
+  triggers: [shift scroll]
+- !mapping
+  action: 2d scroll rotate fast
+  contexts: [bdv]
+  triggers: [shift scroll]
+- !mapping
+  action: 2d zoom in slow
+  contexts: [bdv]
+  triggers: [ctrl UP]
+- !mapping
+  action: 2d scroll rotate
+  contexts: [bdv]
+  triggers: [scroll]
+- !mapping
+  action: 2d scroll translate slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll translate fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll translate
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
   action: edit vertex label
   contexts: [ts]
   triggers: [ENTER]

--- a/src/main/resources/org/mastodon/revised/mamut/keyconf_mastodon.yaml
+++ b/src/main/resources/org/mastodon/revised/mamut/keyconf_mastodon.yaml
@@ -532,6 +532,98 @@
   contexts: [bdv]
   triggers: [not mapped]
 - !mapping
+  action: 2d drag translate
+  contexts: [bdv]
+  triggers: [button2, button3]
+- !mapping
+  action: 2d rotate left
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom in
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d rotate right
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom out
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d drag rotate
+  contexts: [bdv]
+  triggers: [button1]
+- !mapping
+  action: 2d scroll zoom
+  contexts: [bdv]
+  triggers: [meta scroll, shift ctrl scroll]
+- !mapping
+  action: 2d rotate right slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom out slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom out fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d rotate right fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll zoom slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll rotate slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom in fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d rotate left fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d rotate left slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll zoom fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll rotate fast
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d zoom in slow
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll rotate
+  contexts: [bdv]
+  triggers: [not mapped]
+- !mapping
+  action: 2d scroll translate slow
+  contexts: [bdv]
+  triggers: [ctrl scroll]
+- !mapping
+  action: 2d scroll translate fast
+  contexts: [bdv]
+  triggers: [shift scroll]
+- !mapping
+  action: 2d scroll translate
+  contexts: [bdv]
+  triggers: [scroll]
+- !mapping
   action: create new project
   contexts: [mastodon]
   triggers: [not mapped]


### PR DESCRIPTION
This commit brings a convenient way to deal with 2D datasets in Mastodon-app, specifically for the BDV view.

A special `BehaviourTransformEventHandler` is passed to the viewer panel when the data is found to be 2D. It features custom behaviours. Fine tuning is done in the `MamutViewBdv`: we remove actions that align the data with XZ or ZY planes, and sets the transform at z=0.

This was adapted from a similar feature in the MaMuT software.