### PR TITLE
BDV visibility modes.

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -36,6 +36,7 @@ import org.mastodon.views.bdv.overlay.BdvHighlightHandler;
 import org.mastodon.views.bdv.overlay.BdvSelectionBehaviours;
 import org.mastodon.views.bdv.overlay.EditBehaviours;
 import org.mastodon.views.bdv.overlay.EditSpecialBehaviours;
+import org.mastodon.views.bdv.overlay.OverlayActions;
 import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
 import org.mastodon.views.bdv.overlay.OverlayNavigation;
 import org.mastodon.views.bdv.overlay.RenderSettings;
@@ -163,6 +164,7 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		EditSpecialBehaviours.install( viewBehaviours, frame.getViewerPanel(), viewGraph, tracksOverlay, selectionModel, focusModel, model );
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
+		OverlayActions.install( viewActions, viewer, tracksOverlay );
 
 		NavigationActionsMamut.install( viewActions, viewer, sharedBdvData.is2D() );
 		viewer.getTransformEventHandler().install( viewBehaviours );
@@ -181,6 +183,9 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 
 		// Give focus to display so that it can receive key-presses immediately.
 		viewer.getDisplay().requestFocusInWindow();
+
+		// Notifies context provider that context changes when visibility mode changes.
+		tracksOverlay.getVisibilities().getVisibilityListeners().add( contextProvider::notifyContextChanged);
 
 //		if ( !bdv.tryLoadSettings( bdvFile ) ) // TODO
 //			InitializeViewerState.initBrightness( 0.001, 0.999, bdv.getViewer(), bdv.getSetupAssignments() );

--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayActions.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayActions.java
@@ -1,0 +1,49 @@
+package org.mastodon.views.bdv.overlay;
+
+import org.mastodon.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.views.bdv.overlay.Visibilities.VisibilityMode;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.util.Actions;
+
+import bdv.viewer.ViewerPanel;
+
+/**
+ * Install actions related to the track overlay over a BDV window.
+ */
+public class OverlayActions
+{
+	public static final String CYCLE_VISIBILITY_MODE = "cycle visibility mode";
+
+	public static final String[] CYCLE_VISIBILITY_MODE_KEYS = new String[] { "V" };
+
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigContexts.BIGDATAVIEWER );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( CYCLE_VISIBILITY_MODE, CYCLE_VISIBILITY_MODE_KEYS,
+					"Cycle across the visibility modes for the overlay in BDV." );
+		}
+	}
+
+	public static void install(
+			final Actions actions,
+			final ViewerPanel viewerPanel,
+			final OverlayGraphRenderer< ?, ? > renderer )
+	{
+		actions.runnableAction( () -> {
+			// Cycle mode.
+			final VisibilityMode mode = renderer.nextVisibilityMode();
+			// Show message.
+			viewerPanel.showMessage( "Overlay visibility: " + mode );
+		}, CYCLE_VISIBILITY_MODE, CYCLE_VISIBILITY_MODE_KEYS );
+	}
+}

--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
@@ -26,6 +26,8 @@ import org.mastodon.spatial.SpatioTemporalIndex;
 import org.mastodon.ui.coloring.GraphColorGenerator;
 import org.mastodon.util.GeometryUtil;
 import org.mastodon.views.bdv.overlay.ScreenVertexMath.Ellipse;
+import org.mastodon.views.bdv.overlay.Visibilities.Visibility;
+import org.mastodon.views.bdv.overlay.Visibilities.VisibilityMode;
 import org.mastodon.views.bdv.overlay.util.BdvRendererUtil;
 
 import bdv.util.Affine3DHelpers;
@@ -92,6 +94,8 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 	private RenderSettings settings;
 
+	private final Visibilities< V, E > visibilities;
+
 	public OverlayGraphRenderer(
 			final OverlayGraph< V, E > graph,
 			final HighlightModel< V, E > highlight,
@@ -104,6 +108,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		this.focus = focus;
 		this.selection = selection;
 		this.coloring = coloring;
+		this.visibilities = new Visibilities<>( graph, selection, focus, graph.getLock() );
 		index = graph.getIndex();
 		renderTransform = new AffineTransform3D();
 		setRenderSettings( RenderSettings.defaultStyle() ); // default RenderSettings
@@ -134,6 +139,16 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	public void setRenderSettings( final RenderSettings settings )
 	{
 		this.settings = settings;
+	}
+
+	public VisibilityMode nextVisibilityMode()
+	{
+		return visibilities.nextMode();
+	}
+
+	public Visibilities< V, E > getVisibilities()
+	{
+		return visibilities;
 	}
 
 	public static final double pointRadius = 2.5;
@@ -405,9 +420,10 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			final int currentTimepoint,
 			final EdgeOperation< E > edgeOperation )
 	{
-		if ( !settings.getDrawLinks())
+		if ( !settings.getDrawLinks() || visibilities.getMode() == VisibilityMode.NONE )
 			return;
 
+		final Visibility< V, E > visibility = visibilities.getVisibility();
 		final double maxDepth = getMaxDepth( transform );
 
 		final V ref = graph.vertexRef();
@@ -435,6 +451,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 				for ( final E edge : vertex.incomingEdges() )
 				{
+					if ( !visibility.isVisible( edge ) )
+						continue;
+
 					final V source = edge.getSource( ref );
 					source.localize( gPos );
 					transform.apply( gPos, lPos );
@@ -458,6 +477,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	@Override
 	public void drawOverlays( final Graphics g )
 	{
+		if ( visibilities.getMode() == VisibilityMode.NONE )
+			return;
+
 		final Graphics2D graphics = ( Graphics2D ) g;
 		final BasicStroke defaultVertexStroke = new BasicStroke();
 		final BasicStroke highlightedVertexStroke = new BasicStroke( 4f );
@@ -544,6 +566,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 				final boolean drawEllipsoidSliceIntersection = settings.getDrawEllipsoidSliceIntersection();
 				final boolean drawEllipsoidSliceProjection = settings.getDrawEllipsoidSliceProjection();
 				final double pointFadeDepth = settings.getPointFadeDepth();
+				final Visibility< V, E > visibility = visibilities.getVisibility();
 
 				final V highlighted = highlight.getHighlightedVertex( ref1 );
 				final V focused = focus.getFocusedVertex( ref2 );
@@ -556,6 +579,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 				ccp.clip( cropPolytopeGlobal );
 				for ( final V vertex : ccp.getInsideValues() )
 				{
+					if ( !visibility.isVisible( vertex ) )
+						continue;
+
 					final int color = coloring.color( vertex );
 					final boolean isHighlighted = vertex.equals( highlighted );
 					final boolean isFocused = vertex.equals( focused );
@@ -716,7 +742,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		class Op implements EdgeOperation< E >
 		{
 			final double squTolerance = tolerance * tolerance;
+
 			double bestSquDist = Double.POSITIVE_INFINITY;
+
 			boolean found = false;
 
 			@Override
@@ -821,12 +849,13 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	 */
 	public V getVertexAt( final int x, final int y, final double tolerance, final V ref )
 	{
-		if ( !settings.getDrawSpots() )
+		if ( !settings.getDrawSpots() || ( visibilities.getMode() == VisibilityMode.NONE ) )
 			return null;
 
 		final AffineTransform3D transform = getRenderTransformCopy();
 		final double maxDepth = getMaxDepth( transform );
 		final int currentTimepoint = renderTimepoint;
+		final Visibility< V, E > visibility = visibilities.getVisibility();
 
 		final double[] lPos = new double[] { x, y, 0 };
 		final double[] gPos = new double[ 3 ];
@@ -850,6 +879,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			ccp.clip( cropPolytopeGlobal );
 			for ( final V vertex : ccp.getInsideValues() )
 			{
+				if ( !visibility.isVisible( vertex ) )
+					continue;
+
 				screenVertexMath.init( vertex, transform );
 				final double z = screenVertexMath.getViewPos()[ 2 ];
 				final double sd = sliceDistance( z, maxDepth );
@@ -875,6 +907,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			while ( inns.hasNext() )
 			{
 				final V vertex = inns.next();
+				if ( !visibility.isVisible( vertex ) )
+					continue;
+
 				if ( inns.getSquareDistance() > maxSquDist )
 					break;
 				screenVertexMath.init( vertex, transform );
@@ -892,7 +927,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			final NearestNeighborSearch< V > nns = index.getSpatialIndex( currentTimepoint ).getNearestNeighborSearch();
 			nns.search( RealPoint.wrap( gPos ) );
 			final V vertex = nns.getSampler().get();
-			if ( vertex != null )
+			if ( vertex != null && visibility.isVisible( vertex ) )
 			{
 				screenVertexMath.init( vertex, transform );
 				final double z = screenVertexMath.getViewPos()[ 2 ];
@@ -936,18 +971,25 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	RefCollection< V > getVisibleVertices( final AffineTransform3D transform, final int timepoint )
 	{
 		final RefList< V > contextList = RefCollections.createRefList( graph.vertices() );
+		if ( visibilities.getMode() == VisibilityMode.NONE )
+			return contextList;
+
 		final double maxDepth = getMaxDepth( transform );
 		final boolean drawPointsAlways = drawPointsAlways();
 		final boolean drawPointsMaybe = drawPointsMaybe();
 		final boolean drawEllipsoidSliceIntersection = settings.getDrawEllipsoidSliceIntersection();
 		final boolean drawEllipsoidSliceProjection = settings.getDrawEllipsoidSliceProjection();
 		final ScreenVertexMath screenVertexMath = new ScreenVertexMath();
+		final Visibility< V, E > visibility = visibilities.getVisibility();
 
 		final ConvexPolytope cropPolytopeGlobal = getVisiblePolytopeGlobal( transform, timepoint );
 		final ClipConvexPolytope< V > ccp = index.getSpatialIndex( timepoint ).getClipConvexPolytope();
 		ccp.clip( cropPolytopeGlobal );
 		for ( final V vertex : ccp.getInsideValues() )
 		{
+			if ( !visibility.isVisible( vertex ) )
+				continue;
+
 			screenVertexMath.init( vertex, transform );
 
 			if ( drawEllipsoidSliceIntersection )

--- a/src/main/java/org/mastodon/views/bdv/overlay/Visibilities.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/Visibilities.java
@@ -1,0 +1,447 @@
+package org.mastodon.views.bdv.overlay;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.mastodon.collection.RefCollections;
+import org.mastodon.collection.RefSet;
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.ReadOnlyGraph;
+import org.mastodon.graph.Vertex;
+import org.mastodon.graph.algorithm.AbstractGraphAlgorithm;
+import org.mastodon.graph.algorithm.util.Graphs;
+import org.mastodon.model.FocusListener;
+import org.mastodon.model.FocusModel;
+import org.mastodon.model.SelectionListener;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.util.Listeners;
+
+/**
+ * Manages several visibility modes for the vertices and edges of a graph.
+ * <p>
+ * Each visibility mode is identified by the enum {@link VisibilityMode}. The
+ * current visibility mode stored in an instance of this class can be accessed
+ * with {@link #getMode()} and cycled with {@link #nextMode()}.
+ * <p>
+ * {@link Visibilities} can return useful implementation of the
+ * {@link Visibility} interface, that can state whether a vertex or an edge is
+ * visible. The {@link Visibility} instance behavior returned by
+ * {@link #getVisibility()} matches the visibility mode.
+ * <p>
+ * Listeners implementing the {@link VisibilityListener} interface can register
+ * to an instance of this class, to be notified when the visibility of the
+ * current mode changes. This might happens for instance
+ * <ul>
+ * <li>when the visibility mode changes;</li>
+ * <li>when the selection changes in the {@link VisibilityMode#SELECTION} mode;
+ * <li>when the focus changes in the
+ * {@link VisibilityMode#TRACK_OF_FOCUSED_VERTEX} mode.
+ * </ul>
+ *
+ * @author Jean-Yves Tinevez
+ * @param <V>
+ *            the type of model vertex.
+ * @param <E>
+ *            the type of model edge.
+ */
+public class Visibilities< V extends Vertex< E >, E extends Edge< V > >
+{
+
+	private final ReadOnlyGraph< V, E > graph;
+
+	private final SelectionModel< V, E > selectionModel;
+
+	private final FocusModel< V, E > focusModel;
+
+	private VisibilityMode currentMode;
+
+	private Visibility< V, E > currentVisibility;
+
+	private final ReentrantReadWriteLock lock;
+
+	private final Listeners.List< VisibilityListener > visibilityListeners;
+
+	/**
+	 * Used to keep track of the listener we added to the
+	 * {@link SelectionModel}, to deregister it if we have.
+	 */
+	private SelectionListener previousSelectionListener;
+
+	/**
+	 * Used to keep track of the listener we added to the {@link FocusModel}, to
+	 * deregister it if we have.
+	 */
+	private FocusListener previousFocusListener;
+
+	/**
+	 * Creates a new visibilities instance.
+	 *
+	 * @param graph
+	 *            the graph of the objects we want to control visibility of.
+	 * @param selectionModel
+	 *            a selection model built on the specified graph, to be used on
+	 *            the {@link VisibilityMode#SELECTION} mode.
+	 * @param focusModel
+	 *            a focus model built on the specified graph, to be used on the
+	 *            {@link VisibilityMode#TRACK_OF_FOCUSED_VERTEX} mode.
+	 * @param lock
+	 *            the lock on the specified graph, used to read-lock the graph
+	 *            when building the {@link Visibility} instances.
+	 */
+	public Visibilities(
+			final ReadOnlyGraph< V, E > graph,
+			final SelectionModel< V, E > selectionModel,
+			final FocusModel< V, E > focusModel,
+			final ReentrantReadWriteLock lock )
+	{
+		this.graph = graph;
+		this.selectionModel = selectionModel;
+		this.focusModel = focusModel;
+		this.lock = lock;
+		this.visibilityListeners = new Listeners.SynchronizedList<>();
+		setMode( VisibilityMode.ALL );
+	}
+
+	/**
+	 * Cycles to the next visibility mode.
+	 *
+	 * @return the new visibility mode.
+	 */
+	public VisibilityMode nextMode()
+	{
+		final List< VisibilityMode > modes = Arrays.asList( VisibilityMode.values() );
+		int indexOf = modes.indexOf( currentMode );
+		if ( indexOf == modes.size() - 1 )
+			indexOf = -1;
+
+		setMode( modes.get( indexOf + 1 ) );
+		return currentMode;
+	}
+
+	/**
+	 * Sets the current visibility mode.
+	 *
+	 * @param mode
+	 *            the visibility mode.
+	 */
+	public void setMode( final VisibilityMode mode )
+	{
+		currentMode = mode;
+		currentVisibility = createVisibility();
+	}
+
+	/**
+	 * Returns the current visibility mode.
+	 *
+	 * @return the visibility mode.
+	 */
+	public VisibilityMode getMode()
+	{
+		return currentMode;
+	}
+
+	/**
+	 * Returns the visibility instance corresponding to the current visibility
+	 * mode.
+	 *
+	 * @return the visibility object.
+	 */
+	public Visibility< V, E > getVisibility()
+	{
+		return currentVisibility;
+	}
+
+	private Visibility< V, E > createVisibility()
+	{
+		// Deregister previous focus listener.
+		if ( null != previousFocusListener )
+		{
+			focusModel.listeners().remove( previousFocusListener );
+			previousFocusListener = null;
+		}
+		// Deregister previous selection listener.
+		if ( null != previousSelectionListener )
+		{
+			selectionModel.listeners().remove( previousSelectionListener );
+			previousSelectionListener = null;
+		}
+
+		switch ( currentMode )
+		{
+		case ALL:
+			notifyListeners();
+			return new AllVisibility<>();
+		case NONE:
+			notifyListeners();
+			return new NoneVisibility<>();
+		case SELECTION:
+			final SelectionVisibility selectionVisibility = new SelectionVisibility( selectionModel );
+			selectionVisibility.selectionChanged();
+			selectionModel.listeners().add( selectionVisibility );
+			previousSelectionListener = selectionVisibility;
+			return selectionVisibility;
+		case TRACK_OF_FOCUSED_VERTEX:
+			final TrackOfFocusedVisibility trackOfFocusedVisibility = new TrackOfFocusedVisibility( graph, focusModel, lock );
+			trackOfFocusedVisibility.focusChanged();
+			focusModel.listeners().add( trackOfFocusedVisibility );
+			previousFocusListener = trackOfFocusedVisibility;
+			return trackOfFocusedVisibility;
+		default:
+			throw new IllegalArgumentException( "Unknwon VisibilityMode: " + currentMode );
+		}
+	}
+
+	private void notifyListeners()
+	{
+		for ( final VisibilityListener l : visibilityListeners.list )
+			l.visibilityChanged();
+	}
+
+	/**
+	 * Exposes the visibility listeners that will be notified when the
+	 * visibility changes. Notification will be triggered for instance:
+	 * <ul>
+	 * <li>when the visibility mode changes;</li>
+	 * <li>when the selection changes in the {@link VisibilityMode#SELECTION}
+	 * mode;
+	 * <li>when the focus changes in the
+	 * {@link VisibilityMode#TRACK_OF_FOCUSED_VERTEX} mode.
+	 * </ul>
+	 *
+	 * @return
+	 */
+	public Listeners< VisibilityListener > getVisibilityListeners()
+	{
+		return visibilityListeners;
+	}
+
+	/**
+	 * Interface for listeners that will be notified when visibility changes.
+	 */
+	public static interface VisibilityListener
+	{
+		/**
+		 * Called when the visibility changes.
+		 */
+		public void visibilityChanged();
+	}
+
+	/**
+	 * Class that can determine whether the objects of a graph are visible or
+	 * not.
+	 *
+	 * @param <V>
+	 *            the type of model vertex.
+	 * @param <E>
+	 *            the type of model edge.
+	 */
+	public static interface Visibility< V extends Vertex< E >, E extends Edge< V > >
+	{
+		/**
+		 * Returns whether the specified vertex is visible.
+		 *
+		 * @param v
+		 *            the vertex.
+		 * @return <code>true</code> if the specified vertex is visible.
+		 */
+		public boolean isVisible( V v );
+
+		/**
+		 * Returns whether the specified edge is visible.
+		 *
+		 * @param e
+		 *            the edge.
+		 * @return <code>true</code> if the specified edge is visible.
+		 */
+		public boolean isVisible( E e );
+	}
+
+	private class TrackOfFocusedVisibility implements Visibility< V, E >, FocusListener
+	{
+
+		private final FocusModel< V, E > focusModel;
+
+		private final ReadOnlyGraph< V, E > graph;
+
+		private final RefSet< V > vertices;
+
+		private final RefSet< E > edges;
+
+		private final ReentrantReadWriteLock lock;
+
+		public TrackOfFocusedVisibility( final ReadOnlyGraph< V, E > graph, final FocusModel< V, E > focusModel, final ReentrantReadWriteLock lock )
+		{
+			this.graph = graph;
+			this.focusModel = focusModel;
+			this.lock = lock;
+			this.vertices = RefCollections.createRefSet( graph.vertices() );
+			this.edges = RefCollections.createRefSet( graph.edges() );
+		}
+
+		@Override
+		public boolean isVisible( final V v )
+		{
+			return vertices.contains( v );
+		}
+
+		@Override
+		public boolean isVisible( final E e )
+		{
+			return edges.contains( e );
+		}
+
+		@Override
+		public void focusChanged()
+		{
+			vertices.clear();
+			edges.clear();
+			lock.readLock().lock();
+			try
+			{
+				final V focused = focusModel.getFocusedVertex( graph.vertexRef() );
+				if ( null != focused )
+				{
+					final ConnectedComponent< V, E > visitor = new ConnectedComponent<>( graph, vertices, edges );
+					visitor.visit( focused );
+				}
+				notifyListeners();
+			}
+			finally
+			{
+				lock.readLock().unlock();
+			}
+		}
+
+	}
+
+	private static class ConnectedComponent< V extends Vertex< E >, E extends Edge< V > > extends AbstractGraphAlgorithm< V, E >
+	{
+
+		private final RefSet< V > vertices;
+
+		private final RefSet< E > edges;
+
+		public ConnectedComponent( final ReadOnlyGraph< V, E > graph, final RefSet< V > vertices, final RefSet< E > edges )
+		{
+			super( graph );
+			this.vertices = vertices;
+			this.edges = edges;
+		}
+
+		public void visit( final V v )
+		{
+			vertices.add( v );
+			for ( final E e : v.edges() )
+			{
+				edges.add( e );
+				final V target = Graphs.getOppositeVertex( e, v, graph.vertexRef() );
+				if ( vertices.contains( target ) )
+					continue;
+
+				visit( target );
+			}
+		}
+	}
+
+	private class SelectionVisibility implements Visibility< V, E >, SelectionListener
+	{
+
+		private final SelectionModel< V, E > selectionModel;
+
+		public SelectionVisibility( final SelectionModel< V, E > selectionModel )
+		{
+			this.selectionModel = selectionModel;
+		}
+
+		@Override
+		public boolean isVisible( final V v )
+		{
+			return selectionModel.isSelected( v );
+		}
+
+		@Override
+		public boolean isVisible( final E e )
+		{
+			return selectionModel.isSelected( e );
+		}
+
+		@Override
+		public void selectionChanged()
+		{
+			notifyListeners();
+		}
+	}
+
+	private static class NoneVisibility< V extends Vertex< E >, E extends Edge< V > > implements Visibility< V, E >
+	{
+
+		@Override
+		public boolean isVisible( final V v )
+		{
+			return false;
+		}
+
+		@Override
+		public boolean isVisible( final E e )
+		{
+			return false;
+		}
+
+	}
+
+	private static class AllVisibility< V extends Vertex< E >, E extends Edge< V > > implements Visibility< V, E >
+	{
+
+		@Override
+		public boolean isVisible( final V v )
+		{
+			return true;
+		}
+
+		@Override
+		public boolean isVisible( final E e )
+		{
+			return true;
+		}
+
+	}
+
+	/**
+	 * Enum specifying visibility modes.
+	 */
+	public enum VisibilityMode
+	{
+
+		/**
+		 * All the graph objects are visible.
+		 */
+		ALL( "All" ),
+		/**
+		 * Only the vertices and edges of the track (connected component) of the
+		 * currently focused vertex are visible.
+		 */
+		TRACK_OF_FOCUSED_VERTEX( "Track of focused vertex" ),
+		/**
+		 * Only the content of the current selection is visible.
+		 */
+		SELECTION( "Current selection" ),
+		/**
+		 * Nothing is visible.
+		 */
+		NONE( "No overlay" );
+
+		private final String name;
+
+		private VisibilityMode( final String name )
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+}


### PR DESCRIPTION
To use them, press `V` in a BDV window.

4 modes are implemented:
- ALL: everything is visible.
- NONE: nothing is visible.
- FOCUS: the track of the focused vertex is visible.
- SELECTION: the current selection is visible.

The Visibility objects are used every-time one has to decide on the visibility of a vertex or an edge. This includes calls to methods like `#getVertexAt()` or `#getEdgeAt()`. Also the methods called by
the `BdvContextProvider`, to keep visibility consistent.

The visibility itself is not super clever. We simply rely on the `isVisible()` method inside for loops over the vertices and edges returned by the clip convex polytope.