### PR TITLE
Table views for Mastodon, try #3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,11 @@
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+		</dependency>
+		
 		<!-- Test dependencies -->
 
 		<dependency>

--- a/src/main/java/org/mastodon/adapter/RefSetAdapter.java
+++ b/src/main/java/org/mastodon/adapter/RefSetAdapter.java
@@ -66,7 +66,24 @@ public class RefSetAdapter< O, WO >
 	@Override
 	public Iterator< WO > iterator()
 	{
-		throw new UnsupportedOperationException( "not implemented (yet)" );
+		return new Iterator< WO >()
+		{
+			private final Iterator< O > iterator = set.iterator();
+
+			private final WO ref = createRef();
+
+			@Override
+			public boolean hasNext()
+			{
+				return iterator.hasNext();
+			}
+
+			@Override
+			public WO next()
+			{
+				return map.getRight( iterator.next(), ref );
+			}
+		};
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/app/IdentityViewGraph.java
+++ b/src/main/java/org/mastodon/app/IdentityViewGraph.java
@@ -1,0 +1,164 @@
+package org.mastodon.app;
+
+import org.mastodon.RefPool;
+import org.mastodon.adapter.RefBimap;
+import org.mastodon.collection.RefCollection;
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.Edges;
+import org.mastodon.graph.GraphIdBimap;
+import org.mastodon.graph.ReadOnlyGraph;
+import org.mastodon.graph.Vertex;
+
+/**
+ * A {@link ViewGraph} that simply exposes the graph it wraps.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ * @param <V>
+ *            the type of vertices in the view and wrapped graphs.
+ * @param <E>
+ *            the type of edges in the view and wrapped graphs.
+ */
+public class IdentityViewGraph< V extends Vertex< E >, E extends Edge< V > > implements ViewGraph< V, E, V, E >
+{
+
+	private final ReadOnlyGraph< V, E > wrappedGraph;
+
+	private final IdentityRefBimap< V > vertexIdBimap;
+
+	private final IdentityRefBimap< E > edgeIdBimap;
+
+	private IdentityViewGraph( final ReadOnlyGraph< V, E > graph, final GraphIdBimap< V, E > idBimap )
+	{
+		this.wrappedGraph = graph;
+		this.vertexIdBimap = new IdentityRefBimap<>( idBimap.vertexIdBimap() );
+		this.edgeIdBimap = new IdentityRefBimap<>( idBimap.edgeIdBimap() );
+	}
+
+	@Override
+	public E getEdge( final V source, final V target )
+	{
+		return wrappedGraph.getEdge( source, target );
+	}
+
+	@Override
+	public E getEdge( final V source, final V target, final E ref )
+	{
+		return wrappedGraph.getEdge( source, target, ref );
+	}
+
+	@Override
+	public Edges< E > getEdges( final V source, final V target )
+	{
+		return wrappedGraph.getEdges( source, target );
+	}
+
+	@Override
+	public Edges< E > getEdges( final V source, final V target, final V ref )
+	{
+		return wrappedGraph.getEdges( source, target, ref );
+	}
+
+	@Override
+	public V vertexRef()
+	{
+		return wrappedGraph.vertexRef();
+	}
+
+	@Override
+	public E edgeRef()
+	{
+		return wrappedGraph.edgeRef();
+	}
+
+	@Override
+	public void releaseRef( final V ref )
+	{
+		wrappedGraph.releaseRef( ref );
+	}
+
+	@Override
+	public void releaseRef( final E ref )
+	{
+		wrappedGraph.releaseRef( ref );
+	}
+
+	@Override
+	public RefCollection< V > vertices()
+	{
+		return wrappedGraph.vertices();
+	}
+
+	@Override
+	public RefCollection< E > edges()
+	{
+		return wrappedGraph.edges();
+	}
+
+	@Override
+	public RefBimap< V, V > getVertexMap()
+	{
+		return vertexIdBimap;
+	}
+
+	@Override
+	public RefBimap< E, E > getEdgeMap()
+	{
+		return edgeIdBimap;
+	}
+
+	private static final class IdentityRefBimap< O > implements RefBimap< O, O >
+	{
+
+		private final RefPool< O > pool;
+
+		public IdentityRefBimap( final RefPool< O > pool )
+		{
+			this.pool = pool;
+		}
+
+		@Override
+		public O getLeft( final O right )
+		{
+			return right;
+		}
+
+		@Override
+		public O getRight( final O left, final O ref )
+		{
+			return left;
+		}
+
+		@Override
+		public O reusableLeftRef( final O ref )
+		{
+			return ref;
+		}
+
+		@Override
+		public O reusableRightRef()
+		{
+			return pool.createRef();
+		}
+
+		@Override
+		public void releaseRef( final O ref )
+		{
+			pool.releaseRef( ref );
+		}
+	}
+
+	/**
+	 * Wraps the specified graph in a {@link ViewGraph} that plainly exposes it.
+	 * 
+	 * @param graph
+	 *            the graph to wrap.
+	 * @param idBimap
+	 *            a {@link GraphIdBimap} for the wrapped graph.
+	 * @return
+	 */
+	public static final < V extends Vertex< E >, E extends Edge< V > > ViewGraph< V, E, V, E > wrap( final ReadOnlyGraph< V, E > graph, final GraphIdBimap< V, E > idBimap )
+	{
+		return new IdentityViewGraph<>( graph, idBimap );
+	}
+}

--- a/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
+++ b/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
@@ -30,7 +30,7 @@ public class MastodonFrameViewActions
 	{
 		public Descriptions()
 		{
-			super( KeyConfigContexts.BIGDATAVIEWER, KeyConfigContexts.TRACKSCHEME );
+			super( KeyConfigContexts.BIGDATAVIEWER, KeyConfigContexts.TRACKSCHEME, KeyConfigContexts.TABLE );
 		}
 
 		@Override

--- a/src/main/java/org/mastodon/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/mamut/MainWindow.java
@@ -200,7 +200,9 @@ public class MainWindow extends JFrame
 				),
 				windowMenu(
 						item( WindowManager.NEW_BDV_VIEW ),
-						item( WindowManager.NEW_TRACKSCHEME_VIEW )
+						item( WindowManager.NEW_TRACKSCHEME_VIEW ),
+						item( WindowManager.NEW_TABLE_VIEW ),
+						item( WindowManager.NEW_SELECTION_TABLE_VIEW )
 				)
 		);
 	}

--- a/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
+++ b/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
@@ -11,6 +11,7 @@ import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.ui.SelectionActions;
 import org.mastodon.views.bdv.BigDataViewerActionsMamut;
+import org.mastodon.views.table.TableViewActions;
 import org.mastodon.views.trackscheme.display.EditFocusVertexLabelAction;
 import org.mastodon.views.trackscheme.display.TrackSchemeNavigationActions;
 
@@ -30,6 +31,8 @@ public class MamutMenuBuilder extends ViewMenuBuilder
 
 		menuTexts.put( WindowManager.NEW_BDV_VIEW, "New Bdv" );
 		menuTexts.put( WindowManager.NEW_TRACKSCHEME_VIEW, "New Trackscheme" );
+		menuTexts.put( WindowManager.NEW_TABLE_VIEW, "New data table" );
+		menuTexts.put( WindowManager.NEW_SELECTION_TABLE_VIEW, "New selection table" );
 		menuTexts.put( WindowManager.PREFERENCES_DIALOG, "Preferences..." );
 
 		menuTexts.put( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL, "Settings Toolbar" );
@@ -58,6 +61,10 @@ public class MamutMenuBuilder extends ViewMenuBuilder
 		menuTexts.put( TrackSchemeNavigationActions.TOGGLE_FOCUS_SELECTION, "Toggle Focused Vertex Selection" );
 
 		menuTexts.put( EditFocusVertexLabelAction.EDIT_FOCUS_LABEL, "Edit Vertex Label" );
+
+		menuTexts.put( TableViewActions.EDIT_LABEL, "Edit Vertex Label" );
+		menuTexts.put( TableViewActions.TOGGLE_TAG, "Toggle Current Tag" );
+		menuTexts.put( TableViewActions.EXPORT_TO_CSV, "Export to CSV" );
 	}
 
 	public static void build( final ViewMenu viewMenu, final ActionMap actionMap, final MenuItem... items )

--- a/src/main/java/org/mastodon/mamut/MamutViewTable.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewTable.java
@@ -1,0 +1,114 @@
+package org.mastodon.mamut;
+
+import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.separator;
+
+import java.util.function.Function;
+
+import javax.swing.ActionMap;
+
+import org.mastodon.app.IdentityViewGraph;
+import org.mastodon.app.ViewGraph;
+import org.mastodon.app.ui.MastodonFrameViewActions;
+import org.mastodon.app.ui.ViewFrame;
+import org.mastodon.app.ui.ViewMenu;
+import org.mastodon.feature.FeatureModel;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.tag.TagSetModel;
+import org.mastodon.ui.SelectionActions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.views.context.ContextChooser;
+import org.mastodon.views.table.TableViewActions;
+import org.mastodon.views.table.TableViewFrame;
+
+public class MamutViewTable extends MamutView< ViewGraph< Spot, Link, Spot, Link >, Spot, Link >
+{
+
+	private static final String[] CONTEXTS = new String[] { KeyConfigContexts.TABLE };
+
+	public MamutViewTable( final MamutAppModel appModel )
+
+	{
+		super( appModel, IdentityViewGraph.wrap( appModel.getModel().getGraph(), appModel.getModel().getGraphIdBimap() ), CONTEXTS );
+
+		final TableViewFrame< MamutAppModel, ViewGraph< Spot, Link, Spot, Link >, Spot, Link > frame = new TableViewFrame<>(
+				appModel,
+				viewGraph,
+				appModel.getModel().getFeatureModel(),
+				appModel.getModel().getTagSetModel(),
+				( v ) -> v.getLabel(),
+				new Function< Link, String >()
+				{
+
+					private final Spot ref = appModel.getModel().getGraph().vertexRef();
+
+					@Override
+					public String apply( final Link t )
+					{
+						return t.getSource( ref ).getLabel() + " \u2192 " + t.getTarget( ref ).getLabel();
+					}
+				},
+				( v, lbl ) -> v.setLabel( lbl ),
+				null,
+				groupHandle,
+				navigationHandler,
+				appModel.getModel() );
+		setFrame( frame );
+
+		final Model model = appModel.getModel();
+		final FeatureModel featureModel = model.getFeatureModel();
+		final TagSetModel< Spot, Link > tagSetModel = model.getTagSetModel();
+
+		focusModel.listeners().add( frame );
+		highlightModel.listeners().add( frame );
+		featureModel.listeners().add( frame );
+		tagSetModel.listeners().add( frame );
+
+		MastodonFrameViewActions.install( viewActions, this );
+		TableViewActions.install( viewActions, frame );
+
+		onClose( () -> {
+			focusModel.listeners().remove( frame );
+			highlightModel.listeners().remove( frame );
+			featureModel.listeners().remove( frame );
+			tagSetModel.listeners().remove( frame );
+		} );
+
+		final ViewMenu menu = new ViewMenu( this );
+		final ActionMap actionMap = frame.getKeybindings().getConcatenatedActionMap();
+
+		MamutMenuBuilder.build( menu, actionMap,
+				MamutMenuBuilder.fileMenu(
+						item( TableViewActions.EXPORT_TO_CSV ),
+						separator() ) );
+		MainWindow.addMenus( menu, actionMap );
+		MamutMenuBuilder.build( menu, actionMap,
+				MamutMenuBuilder.viewMenu(
+						item( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL ) ),
+				MamutMenuBuilder.editMenu(
+						item( TableViewActions.EDIT_LABEL ),
+						item( TableViewActions.TOGGLE_TAG ),
+						separator(),
+						item( SelectionActions.DELETE_SELECTION ) ) );
+		appModel.getPlugins().addMenus( menu );
+
+		frame.setSize( 400, 400 );
+		frame.setVisible( true );
+	}
+
+	@Override
+	public TableViewFrame< MamutAppModel, ViewGraph< Spot, Link, Spot, Link >, Spot, Link > getFrame()
+	{
+		final ViewFrame f = super.getFrame();
+		@SuppressWarnings( "unchecked" )
+		final TableViewFrame< MamutAppModel, ViewGraph< Spot, Link, Spot, Link >, Spot, Link > vf = ( TableViewFrame< MamutAppModel, ViewGraph< Spot, Link, Spot, Link >, Spot, Link > ) f;
+		return vf;
+	}
+
+	public ContextChooser< Spot > getContextChooser()
+	{
+		return getFrame().getContextChooser();
+	}
+}

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -442,6 +442,8 @@ public class WindowManager
 			frames.add( w.getFrame() );
 		for ( final MamutViewTrackScheme w : tsWindows )
 			frames.add( w.getFrame() );
+		for ( final MamutViewTable w : tableWindows )
+			frames.add( w.getFrame() );
 		try
 		{
 			InvokeOnEDT.invokeAndWait( new Runnable()

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -17,6 +17,7 @@ import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.SpotPool;
 import org.mastodon.mamut.plugin.MamutPlugin;
 import org.mastodon.mamut.plugin.MamutPluginAppModel;
 import org.mastodon.mamut.plugin.MamutPlugins;
@@ -411,9 +412,11 @@ public class WindowManager
 			view.onClose( () -> selectionModel.listeners().remove( view.getFrame() ) );
 		}
 		/*
-		 * TODO Have the model expose the label property so that we can register a
-		 * listener to it, that will update the table-view when the label change.
+		 * Register a listener to vertex label property changes, will update the
+		 * table-view when the label change.
 		 */
+		final SpotPool spotPool = ( SpotPool ) appModel.getModel().getGraph().vertices().getRefPool();
+		spotPool.labelProperty().addPropertyChangeListener( v -> view.getFrame().repaint() );
 
 		addTableWindow( view );
 		return view;

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -11,12 +11,17 @@ import javax.swing.JFrame;
 
 import org.mastodon.feature.FeatureSpecsService;
 import org.mastodon.feature.ui.FeatureColorModeConfigPage;
+import org.mastodon.graph.GraphChangeListener;
 import org.mastodon.mamut.feature.MamutFeatureProjectionsManager;
+import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
-import org.mastodon.mamut.plugin.MamutPluginAppModel;
 import org.mastodon.mamut.plugin.MamutPlugin;
+import org.mastodon.mamut.plugin.MamutPluginAppModel;
 import org.mastodon.mamut.plugin.MamutPlugins;
+import org.mastodon.model.SelectionListener;
+import org.mastodon.model.SelectionModel;
 import org.mastodon.model.tag.ui.TagSetDialog;
 import org.mastodon.ui.SelectionActions;
 import org.mastodon.ui.coloring.feature.FeatureColorModeManager;
@@ -31,6 +36,7 @@ import org.mastodon.util.ToggleDialogAction;
 import org.mastodon.views.bdv.overlay.ui.RenderSettingsConfigPage;
 import org.mastodon.views.bdv.overlay.ui.RenderSettingsManager;
 import org.mastodon.views.context.ContextProvider;
+import org.mastodon.views.table.FeatureTagTablePanel;
 import org.mastodon.views.trackscheme.display.style.TrackSchemeStyleManager;
 import org.mastodon.views.trackscheme.display.style.TrackSchemeStyleSettingsPage;
 import org.scijava.Context;
@@ -49,12 +55,16 @@ public class WindowManager
 {
 	public static final String NEW_BDV_VIEW = "new bdv view";
 	public static final String NEW_TRACKSCHEME_VIEW = "new trackscheme view";
+	public static final String NEW_TABLE_VIEW = "new full table view";
+	public static final String NEW_SELECTION_TABLE_VIEW = "new selection table view";
 	public static final String PREFERENCES_DIALOG = "Preferences";
 	public static final String TAGSETS_DIALOG = "edit tag sets";
 	public static final String COMPUTE_FEATURE_DIALOG = "compute features";
 
 	static final String[] NEW_BDV_VIEW_KEYS = new String[] { "not mapped" };
 	static final String[] NEW_TRACKSCHEME_VIEW_KEYS = new String[] { "not mapped" };
+	static final String[] NEW_TABLE_VIEW_KEYS = new String[] { "not mapped" };
+	static final String[] NEW_SELECTION_TABLE_VIEW_KEYS = new String[] { "not mapped" };
 	static final String[] PREFERENCES_DIALOG_KEYS = new String[] { "meta COMMA", "ctrl COMMA" };
 	static final String[] TAGSETS_DIALOG_KEYS = new String[] { "not mapped" };
 	static final String[] COMPUTE_FEATURE_DIALOG_KEYS = new String[] { "not mapped" };
@@ -73,8 +83,14 @@ public class WindowManager
 		@Override
 		public void getCommandDescriptions( final CommandDescriptions descriptions )
 		{
-			descriptions.add( NEW_BDV_VIEW, NEW_BDV_VIEW_KEYS, "Open new BigDataViewer view." );
-			descriptions.add( NEW_TRACKSCHEME_VIEW, NEW_TRACKSCHEME_VIEW_KEYS, "Open new TrackScheme view." );
+			descriptions.add( NEW_BDV_VIEW, NEW_BDV_VIEW_KEYS, "Open a new BigDataViewer view." );
+			descriptions.add( NEW_TRACKSCHEME_VIEW, NEW_TRACKSCHEME_VIEW_KEYS, "Open a new TrackScheme view." );
+			descriptions.add( NEW_TABLE_VIEW, NEW_TABLE_VIEW_KEYS, "Open a new table view. "
+					+ "The table displays the full data." );
+			descriptions.add( NEW_SELECTION_TABLE_VIEW, NEW_SELECTION_TABLE_VIEW_KEYS,
+					"Open a new selection table view. "
+							+ "The table only displays the current selection and "
+							+ "is updated as the selection changes." );
 			descriptions.add( PREFERENCES_DIALOG, PREFERENCES_DIALOG_KEYS, "Edit Mastodon preferences." );
 			descriptions.add( TAGSETS_DIALOG, TAGSETS_DIALOG_KEYS, "Edit tag definitions." );
 		}
@@ -99,6 +115,11 @@ public class WindowManager
 	 */
 	private final List< MamutViewTrackScheme > tsWindows = new ArrayList<>();
 
+	/**
+	 * All currently open Table windows.
+	 */
+	private final List< MamutViewTable > tableWindows = new ArrayList<>();
+
 	private final KeyPressedManager keyPressedManager;
 
 	private final TrackSchemeStyleManager trackSchemeStyleManager;
@@ -116,6 +137,10 @@ public class WindowManager
 	private final AbstractNamedAction newBdvViewAction;
 
 	private final AbstractNamedAction newTrackSchemeViewAction;
+
+	private final AbstractNamedAction newTableViewAction;
+
+	private final AbstractNamedAction newSelectionTableViewAction;
 
 	private final AbstractNamedAction editTagSetsAction;
 
@@ -166,11 +191,15 @@ public class WindowManager
 
 		newBdvViewAction = new RunnableAction( NEW_BDV_VIEW, this::createBigDataViewer );
 		newTrackSchemeViewAction = new RunnableAction( NEW_TRACKSCHEME_VIEW, this::createTrackScheme );
+		newTableViewAction = new RunnableAction( NEW_TABLE_VIEW, () -> createTable( false ) );
+		newSelectionTableViewAction = new RunnableAction( NEW_SELECTION_TABLE_VIEW, () -> createTable( true ) );
 		editTagSetsAction = new RunnableAction( TAGSETS_DIALOG, this::editTagSets );
 		featureComputationAction = new RunnableAction( COMPUTE_FEATURE_DIALOG, this::computeFeatures );
 
 		globalAppActions.namedAction( newBdvViewAction, NEW_BDV_VIEW_KEYS );
 		globalAppActions.namedAction( newTrackSchemeViewAction, NEW_TRACKSCHEME_VIEW_KEYS );
+		globalAppActions.namedAction( newTableViewAction, NEW_SELECTION_TABLE_VIEW_KEYS );
+		globalAppActions.namedAction( newSelectionTableViewAction, NEW_SELECTION_TABLE_VIEW_KEYS );
 		globalAppActions.namedAction( editTagSetsAction, TAGSETS_DIALOG_KEYS );
 		globalAppActions.namedAction( featureComputationAction, COMPUTE_FEATURE_DIALOG_KEYS );
 
@@ -212,6 +241,8 @@ public class WindowManager
 	{
 		newBdvViewAction.setEnabled( appModel != null );
 		newTrackSchemeViewAction.setEnabled( appModel != null );
+		newTableViewAction.setEnabled( appModel != null );
+		newSelectionTableViewAction.setEnabled( appModel != null );
 		editTagSetsAction.setEnabled( appModel != null );
 		featureComputationAction.setEnabled( appModel != null );
 	}
@@ -252,11 +283,15 @@ public class WindowManager
 		contextProviders.add( w.getContextProvider() );
 		for ( final MamutViewTrackScheme tsw : tsWindows )
 			tsw.getContextChooser().updateContextProviders( contextProviders );
+		for ( final MamutViewTable tw : tableWindows )
+			tw.getContextChooser().updateContextProviders( contextProviders );
 		w.onClose( () -> {
 			bdvWindows.remove( w );
 			contextProviders.remove( w.getContextProvider() );
 			for ( final MamutViewTrackScheme tsw : tsWindows )
 				tsw.getContextChooser().updateContextProviders( contextProviders );
+			for ( final MamutViewTable tw : tableWindows )
+				tw.getContextChooser().updateContextProviders( contextProviders );
 		} );
 	}
 
@@ -275,6 +310,21 @@ public class WindowManager
 		} );
 	}
 
+	private synchronized void addTableWindow( final MamutViewTable table )
+	{
+		tableWindows.add( table );
+		table.getContextChooser().updateContextProviders( contextProviders );
+		table.onClose( () -> {
+			tableWindows.remove( table );
+			table.getContextChooser().updateContextProviders( new ArrayList<>() );
+		} );
+	}
+
+	public void forEachTableView( final Consumer< ? super MamutViewTable > action )
+	{
+		tableWindows.forEach( action );
+	}
+
 	public void forEachTrackSchemeView( final Consumer< ? super MamutViewTrackScheme > action )
 	{
 		tsWindows.forEach( action );
@@ -284,6 +334,7 @@ public class WindowManager
 	{
 		forEachBdvView( action );
 		forEachTrackSchemeView( action );
+		forEachTableView( action );
 	}
 
 	public MamutViewBdv createBigDataViewer()
@@ -306,6 +357,66 @@ public class WindowManager
 			return view;
 		}
 		return null;
+	}
+
+	/**
+	 * Creates, shows and registers a new table view.
+	 *
+	 * @param selectionOnly
+	 *            if <code>true</code>, the table will only display the current
+	 *            content of the selection, and will listen to its changes. If
+	 *            <code>false</code>, the table will display the full graph content,
+	 *            listen to its changes, and will be able to edit the selection.
+	 * @return a new table view.
+	 */
+	public MamutViewTable createTable( final boolean selectionOnly )
+	{
+		if ( appModel == null )
+			return null;
+
+		final MamutViewTable view = new MamutViewTable( appModel );
+		final FeatureTagTablePanel< Spot > vertexTable = view.getFrame().getVertexTable();
+		final FeatureTagTablePanel< Link > edgeTable = view.getFrame().getEdgeTable();
+		final SelectionModel< Spot, Link > selectionModel = appModel.getSelectionModel();
+
+		if ( selectionOnly )
+		{
+			// Pass only the selection.
+			view.getFrame().setTitle( "Selection table" );
+			view.getFrame().setMirrorSelection( false );
+			final SelectionListener selectionListener = () -> {
+				vertexTable.setRows( selectionModel.getSelectedVertices() );
+				edgeTable.setRows( selectionModel.getSelectedEdges() );
+			};
+			selectionModel.listeners().add( selectionListener );
+			selectionListener.selectionChanged();
+			view.onClose( () -> selectionModel.listeners().remove( selectionListener ) );
+		}
+		else
+		{
+			// Pass and listen to the full graph.
+			final ModelGraph graph = appModel.getModel().getGraph();
+			final GraphChangeListener graphChangeListener = () -> {
+				vertexTable.setRows( graph.vertices() );
+				edgeTable.setRows( graph.edges() );
+			};
+			graph.addGraphChangeListener( graphChangeListener );
+			graphChangeListener.graphChanged();
+			view.onClose( () -> graph.removeGraphChangeListener( graphChangeListener ) );
+
+			// Listen to selection changes.
+			view.getFrame().setMirrorSelection( true );
+			selectionModel.listeners().add( view.getFrame() );
+			view.getFrame().selectionChanged();
+			view.onClose( () -> selectionModel.listeners().remove( view.getFrame() ) );
+		}
+		/*
+		 * TODO Have the model expose the label property so that we can register a
+		 * listener to it, that will update the table-view when the label change.
+		 */
+
+		addTableWindow( view );
+		return view;
 	}
 
 	public void editTagSets()

--- a/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeature.java
@@ -1,0 +1,154 @@
+package org.mastodon.mamut.feature;
+
+import static org.mastodon.feature.FeatureProjectionKey.key;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjection;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.Multiplicity;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.scijava.plugin.Plugin;
+
+public class LinkTargetIdFeature implements Feature< Link >
+{
+
+	public static final String KEY = "Link target IDs";
+
+	private static final FeatureProjectionSpec SOURCE_PROJECTION_SPEC =
+			new FeatureProjectionSpec( "Source spot id", Dimension.NONE );
+
+	private static final FeatureProjectionSpec TARGET_PROJECTION_SPEC =
+			new FeatureProjectionSpec( "Target spot id", Dimension.NONE );
+
+	public static final Spec SPEC = new Spec();
+
+	private static final String HELP_STRING = "Exposes the link source and target spot ids.";
+
+	private final ModelGraph graph;
+
+	@Plugin( type = FeatureSpec.class )
+	public static class Spec extends FeatureSpec< LinkTargetIdFeature, Link >
+	{
+		public Spec()
+		{
+			super(
+					KEY,
+					HELP_STRING,
+					LinkTargetIdFeature.class,
+					Link.class,
+					Multiplicity.SINGLE,
+					SOURCE_PROJECTION_SPEC,
+					TARGET_PROJECTION_SPEC );
+		}
+	}
+
+	LinkTargetIdFeature( final ModelGraph graph )
+	{
+		this.graph = graph;
+	}
+
+	@Override
+	public FeatureProjection< Link > project( final FeatureProjectionKey key )
+	{
+		if ( key( SOURCE_PROJECTION_SPEC ).equals( key ) )
+			return new SourceIdProjection( graph.vertexRef() );
+		if ( key(TARGET_PROJECTION_SPEC ).equals( key ) )
+			return new TargetIdProjection( graph.vertexRef() );
+		return null;
+	}
+
+
+	@Override
+	public FeatureSpec< ? extends Feature< Link >, Link > getSpec()
+	{
+		return SPEC;
+	}
+
+	@Override
+	public Set< FeatureProjection< Link > > projections()
+	{
+		final Set< FeatureProjection< Link > > projections = new HashSet<>();
+		projections.add( new SourceIdProjection( graph.vertexRef() ) );
+		projections.add( new TargetIdProjection( graph.vertexRef() ) );
+		return Collections.unmodifiableSet( projections );
+	}
+
+	private static final class SourceIdProjection implements FeatureProjection< Link >
+	{
+
+		private final Spot ref;
+
+		public SourceIdProjection( final Spot ref )
+		{
+			this.ref = ref;
+		}
+
+		@Override
+		public boolean isSet( final Link obj )
+		{
+			return true;
+		}
+
+		@Override
+		public double value( final Link obj )
+		{
+			return obj.getSource( ref ).getInternalPoolIndex();
+		}
+
+		@Override
+		public String units()
+		{
+			return Dimension.NONE_UNITS;
+		}
+
+		@Override
+		public FeatureProjectionKey getKey()
+		{
+			return key( SOURCE_PROJECTION_SPEC );
+		}
+	}
+
+	private static final class TargetIdProjection implements FeatureProjection< Link >
+	{
+
+		private final Spot ref;
+
+		public TargetIdProjection( final Spot ref )
+		{
+			this.ref = ref;
+		}
+
+		@Override
+		public boolean isSet( final Link obj )
+		{
+			return true;
+		}
+
+		@Override
+		public double value( final Link obj )
+		{
+			return obj.getTarget( ref ).getInternalPoolIndex();
+		}
+
+		@Override
+		public String units()
+		{
+			return Dimension.NONE_UNITS;
+		}
+
+		@Override
+		public FeatureProjectionKey getKey()
+		{
+			return key( TARGET_PROJECTION_SPEC );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeatureComputer.java
@@ -1,0 +1,28 @@
+package org.mastodon.mamut.feature;
+
+import org.mastodon.mamut.model.Model;
+import org.scijava.ItemIO;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = LinkTargetIdFeatureComputer.class, name = "Link target IDs" )
+public class LinkTargetIdFeatureComputer implements MamutFeatureComputer
+{
+
+	@Parameter
+	private Model model;
+
+	@Parameter( type = ItemIO.OUTPUT )
+	private LinkTargetIdFeature output;
+
+	@Override
+	public void createOutput()
+	{
+		if ( null == output )
+			output = new LinkTargetIdFeature( model.getGraph() );
+	}
+
+	@Override
+	public void run()
+	{}
+}

--- a/src/main/java/org/mastodon/ui/keymap/KeyConfigContexts.java
+++ b/src/main/java/org/mastodon/ui/keymap/KeyConfigContexts.java
@@ -21,6 +21,11 @@ public final class KeyConfigContexts
 	 */
 	public static final String BIGDATAVIEWER = "bdv";
 
+	/**
+	 * The action or behaviour applies to the table views.
+	 */
+	public static final String TABLE = "table";
+
 	private KeyConfigContexts()
 	{}
 }

--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayContext.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayContext.java
@@ -2,9 +2,9 @@ package org.mastodon.views.bdv.overlay;
 
 import java.util.concurrent.locks.Lock;
 
+import org.mastodon.spatial.SpatioTemporalIndex;
 import org.mastodon.views.context.Context;
 import org.mastodon.views.context.ContextListener;
-import org.mastodon.spatial.SpatioTemporalIndex;
 
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.ui.TransformListener;
@@ -44,6 +44,12 @@ public class OverlayContext< V extends OverlayVertex< V, ? > > implements
 //		ccp.clip( visiblePolytope );
 //		return ccp.getInsideValues();
 		return renderer.getVisibleVertices( transform, timepoint );
+	}
+
+	@Override
+	public int getTimepoint()
+	{
+		return renderer.getCurrentTimepoint();
 	}
 
 	private final AffineTransform3D transform = new AffineTransform3D();

--- a/src/main/java/org/mastodon/views/bdv/overlay/wrap/OverlayContextWrapper.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/wrap/OverlayContextWrapper.java
@@ -74,4 +74,10 @@ public class OverlayContextWrapper< V extends Vertex< E >, E extends Edge< V > >
 			}
 		};
 	}
+
+	@Override
+	public int getTimepoint()
+	{
+		return context.getTimepoint();
+	}
 }

--- a/src/main/java/org/mastodon/views/context/Context.java
+++ b/src/main/java/org/mastodon/views/context/Context.java
@@ -7,4 +7,6 @@ public interface Context< V >
 	public Lock readLock();
 
 	public Iterable< V > getInsideVertices( final int timepoint );
+
+	public int getTimepoint();
 }

--- a/src/main/java/org/mastodon/views/table/ColumnGroup.java
+++ b/src/main/java/org/mastodon/views/table/ColumnGroup.java
@@ -1,0 +1,153 @@
+package org.mastodon.views.table;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.Enumeration;
+import java.util.Vector;
+
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.UIManager;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+
+/**
+ * ColumnGroup
+ *
+ * @version 1.1 2010/10/23
+ * @author Nobuo Tamemasa (modified by Q)
+ */
+
+public class ColumnGroup
+{
+	protected TableCellRenderer renderer;
+
+	protected Vector< Object > v;
+
+	protected String text;
+
+	protected int margin = 0;
+
+	public ColumnGroup( final String text )
+	{
+		this( null, text );
+	}
+
+	public ColumnGroup( final TableCellRenderer renderer, final String text )
+	{
+		if ( renderer == null )
+		{
+			this.renderer = new DefaultTableCellRenderer()
+			{
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Component getTableCellRendererComponent( final JTable table, final Object value,
+						final boolean isSelected, final boolean hasFocus, final int row, final int column )
+				{
+					final JTableHeader header = table.getTableHeader();
+					if ( header != null )
+					{
+						setForeground( header.getForeground() );
+						setBackground( header.getBackground() );
+						setFont( header.getFont() );
+					}
+					setHorizontalAlignment( JLabel.CENTER );
+					setText( ( value == null ) ? "" : value.toString() );
+					setBorder( UIManager.getBorder( "TableHeader.cellBorder" ) );
+					return this;
+				}
+			};
+		}
+		else
+		{
+			this.renderer = renderer;
+		}
+		this.text = text;
+		v = new Vector<>();
+	}
+
+	/**
+	 * @param obj
+	 *            TableColumn or ColumnGroup
+	 */
+	public void add( final Object obj )
+	{
+		if ( obj == null ) { return; }
+		v.addElement( obj );
+	}
+
+	/**
+	 * @param c
+	 *            TableColumn
+	 * @param g
+	 *            ColumnGroups
+	 * @return the column groups.
+	 */
+	public Vector< ColumnGroup > getColumnGroups( final TableColumn c, final Vector< ColumnGroup > g )
+	{
+		g.addElement( this );
+		if ( v.contains( c ) )
+			return g;
+		final Enumeration< Object > en = v.elements();
+		while ( en.hasMoreElements() )
+		{
+			final Object obj = en.nextElement();
+			if ( obj instanceof ColumnGroup )
+			{
+				@SuppressWarnings( "unchecked" )
+				final Vector< ColumnGroup > groups =
+						( ( ColumnGroup ) obj ).getColumnGroups( c, ( Vector< ColumnGroup > ) g.clone() );
+				if ( groups != null )
+					return groups;
+			}
+		}
+		return null;
+	}
+
+	public TableCellRenderer getHeaderRenderer()
+	{
+		return renderer;
+	}
+
+	public void setHeaderRenderer( final TableCellRenderer renderer )
+	{
+		if ( renderer != null )
+		{
+			this.renderer = renderer;
+		}
+	}
+
+	public Object getHeaderValue()
+	{
+		return text;
+	}
+
+	public Dimension getSize( final JTable table )
+	{
+		final Component comp = renderer.getTableCellRendererComponent(
+				table, getHeaderValue(), false, false, -1, -1 );
+		final int height = comp.getPreferredSize().height;
+		int width = 0;
+		final Enumeration< Object > en = v.elements();
+		while ( en.hasMoreElements() )
+		{
+			final Object obj = en.nextElement();
+			if ( obj instanceof TableColumn )
+			{
+				final TableColumn aColumn = ( TableColumn ) obj;
+				width += aColumn.getWidth();
+			}
+			else
+			{
+				width += ( ( ColumnGroup ) obj ).getSize( table ).width;
+			}
+		}
+		return new Dimension( width, height );
+	}
+
+	public void setColumnMargin( final int margin )
+	{}
+}

--- a/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
+++ b/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
@@ -750,8 +750,9 @@ public class FeatureTagTablePanel< O > extends JPanel
 			{
 				final O o = getObjectForViewRow( row, ref );
 				final int color = coloring.color( o );
-				c.setBackground( color == 0 ? table.getBackground() : new Color( color, true ) );
-				c.setForeground( table.getForeground() );
+				final Color bgColor = color == 0 ? table.getBackground() : new Color( color, true );
+				c.setBackground( bgColor );
+				c.setForeground( textColorForBackground( bgColor ) );
 			}
 
 			if ( hasFocus )
@@ -864,5 +865,24 @@ public class FeatureTagTablePanel< O > extends JPanel
 		final InputMap inputMap = editorComponent.getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
 		for ( final KeyStroke key : allTableKeys )
 			inputMap.put( key, "nothing" );
+	}
+
+	/**
+	 * Returns the black color or white color depending on the specified
+	 * background color, to ensure proper readability of the text on said
+	 * background.
+	 *
+	 * @param backgroundColor
+	 *            the background color.
+	 * @return the black or white color.
+	 */
+	private static Color textColorForBackground( final Color backgroundColor )
+	{
+		if ( ( backgroundColor.getRed() * 0.299
+				+ backgroundColor.getGreen() * 0.587
+				+ backgroundColor.getBlue() * 0.114 ) > 150 )
+			return Color.BLACK;
+		else
+			return Color.WHITE;
 	}
 }

--- a/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
+++ b/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
@@ -58,6 +58,7 @@ import org.mastodon.feature.IntFeatureProjection;
 import org.mastodon.model.tag.ObjTags;
 import org.mastodon.model.tag.TagSetStructure.Tag;
 import org.mastodon.model.tag.TagSetStructure.TagSet;
+import org.mastodon.ui.coloring.ColorGenerator;
 import org.mastodon.undo.UndoPointMarker;
 
 import gnu.trove.map.hash.TIntIntHashMap;
@@ -130,18 +131,22 @@ public class FeatureTagTablePanel< O > extends JPanel
 
 	private boolean doFilter = false;
 
+	private final ColorGenerator< O > coloring;
+
 	public FeatureTagTablePanel(
 			final ObjTags< O > tags,
 			final RefPool< O > idBimap,
 			final Function< O, String > labelGenerator,
 			final BiConsumer< O, String > labelSetter,
-			final UndoPointMarker undoPointMarker )
+			final UndoPointMarker undoPointMarker,
+			final ColorGenerator< O > coloring )
 	{
 		this.tags = tags;
 		this.idBimap = idBimap;
 		this.labelGenerator = labelGenerator;
 		this.labelSetter = labelSetter;
 		this.undoPointMarker = undoPointMarker;
+		this.coloring = coloring;
 		this.columnClasses = new ArrayList<>();
 		this.mapToProjections = new ArrayList<>();
 		this.mapToTooltip = new ArrayList<>();
@@ -698,6 +703,8 @@ public class FeatureTagTablePanel< O > extends JPanel
 
 		private final JCheckBox checkBox;
 
+		private final O ref = idBimap.createRef();
+
 		private static final long serialVersionUID = 1L;
 
 		public MyTableCellRenderer()
@@ -741,7 +748,9 @@ public class FeatureTagTablePanel< O > extends JPanel
 			}
 			else
 			{
-				c.setBackground( table.getBackground() );
+				final O o = getObjectForViewRow( row, ref );
+				final int color = coloring.color( o );
+				c.setBackground( color == 0 ? table.getBackground() : new Color( color, true ) );
 				c.setForeground( table.getForeground() );
 			}
 

--- a/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
+++ b/src/main/java/org/mastodon/views/table/FeatureTagTablePanel.java
@@ -1,0 +1,859 @@
+package org.mastodon.views.table;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EventObject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.InputMap;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.KeyStroke;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
+import javax.swing.border.MatteBorder;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableColumnModel;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
+import javax.swing.text.JTextComponent;
+
+import org.mastodon.RefPool;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjection;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.IntFeatureProjection;
+import org.mastodon.model.tag.ObjTags;
+import org.mastodon.model.tag.TagSetStructure.Tag;
+import org.mastodon.model.tag.TagSetStructure.TagSet;
+import org.mastodon.undo.UndoPointMarker;
+
+import gnu.trove.map.hash.TIntIntHashMap;
+
+public class FeatureTagTablePanel< O > extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Color HIGHLIGHT_BORDER_COLOR = Color.BLACK;
+
+	private static final Color HEADER_BG_COLOR = new Color( 245, 245, 245 );
+
+	private static final Font FOCUS_FONT = new JLabel().getFont().deriveFont( Font.ITALIC );
+
+	private static final int ROW_HEIGHT = 26;
+
+	private final RefPool< O > idBimap;
+
+	private final ObjTags< O > tags;
+
+	private final JTable table;
+
+	private final MyTableModel tableModel;
+
+	private final MyTableCellRenderer cellRenderer;
+
+	private final List< Class< ? > > columnClasses;
+
+	private final List< FeatureProjection< O > > mapToProjections;
+
+	private final List< String > mapToTooltip;
+
+	private final List< int[] > mapToTagIndices;
+
+	private final List< TagSet > tagSets;
+
+	private final Map< FeatureSpec< ?, ? >, Feature< ? > > featureMap;
+
+	private final Function< O, String > labelGenerator;
+
+	private final BiConsumer< O, String > labelSetter;
+
+	private final UndoPointMarker undoPointMarker;
+
+	private int focusRow = -1;
+
+	private int highlightRow = -1;
+
+	/**
+	 * Map of model row in the table to the id of the object the row display.
+	 */
+	private TIntIntHashMap rowMap = new TIntIntHashMap( 1, 0.5f, -1, -1 );
+
+	/**
+	 * Map of object ids to their model row in the table.
+	 */
+	private TIntIntHashMap idMap = new TIntIntHashMap( 1, 0.5f, -1, -1 );
+
+	/**
+	 * Map of filtered model row in the table to the id of the object the row
+	 * display.
+	 */
+	private TIntIntHashMap filterRowMap;
+
+	/**
+	 * Map of filtered object ids to their model row in the table.
+	 */
+	private TIntIntHashMap filterIdMap = new TIntIntHashMap( 1, 0.5f, -1, -1 );
+
+	private boolean doFilter = false;
+
+	public FeatureTagTablePanel(
+			final ObjTags< O > tags,
+			final RefPool< O > idBimap,
+			final Function< O, String > labelGenerator,
+			final BiConsumer< O, String > labelSetter,
+			final UndoPointMarker undoPointMarker )
+	{
+		this.tags = tags;
+		this.idBimap = idBimap;
+		this.labelGenerator = labelGenerator;
+		this.labelSetter = labelSetter;
+		this.undoPointMarker = undoPointMarker;
+		this.columnClasses = new ArrayList<>();
+		this.mapToProjections = new ArrayList<>();
+		this.mapToTooltip = new ArrayList<>();
+		this.mapToTagIndices = new ArrayList<>();
+		this.featureMap = new LinkedHashMap<>();
+		this.tagSets = new ArrayList<>();
+
+		this.tableModel = new MyTableModel();
+		final DefaultTableColumnModel tableColumnModel = new DefaultTableColumnModel();
+		this.table = new JTable( tableModel, tableColumnModel )
+		{
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected JTableHeader createDefaultTableHeader()
+			{
+				return new GroupableTableHeader( columnModel );
+			}
+
+			@Override
+			public boolean isCellEditable( final int row, final int column )
+			{
+				// Only label and tags are editable.
+				return ( labelSetter != null && column == 0 ) || column >= 2 + mapToProjections.size();
+			}
+
+			@Override
+			public boolean editCellAt( final int row, final int column, final EventObject e )
+			{
+				// Intercept to block keys.
+				final boolean result = super.editCellAt( row, column, e );
+				final Component editor = getEditorComponent();
+				if ( editor == null || !( editor instanceof JTextComponent ) )
+				{ return result; }
+
+				// Is about text.
+				blockKeys( ( JComponent ) editor, table );
+				if ( e instanceof MouseEvent )
+					EventQueue.invokeLater( () -> ( ( JTextComponent ) editor ).selectAll() );
+				else
+					SwingUtilities.invokeLater( new Runnable()
+					{
+						@Override
+						public void run()
+						{
+							( ( JTextComponent ) editor ).selectAll();
+							( ( JTextComponent ) editor ).requestFocusInWindow();
+						}
+					} );
+				return result;
+			}
+		};
+		table.putClientProperty( "JTable.autoStartsEdit", Boolean.FALSE );
+
+		table.setRowHeight( ROW_HEIGHT );
+		this.cellRenderer = new MyTableCellRenderer();
+
+		table.getSelectionModel().setSelectionMode( ListSelectionModel.MULTIPLE_INTERVAL_SELECTION );
+		refreshColumns();
+
+		final TableRowSorter< MyTableModel > sorter = new TableRowSorter<>( tableModel );
+		table.setRowSorter( sorter );
+
+		final JScrollPane scroll = new JScrollPane( table, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED );
+		table.setAutoResizeMode( JTable.AUTO_RESIZE_OFF );
+
+		setLayout( new BorderLayout() );
+		add( scroll, BorderLayout.CENTER );
+	}
+
+	/**
+	 * Exposes the {@link JTable} in which the data is displayed.
+	 *
+	 * @return the table.
+	 */
+	public JTable getTable()
+	{
+		return table;
+	}
+
+	/**
+	 * Returns the object listed at the specified <b>view</b> row index.
+	 *
+	 * @param viewRowIndex
+	 *            the row to query.
+	 * @param ref
+	 *            a ref object for allocation free retrieval.
+	 * @return the object or <code>null</code> if the view row does not
+	 *         correspond to an object currently displayed.
+	 */
+	public O getObjectForViewRow( final int viewRowIndex, final O ref )
+	{
+		if ( viewRowIndex < 0 )
+			return null;
+		final int modelRow = table.convertRowIndexToModel( viewRowIndex );
+		final int id = doFilter ? filterRowMap.get( modelRow ) : rowMap.get( modelRow );
+		return idBimap.getObjectIfExists( id, ref );
+	}
+
+	public int getViewRowForObject( final O o )
+	{
+		final int modeRow = doFilter ? filterIdMap.get( idBimap.getId( o ) ) : idMap.get( idBimap.getId( o ) );
+		if ( modeRow < 0 ) // Object not in table.
+			return -1;
+		return table.convertRowIndexToView( modeRow );
+	}
+
+	/**
+	 * Returns the object listed at the specified <b>view</b> row index.
+	 *
+	 * @param viewRowIndex
+	 *            the row to query.
+	 * @return the object.
+	 */
+	public O getObjectForViewRow( final int viewRowIndex )
+	{
+		return getObjectForViewRow( viewRowIndex, idBimap.createRef() );
+	}
+
+	public void scrollToObject( final O o )
+	{
+		final Rectangle rect = table.getVisibleRect();
+		final int row = getViewRowForObject( o );
+		final Rectangle cellRect = table.getCellRect( row, 0, true );
+		cellRect.setLocation( rect.x, cellRect.y );
+		table.scrollRectToVisible( cellRect );
+	}
+
+	/**
+	 * Sets the collection of objects to display in this table.
+	 *
+	 * @param rows
+	 *            the collection of objects to display (unchanged).
+	 */
+	public void setRows( final Collection< O > rows )
+	{
+		final TIntIntHashMap idMap = new TIntIntHashMap( rows.size(), 0.5f, -1, -1 );
+		final TIntIntHashMap rowMap = new TIntIntHashMap( rows.size(), 0.5f, -1, -1 );
+		int row = 0;
+		for ( final O o : rows )
+		{
+			final int id = idBimap.getId( o );
+			rowMap.put( row, id );
+			idMap.put( id, row );
+			row++;
+		}
+
+		synchronized ( this )
+		{
+			this.rowMap = rowMap;
+			this.idMap = idMap;
+		}
+		tableModel.fireTableDataChanged();
+	}
+
+	public void filter( final Collection< O > content )
+	{
+		if ( null == content )
+		{
+			doFilter = false;
+		}
+		else
+		{
+			doFilter = true;
+			final TIntIntHashMap filterIdMap = new TIntIntHashMap( content.size(), 0.5f, -1, -1 );
+			final TIntIntHashMap filterRowMap = new TIntIntHashMap( content.size(), 0.5f, -1, -1 );
+
+			int filteredRow = 0;
+			for ( final O o : content )
+			{
+				final int id = idBimap.getId( o );
+				final int row = idMap.get( id );
+				if ( row < 0 )
+					continue;
+
+				filterIdMap.put( id, filteredRow );
+				filterRowMap.put( filteredRow, id );
+				filteredRow++;
+			}
+
+			synchronized ( this )
+			{
+				this.filterIdMap = filterIdMap;
+				this.filterRowMap = filterRowMap;
+			}
+		}
+		tableModel.fireTableDataChanged();
+	}
+
+	private void refreshColumns()
+	{
+		// Class of columns.
+		columnClasses.clear();
+		// Last line of header is for units.
+		final List< String > lastHeaderLine = new ArrayList<>();
+		// Map from column index to projection keys.
+		mapToProjections.clear();
+		// Map from column index to tooltip strings.
+		mapToTooltip.clear();
+		// Map from column index to tag indices.
+		mapToTagIndices.clear();
+		// Table column model.
+		final TableColumnModel tableColumnModel = new DefaultTableColumnModel();
+		table.setColumnModel( tableColumnModel );
+
+		final GroupableTableHeader header = ( GroupableTableHeader ) table.getTableHeader();
+		final TableCellRenderer defaultRenderer = header.getDefaultRenderer();
+		header.clear();
+		// Provide tooltips on the fly.
+		header.addMouseMotionListener( new MyTableToolTipProvider() );
+
+		// Top header, bold and not the last line.
+		final MyTopHeaderRenderer headerRenderer = new MyTopHeaderRenderer( defaultRenderer, false, true );
+		// Top header, last line, not bold.
+		final MyTopHeaderRenderer headerRendererLast = new MyTopHeaderRenderer( defaultRenderer, true, false );
+		// Top header, mid line, not bold.
+		final MyTopHeaderRenderer headerRendererMid = new MyTopHeaderRenderer( defaultRenderer, false, false );
+
+		int colIndex = 0;
+		// First 2 columns.
+		lastHeaderLine.add( "Label" );
+		columnClasses.add( String.class );
+		tableColumnModel.addColumn( new TableColumn( colIndex++ ) );
+		lastHeaderLine.add( "ID" );
+		columnClasses.add( Integer.class );
+		tableColumnModel.addColumn( new TableColumn( colIndex++ ) );
+		// Units for feature columns.
+		for ( final FeatureSpec< ?, ? > fs : featureMap.keySet() )
+		{
+			final Feature< ? > feature = featureMap.get( fs );
+			if ( null == feature.projections() )
+				continue;
+			final List< FeatureProjection< ? > > projections = new ArrayList<>( feature.projections() );
+			projections.sort( Comparator.comparing( FeatureProjection::getKey, Comparator.comparing( FeatureProjectionKey::toString ) ) );
+			for ( final FeatureProjection< ? > projection : projections )
+			{
+				@SuppressWarnings( "unchecked" )
+				final FeatureProjection< O > fp = ( FeatureProjection< O > ) projection;
+				mapToProjections.add( fp );
+				mapToTooltip.add( "<html><p width=\"300\">" + fs.getInfo() + "</p></html>" );
+				final String units = fp.units();
+				lastHeaderLine.add( ( units == null || units.isEmpty() ) ? "" : "(" + units + ")" );
+				tableColumnModel.addColumn( new TableColumn( colIndex++ ) );
+
+				final Class< ? > pclass;
+				if ( fp instanceof IntFeatureProjection )
+					pclass = Integer.class;
+				else
+					pclass = Double.class;
+				columnClasses.add( pclass );
+			}
+		}
+
+		// Last line for tag columns is empty.
+		for ( int tagSetID = 0; tagSetID < tagSets.size(); tagSetID++ )
+		{
+			final TagSet tagSet = tagSets.get( tagSetID );
+			final List< Tag > tags = tagSet.getTags();
+			for ( int tagID = 0; tagID < tags.size(); tagID++ )
+			{
+				columnClasses.add( Boolean.class );
+				mapToTagIndices.add( new int[] { tagSetID, tagID } );
+				lastHeaderLine.add( "" );
+				tableColumnModel.addColumn( new TableColumn( colIndex++ ) );
+			}
+		}
+
+		// Add feature names and feature projection names.
+		int index = 2;
+		for ( final FeatureSpec< ?, ? > fs : featureMap.keySet() )
+		{
+			final ColumnGroup featureGroup = new ColumnGroup( fs.getKey() );
+			featureGroup.setHeaderRenderer( headerRenderer );
+			final Feature< ? > feature = featureMap.get( fs );
+			if ( null == feature.projections() )
+				continue;
+			final List< FeatureProjection< ? > > projections = new ArrayList<>( feature.projections() );
+			if ( projections.size() == 1 )
+			{
+				final ColumnGroup projectionGroup = new ColumnGroup( " " );
+				projectionGroup.setHeaderRenderer( headerRendererMid );
+				projectionGroup.add( tableColumnModel.getColumn( index++ ) );
+				featureGroup.add( projectionGroup );
+			}
+			else
+			{
+				projections.sort( Comparator.comparing( FeatureProjection::getKey, Comparator.comparing( FeatureProjectionKey::toString ) ) );
+
+				for ( final FeatureProjection< ? > projection : projections )
+				{
+					final ColumnGroup projectionGroup = new ColumnGroup( projection.getKey().toString() );
+					projectionGroup.setHeaderRenderer( headerRendererMid );
+					projectionGroup.add( tableColumnModel.getColumn( index++ ) );
+					featureGroup.add( projectionGroup );
+				}
+			}
+			header.addColumnGroup( featureGroup );
+		}
+
+		// Add tag set names and tag names.
+		for ( final TagSet tagSet : tagSets )
+		{
+			final ColumnGroup tagSetGroup = new ColumnGroup( tagSet.getName() );
+			tagSetGroup.setHeaderRenderer( headerRenderer );
+			final List< Tag > tags = tagSet.getTags();
+			for ( final Tag tag : tags )
+			{
+				final ColumnGroup tagGroup = new ColumnGroup( tag.label() );
+				tagGroup.add( tableColumnModel.getColumn( index++ ) );
+				tagGroup.setHeaderRenderer( new MyTagHeaderRenderer( tag ) );
+				tagSetGroup.add( tagGroup );
+			}
+			header.addColumnGroup( tagSetGroup );
+		}
+
+		// Pass last line to column headers and set cell renderer.
+		for ( int c = 0; c < tableColumnModel.getColumnCount(); c++ )
+		{
+			final TableColumn column = tableColumnModel.getColumn( c );
+			column.setHeaderValue( lastHeaderLine.get( c ) );
+			column.setCellRenderer( cellRenderer );
+		}
+
+		table.getTableHeader().setDefaultRenderer( headerRendererLast );
+		tableModel.fireTableStructureChanged();
+	}
+
+	public void setFeatures( final Map< FeatureSpec< ?, O >, Feature< O > > features )
+	{
+		this.featureMap.clear();
+		if ( features != null )
+		{
+			final List< FeatureSpec< ?, O > > fss = new ArrayList<>( features.keySet() );
+			fss.sort( Comparator.comparing( FeatureSpec::getKey ) );
+			for ( final FeatureSpec< ?, O > fs : fss )
+				this.featureMap.put( fs, features.get( fs ) );
+		}
+		refreshColumns();
+	}
+
+	public void setTagSets( final List< TagSet > tagSets )
+	{
+		this.tagSets.clear();
+		if ( tagSets != null )
+		{
+			this.tagSets.addAll( tagSets );
+			this.tagSets.sort( ( o1, o2 ) -> o1.getName().compareTo( o2.getName() ) );
+		}
+		refreshColumns();
+	}
+
+	public void focusObject( final O o )
+	{
+		this.focusRow = ( null == o ) ? -1 : getViewRowForObject( o );
+		table.repaint();
+	}
+
+	public void highlightObject( final O o )
+	{
+		this.highlightRow = ( null == o ) ? -1 : getViewRowForObject( o );
+		table.repaint();
+	}
+
+	/*
+	 * INNER CLASSES
+	 */
+
+	private class MyTableToolTipProvider extends MouseMotionAdapter
+	{
+		private int previousCol = -1;
+
+		@Override
+		public void mouseMoved( final MouseEvent evt )
+		{
+			final TableColumnModel tableColumnModel = table.getColumnModel();
+			final int vColIndex = tableColumnModel.getColumnIndexAtX( evt.getX() ) - 2;
+			if ( vColIndex != previousCol )
+			{
+				if ( vColIndex >= 0 && vColIndex < mapToTooltip.size() )
+				{
+					table.getTableHeader().setToolTipText( mapToTooltip.get( vColIndex ) );
+					previousCol = vColIndex;
+				}
+				else
+				{
+					table.getTableHeader().setToolTipText( "" );
+				}
+			}
+		}
+	}
+
+	private class MyTableModel extends AbstractTableModel
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final O ref = idBimap.createRef();
+
+		@Override
+		public Class< ? > getColumnClass( final int columnIndex )
+		{
+			return columnClasses.get( columnIndex );
+		}
+
+		@Override
+		public int getRowCount()
+		{
+			return doFilter ? filterIdMap.size() : idMap.size();
+		}
+
+		@Override
+		public int getColumnCount()
+		{
+			return columnClasses.size();
+		}
+
+		@Override
+		public Object getValueAt( final int rowIndex, final int columnIndex )
+		{
+			final int id = doFilter ? filterRowMap.get( rowIndex ) : rowMap.get( rowIndex );
+
+			final O o = idBimap.getObjectIfExists( id, ref );
+			if ( null == o )
+				return null;
+
+			if ( columnIndex == 0 )
+				return labelGenerator.apply( o );
+			else if ( columnIndex == 1 )
+				return Integer.valueOf( idBimap.getId( o ) );
+			else if ( columnIndex >= 2 && columnIndex < 2 + mapToProjections.size() )
+			{
+				final FeatureProjection< O > featureProjection = mapToProjections.get( columnIndex - 2 );
+				if ( featureProjection.isSet( o ) )
+				{
+					if ( columnClasses.get( columnIndex ).equals( Integer.class ) )
+						return Integer.valueOf( ( int ) featureProjection.value( o ) );
+					else
+						return Double.valueOf( featureProjection.value( o ) );
+				}
+				else
+					return null;
+			}
+			else if ( columnIndex >= 2 + mapToProjections.size() )
+			{
+				final int[] ids = mapToTagIndices.get( columnIndex - ( 2 + mapToProjections.size() ) );
+				final TagSet tagSet = tagSets.get( ids[ 0 ] );
+				final Tag columnTag = tagSet.getTags().get( ids[ 1 ] );
+				final Tag tag = tags.tags( tagSet ).get( o );
+				return Boolean.valueOf( columnTag.equals( tag ) );
+			}
+			else
+				return null;
+		}
+
+		@Override
+		public void setValueAt( final Object aValue, final int rowIndex, final int columnIndex )
+		{
+			if ( columnIndex == 0 )
+			{
+				final int id = doFilter ? filterRowMap.get( rowIndex ) : rowMap.get( rowIndex );
+
+				final O o = idBimap.getObjectIfExists( id, ref );
+				if ( null == o )
+					return;
+				labelSetter.accept( o, ( String ) aValue );
+				if ( null != undoPointMarker )
+					undoPointMarker.setUndoPoint();
+			}
+			else if ( columnIndex >= 2 + mapToProjections.size() )
+			{
+				final boolean isSet = ( boolean ) aValue;
+				final int id = doFilter ? filterRowMap.get( rowIndex ) : rowMap.get( rowIndex );
+
+				final O o = idBimap.getObjectIfExists( id, ref );
+				if ( null == o )
+					return;
+				final int[] ids = mapToTagIndices.get( columnIndex - ( 2 + mapToProjections.size() ) );
+				final TagSet tagSet = tagSets.get( ids[ 0 ] );
+				final Tag columnTag = tagSet.getTags().get( ids[ 1 ] );
+				if ( isSet )
+					tags.tags( tagSet ).set( o, columnTag );
+				else
+					tags.tags( tagSet ).remove( o );
+				if ( null != undoPointMarker )
+					undoPointMarker.setUndoPoint();
+
+				fireTableRowsUpdated( rowIndex, rowIndex );
+			}
+		}
+	}
+
+	private class MyTagHeaderRenderer extends DefaultTableCellRenderer
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		public MyTagHeaderRenderer( final Tag tag )
+		{
+			final Color color = new Color( tag.color(), true );
+			final JLabel renderer = ( JLabel ) super.getTableCellRendererComponent( table, "", false, false, 0, 0 );
+			renderer.setBackground( color );
+			renderer.setHorizontalTextPosition( SwingConstants.CENTER );
+			renderer.setHorizontalAlignment( SwingConstants.CENTER );
+		}
+	}
+
+	private class MyTopHeaderRenderer implements TableCellRenderer
+	{
+
+		private final TableCellRenderer defaultRenderer;
+
+		private final MatteBorder border;
+
+		private final Font normalFont = new JLabel().getFont();
+
+		private final Font boldFont = normalFont.deriveFont( Font.BOLD );
+
+		private final boolean bold;
+
+		public MyTopHeaderRenderer( final TableCellRenderer defaultRenderer, final boolean bottomLine, final boolean bold )
+		{
+			this.defaultRenderer = defaultRenderer;
+			this.bold = bold;
+			this.border = bottomLine
+					? BorderFactory.createMatteBorder( 0, 0, 1, 1, Color.GRAY )
+					: BorderFactory.createMatteBorder( 0, 0, 0, 1, Color.GRAY );
+		}
+
+		@Override
+		public Component getTableCellRendererComponent( final JTable table, final Object value, final boolean isSelected, final boolean hasFocus, final int row, final int column )
+		{
+			final JLabel renderer = ( JLabel ) defaultRenderer.getTableCellRendererComponent( table, value, isSelected, hasFocus, row, column );
+			renderer.setFont( bold ? boldFont : normalFont );
+			renderer.setBorder( border );
+			renderer.setBackground( HEADER_BG_COLOR );
+			return renderer;
+		}
+	}
+
+	private class MyTableCellRenderer extends DefaultTableCellRenderer
+	{
+
+		private final Border normalBorder;
+
+		private final MatteBorder highlightBorderCenter;
+
+		private final MatteBorder highlightBorderRight;
+
+		private final MatteBorder highlightBorderLeft;
+
+		private final Font normalFont;
+
+		private final DecimalFormat nf;
+
+		private final JCheckBox checkBox;
+
+		private static final long serialVersionUID = 1L;
+
+		public MyTableCellRenderer()
+		{
+			this.normalBorder = ( ( JLabel ) super.getTableCellRendererComponent( table, "", false, false, 0, 0 ) ).getBorder();
+			this.highlightBorderCenter = BorderFactory.createMatteBorder( 2, 0, 2, 0, HIGHLIGHT_BORDER_COLOR );
+			this.highlightBorderLeft = BorderFactory.createMatteBorder( 2, 2, 2, 0, HIGHLIGHT_BORDER_COLOR );
+			this.highlightBorderRight = BorderFactory.createMatteBorder( 2, 0, 2, 2, HIGHLIGHT_BORDER_COLOR );
+			this.normalFont = table.getFont();
+			this.nf = new DecimalFormat();
+			final DecimalFormatSymbols formatSymbols = new DecimalFormatSymbols();
+			formatSymbols.setNaN( "NaN" );
+			nf.setDecimalFormatSymbols( formatSymbols );
+			this.checkBox = new JCheckBox();
+			checkBox.setHorizontalAlignment( SwingConstants.CENTER );
+			checkBox.setBorderPainted( true );
+		}
+
+		@Override
+		public Component getTableCellRendererComponent( final JTable table, final Object value, final boolean isSelected, final boolean hasFocus, final int row, final int column )
+		{
+			final JComponent c;
+			if ( value instanceof Boolean )
+			{
+				// Special case: boolean. We prepare the checkbox.
+				final Boolean boolValue = ( Boolean ) value;
+				checkBox.setSelected( boolValue.booleanValue() );
+				c = checkBox;
+			}
+			else
+			{
+				c = ( JComponent ) super.getTableCellRendererComponent( table, value, isSelected, hasFocus, row, column );
+			}
+
+			c.setBorder( normalBorder );
+
+			if ( isSelected )
+			{
+				c.setBackground( table.getSelectionBackground() );
+				c.setForeground( table.getSelectionForeground() );
+			}
+			else
+			{
+				c.setBackground( table.getBackground() );
+				c.setForeground( table.getForeground() );
+			}
+
+			if ( hasFocus )
+			{
+				c.setBackground( table.getSelectionBackground().darker().darker() );
+				c.setForeground( table.getSelectionForeground() );
+			}
+
+			if ( row == highlightRow )
+			{
+				if ( column == 0 )
+					c.setBorder( highlightBorderLeft );
+				else if ( column == table.getColumnCount() - 1 )
+					c.setBorder( highlightBorderRight );
+				else
+					c.setBorder( highlightBorderCenter );
+			}
+			c.setFont( focusRow == row ? FOCUS_FONT : normalFont );
+
+			if ( value instanceof Double )
+			{
+				setHorizontalAlignment( JLabel.RIGHT );
+				final Double doubleValue = ( Double ) value;
+				setText( nf.format( doubleValue.doubleValue() ) );
+			}
+			else if ( value instanceof Number )
+			{
+				setHorizontalAlignment( JLabel.RIGHT );
+			}
+			else
+			{
+				setHorizontalAlignment( JLabel.CENTER );
+			}
+
+			return c;
+		}
+	}
+
+	/**
+	 * Starts editing the label of the object currently selected in the table.
+	 * Has not effect if the table focus is not on the first column (the label
+	 * column).
+	 */
+	public void editCurrentLabel()
+	{
+		final int col = table.getSelectedColumn();
+		final int row = table.getSelectedRow();
+		if ( col != 0 || row < 0 )
+			return;
+		table.editCellAt( row, col );
+	}
+
+	/**
+	 * Toggles the tag that currently has the focus in the table. Does nothing
+	 * if the focused cell is not a tag.
+	 */
+	public void toggleCurrentTag()
+	{
+		final int col = table.getSelectedColumn();
+		final int row = table.getSelectedRow();
+		if ( col < ( 2 + mapToProjections.size() ) || row < 0 )
+			return;
+
+		final O o = getObjectForViewRow( row );
+		final int[] ids = mapToTagIndices.get( col - ( 2 + mapToProjections.size() ) );
+		final TagSet tagSet = tagSets.get( ids[ 0 ] );
+		final Tag columnTag = tagSet.getTags().get( ids[ 1 ] );
+		final boolean isSet = columnTag.equals( tags.tags( tagSet ).get( o ) );
+		if ( !isSet )
+			tags.tags( tagSet ).set( o, columnTag );
+		else
+			tags.tags( tagSet ).remove( o );
+		if ( null != undoPointMarker )
+			undoPointMarker.setUndoPoint();
+
+		final int modelRow = table.convertRowIndexToModel( row );
+		tableModel.fireTableRowsUpdated( modelRow, modelRow );
+	}
+
+	/**
+	 * Adapted from Jan Funke's code in
+	 * https://github.com/saalfeldlab/bigcat/blob/janh5/src/main/java/bdv/bigcat/ui/BigCatTable.java#L112-L143
+	 *
+	 * @param editorComponent
+	 */
+	private static void blockKeys( final JComponent editorComponent, final JComponent from )
+	{
+		final ArrayList< KeyStroke > allTableKeys = new ArrayList<>();
+		for ( Container c = from; c != null; c = c.getParent() )
+		{
+			if ( c instanceof JComponent )
+			{
+				final InputMap inputMap = ( ( JComponent ) c ).getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
+				final KeyStroke[] tableKeys = inputMap.allKeys();
+				if ( tableKeys != null )
+					allTableKeys.addAll( Arrays.asList( tableKeys ) );
+			}
+		}
+
+		final Action nada = new AbstractAction()
+		{
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{}
+		};
+		editorComponent.getActionMap().put( "nothing", nada );
+
+		final InputMap inputMap = editorComponent.getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
+		for ( final KeyStroke key : allTableKeys )
+			inputMap.put( key, "nothing" );
+	}
+}

--- a/src/main/java/org/mastodon/views/table/GroupableTableHeader.java
+++ b/src/main/java/org/mastodon/views/table/GroupableTableHeader.java
@@ -1,0 +1,90 @@
+package org.mastodon.views.table;
+
+import java.awt.Component;
+import java.util.Enumeration;
+import java.util.Vector;
+
+import javax.swing.SwingUtilities;
+import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+
+/**
+ * GroupableTableHeader
+ *
+ * @version 1.1 2010/10/23
+ * @author Nobuo Tamemasa (modified by Q)
+ */
+
+public class GroupableTableHeader extends JTableHeader
+{
+
+	private static final long serialVersionUID = 1L;
+
+	protected Vector< ColumnGroup > columnGroups = null;
+
+	public GroupableTableHeader( final TableColumnModel model )
+	{
+		super( model );
+		setReorderingAllowed( false );
+	}
+
+	@Override
+	public void setReorderingAllowed( final boolean b )
+	{
+		reorderingAllowed = false;
+	}
+
+	public void addColumnGroup( final ColumnGroup g )
+	{
+		if ( columnGroups == null )
+			columnGroups = new Vector< ColumnGroup >();
+
+		columnGroups.addElement( g );
+	}
+
+	public void clear()
+	{
+		if ( columnGroups != null )
+			columnGroups.clear();
+	}
+
+	public Enumeration< ? > getColumnGroups( final TableColumn col )
+	{
+		if ( columnGroups == null )
+			return null;
+		final Enumeration< ColumnGroup > en = columnGroups.elements();
+		while ( en.hasMoreElements() )
+		{
+			final ColumnGroup cGroup = en.nextElement();
+			final Vector< ? > v_ret = cGroup.getColumnGroups( col, new Vector< ColumnGroup >() );
+			if ( v_ret != null ) { return v_ret.elements(); }
+		}
+		return null;
+	}
+
+	@Override
+	public void updateUI()
+	{
+		setUI( new GroupableTableHeaderUI() );
+
+		final TableCellRenderer tablecellrenderer = getDefaultRenderer();
+		if ( tablecellrenderer instanceof Component )
+			SwingUtilities.updateComponentTreeUI( ( Component ) tablecellrenderer );
+	}
+
+	public void setColumnMargin()
+	{
+		if ( columnGroups == null )
+			return;
+//    final int columnMargin = getColumnModel().getColumnMargin();
+		final Enumeration< ColumnGroup > en = columnGroups.elements();
+		while ( en.hasMoreElements() )
+		{
+			final ColumnGroup cGroup = en.nextElement();
+			cGroup.setColumnMargin( 0/* columnMargin */ );
+		}
+	}
+
+}

--- a/src/main/java/org/mastodon/views/table/GroupableTableHeaderUI.java
+++ b/src/main/java/org/mastodon/views/table/GroupableTableHeaderUI.java
@@ -1,0 +1,158 @@
+package org.mastodon.views.table;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.util.Enumeration;
+import java.util.Hashtable;
+
+import javax.swing.JComponent;
+import javax.swing.plaf.basic.BasicTableHeaderUI;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+
+/**
+ *
+ * @version 1.1 2010/10/23
+ * @author Nobuo Tamemasa (modified by Q)
+ */
+public class GroupableTableHeaderUI extends BasicTableHeaderUI
+{
+
+	@Override
+	public void paint( final Graphics g, final JComponent c )
+	{
+		final Rectangle clipBounds = g.getClipBounds();
+		if ( header.getColumnModel() == null )
+			return;
+		( ( GroupableTableHeader ) header ).setColumnMargin();
+		int column = 0;
+		final Dimension size = header.getSize();
+		final Rectangle cellRect = new Rectangle( 0, 0, size.width, size.height );
+		final Hashtable< ColumnGroup, Rectangle > h = new Hashtable<>();
+
+		final Enumeration< ? > enumeration = header.getColumnModel().getColumns();
+		while ( enumeration.hasMoreElements() )
+		{
+			cellRect.height = size.height;
+			cellRect.y = 0;
+			final TableColumn aColumn = ( TableColumn ) enumeration.nextElement();
+			final Enumeration< ? > cGroups = ( ( GroupableTableHeader ) header ).getColumnGroups( aColumn );
+			if ( cGroups != null )
+			{
+				int groupHeight = 0;
+				while ( cGroups.hasMoreElements() )
+				{
+					final ColumnGroup cGroup = ( ColumnGroup ) cGroups.nextElement();
+					Rectangle groupRect = h.get( cGroup );
+					if ( groupRect == null )
+					{
+						groupRect = new Rectangle( cellRect );
+						final Dimension d = cGroup.getSize( header.getTable() );
+						groupRect.width = d.width;
+						groupRect.height = d.height;
+						h.put( cGroup, groupRect );
+					}
+					paintCell( g, groupRect, cGroup );
+					groupHeight += groupRect.height;
+					cellRect.height = size.height - groupHeight;
+					cellRect.y = groupHeight;
+				}
+			}
+			cellRect.width = aColumn.getWidth();
+			if ( cellRect.intersects( clipBounds ) )
+			{
+				paintCell( g, cellRect, column );
+			}
+			cellRect.x += cellRect.width;
+			column++;
+		}
+	}
+
+	private void paintCell( final Graphics g, final Rectangle cellRect, final int columnIndex )
+	{
+		final TableColumn aColumn = header.getColumnModel().getColumn( columnIndex );
+		final TableCellRenderer renderer = getRenderer( columnIndex );
+		final Component component = renderer.getTableCellRendererComponent(
+				header.getTable(), aColumn.getHeaderValue(), false, false, -1, columnIndex );
+		rendererPane.add( component );
+		rendererPane.paintComponent( g, component, header, cellRect.x, cellRect.y,
+				cellRect.width, cellRect.height, true );
+	}
+
+	private void paintCell( final Graphics g, final Rectangle cellRect, final ColumnGroup cGroup )
+	{
+		final TableCellRenderer renderer = cGroup.getHeaderRenderer();
+		final Component component = renderer.getTableCellRendererComponent(
+				header.getTable(), cGroup.getHeaderValue(), false, false, -1, -1 );
+		rendererPane.add( component );
+		rendererPane.paintComponent( g, component, header, cellRect.x, cellRect.y,
+				cellRect.width, cellRect.height, true );
+	}
+
+	private int getHeaderHeight()
+	{
+		int height = 0;
+		final TableColumnModel columnModel = header.getColumnModel();
+		for ( int column = 0; column < columnModel.getColumnCount(); column++ )
+		{
+			final TableColumn aColumn = columnModel.getColumn( column );
+			final TableCellRenderer renderer = getRenderer( column );
+			final Component comp = renderer.getTableCellRendererComponent(
+					header.getTable(), aColumn.getHeaderValue(), false, false, -1, column );
+			int cHeight = comp.getPreferredSize().height;
+			final Enumeration< ? > en = ( ( GroupableTableHeader ) header ).getColumnGroups( aColumn );
+			if ( en != null )
+			{
+				while ( en.hasMoreElements() )
+				{
+					final ColumnGroup cGroup = ( ColumnGroup ) en.nextElement();
+					cHeight += cGroup.getSize( header.getTable() ).height;
+				}
+			}
+			height = Math.max( height, cHeight );
+		}
+		return height;
+	}
+
+	private TableCellRenderer getRenderer( final int column )
+	{
+		final TableColumnModel columnModel = header.getColumnModel();
+		TableCellRenderer renderer = null;
+		if ( column < 0 && column < columnModel.getColumnCount() )
+		{
+			renderer = columnModel.getColumn( column ).getHeaderRenderer();
+		}
+		if ( renderer == null )
+		{
+			renderer = header.getDefaultRenderer();
+		}
+		return renderer;
+	}
+
+	private Dimension createHeaderSize( long width )
+	{
+		final TableColumnModel columnModel = header.getColumnModel();
+		width += columnModel.getColumnMargin() * columnModel.getColumnCount();
+		if ( width > Integer.MAX_VALUE )
+		{
+			width = Integer.MAX_VALUE;
+		}
+		return new Dimension( ( int ) width, getHeaderHeight() );
+	}
+
+	@Override
+	public Dimension getPreferredSize( final JComponent c )
+	{
+		long width = 0;
+		final Enumeration< ? > enumeration = header.getColumnModel().getColumns();
+		while ( enumeration.hasMoreElements() )
+		{
+			final TableColumn aColumn = ( TableColumn ) enumeration.nextElement();
+			width = width + aColumn.getPreferredWidth();
+		}
+		return createHeaderSize( width );
+	}
+}

--- a/src/main/java/org/mastodon/views/table/TableViewActions.java
+++ b/src/main/java/org/mastodon/views/table/TableViewActions.java
@@ -1,0 +1,217 @@
+package org.mastodon.views.table;
+
+import java.awt.Component;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import javax.swing.JOptionPane;
+import javax.swing.table.TableModel;
+
+import org.mastodon.app.MastodonAppModel;
+import org.mastodon.app.ViewGraph;
+import org.mastodon.graph.ref.AbstractListenableEdge;
+import org.mastodon.model.AbstractSpot;
+import org.mastodon.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.ui.util.ExtensionFileFilter;
+import org.mastodon.ui.util.FileChooser;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.RunnableAction;
+
+import com.opencsv.CSVWriter;
+
+public class TableViewActions<
+			M extends MastodonAppModel< ?, V, E >,
+			VG extends ViewGraph< V, E, V, E >,
+			V extends AbstractSpot< V, E, ?, ?, ? >,
+			E extends AbstractListenableEdge< E, V, ?, ? > >
+{
+
+	public static final String EDIT_LABEL = "edit vertex label";
+	public static final String TOGGLE_TAG = "toggle tag";
+	public static final String EXPORT_TO_CSV = "export to csv";
+
+	private static final String[] EDIT_LABEL_KEYS = new String[] { "F2" };
+	private static final String[] TOGGLE_TAG_KEYS = new String[] { "SPACE" };
+	private static final String[] EXPORT_TO_CSV_KEYS = new String[] { "not mapped" };
+
+	private final RunnableAction editLabel;
+
+	private final RunnableAction toggleTag;
+
+	private final RunnableAction exportToCSV;
+
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigContexts.TABLE );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( EDIT_LABEL, EDIT_LABEL_KEYS, "Edit the label of the current vertex." );
+			descriptions.add( TOGGLE_TAG, TOGGLE_TAG_KEYS, "Toggle the tag at the current cell in the table." );
+			descriptions.add( EXPORT_TO_CSV, EXPORT_TO_CSV_KEYS, "Export the current content of the table to two CSV files (one for vertices, one for edges)." );
+		}
+	}
+
+	private TableViewActions( final TableViewFrame< M, VG, V, E > tableView )
+	{
+		this.editLabel = new RunnableAction( EDIT_LABEL, tableView::editCurrentLabel );
+		this.toggleTag = new RunnableAction( TOGGLE_TAG, tableView::toggleTag );
+		this.exportToCSV = new RunnableAction( EXPORT_TO_CSV, () -> exportToCSV( tableView ) );
+	}
+
+	/**
+	 * Create table-view actions and install them in the specified
+	 * {@link Actions}.
+	 *
+	 * @param <M>
+	 *            the type of the {@link MastodonAppModel}.
+	 * @param <VG>
+	 *            the type of the view graph used.
+	 * @param <V>
+	 *            the type of vertices in the graph.
+	 * @param <E>
+	 *            the type of edges in the graph.
+	 * @param actions
+	 *            Actions are added here.
+	 * @param frame
+	 *            Actions are targeted at this table view.
+	 */
+	public static <
+		M extends MastodonAppModel< ?, V, E >,
+		VG extends ViewGraph< V, E, V, E >,
+		V extends AbstractSpot< V, E, ?, ?, ? >,
+		E extends AbstractListenableEdge< E, V, ?, ? > > void install(
+			final Actions actions,
+			final TableViewFrame< M, VG, V, E > frame )
+	{
+		final TableViewActions< M, VG, V, E > tva = new TableViewActions<>( frame );
+		actions.namedAction( tva.editLabel, EDIT_LABEL_KEYS );
+		actions.namedAction( tva.toggleTag, TOGGLE_TAG_KEYS );
+		actions.namedAction( tva.exportToCSV, EXPORT_TO_CSV_KEYS );
+	}
+
+	private static File csvFile;
+
+	private static final < M extends MastodonAppModel< ?, V, E >, VG extends ViewGraph< V, E, V, E >, V extends AbstractSpot< V, E, ?, ?, ? >, E extends AbstractListenableEdge< E, V, ?, ? > >
+			void exportToCSV( final TableViewFrame< M, VG, V, E > frame )
+	{
+		final Component parent = frame;
+		final String filename = ( csvFile == null )
+				? new File( System.getProperty( "user.home" ), "FeatureAndTagTable.csv" ).getAbsolutePath()
+				: csvFile.getAbsolutePath();
+		final File file = FileChooser.chooseFile(
+				parent,
+				filename,
+				new ExtensionFileFilter( "csv" ),
+				"Export Table content as CSV files",
+				FileChooser.DialogType.SAVE );
+		if ( file == null )
+			return;
+		csvFile = file;
+
+		final int p = csvFile.getAbsolutePath().lastIndexOf( '.' );
+		final String vertexPath = csvFile.getAbsolutePath().substring( 0, p ) + "-vertices.csv";
+		try
+		{
+			export( vertexPath, frame.getVertexTable(), CSVWriter.DEFAULT_SEPARATOR );
+		}
+		catch ( final IOException e )
+		{
+			JOptionPane.showMessageDialog( frame.getVertexTable(),
+					"Could not save to file " + vertexPath + ":\n" + e.getMessage(),
+					"Error exporting vertices to CSV",
+					JOptionPane.ERROR_MESSAGE );
+			e.printStackTrace();
+			return;
+		}
+
+		final String edgePath = csvFile.getAbsolutePath().substring( 0, p ) + "-edges.csv";
+		try
+		{
+			export( edgePath, frame.getEdgeTable(), CSVWriter.DEFAULT_SEPARATOR );
+		}
+		catch ( final IOException e )
+		{
+			JOptionPane.showMessageDialog( frame.getEdgeTable(),
+					"Could not save to file " + edgePath + ":\n" + e.getMessage(),
+					"Error exporting edges to CSV",
+					JOptionPane.ERROR_MESSAGE );
+			e.printStackTrace();
+		}
+
+	}
+
+	public static < O > void export( final String path, final FeatureTagTablePanel< O > table, final char separator ) throws IOException
+	{
+		try (CSVWriter writer = new CSVWriter( new FileWriter( new File( path ) ), separator ))
+		{
+			/*
+			 * Headers are complicated: The first 2 columns are label and id,
+			 * and they are not in column group. All the rest is, and have an
+			 * extra line for units.
+			 */
+			final GroupableTableHeader header = ( GroupableTableHeader ) table.getTable().getTableHeader();
+			final int nCols = table.getTable().getColumnCount();
+			final String[][] headerEntries = new String[ 3 ][ nCols ];
+			headerEntries[ 0 ][ 0 ] = header.getColumnModel().getColumn( 0 ).getHeaderValue().toString();
+			headerEntries[ 1 ][ 0 ] = "";
+			headerEntries[ 2 ][ 0 ] = "";
+			headerEntries[ 0 ][ 1 ] = header.getColumnModel().getColumn( 1 ).getHeaderValue().toString();
+			headerEntries[ 1 ][ 1 ] = "";
+			headerEntries[ 2 ][ 1 ] = "";
+
+			if ( null != header.columnGroups)
+			{
+				int lcol = 2;
+				for ( final ColumnGroup cg : header.columnGroups )
+				{
+					for ( final Object obj : cg.v )
+					{
+						final ColumnGroup cg2 = ( ColumnGroup ) obj;
+						headerEntries[ 0 ][ lcol ] = cg.text;
+						headerEntries[ 1 ][ lcol ] = cg2.text;
+						headerEntries[ 2 ][ lcol ] = header.getColumnModel().getColumn( lcol ).getHeaderValue().toString();
+						lcol++;
+					}
+				}
+			}
+			for ( int hr = 0; hr < 3; hr++ )
+				writer.writeNext( headerEntries[ hr ] );
+
+			/*
+			 * Content.
+			 */
+			final String[] content = new String[ nCols ];
+			final int nRows = table.getTable().getRowCount();
+			final TableModel model = table.getTable().getModel();
+			for ( int r = 0; r < nRows; r++ )
+			{
+				final int row = table.getTable().convertRowIndexToModel( r );
+				for ( int col = 0; col < nCols; col++ )
+				{
+					final Object obj = model.getValueAt( row, col );
+					if ( null == obj )
+						content[ col ] = "";
+					else if ( obj instanceof Integer )
+						content[ col ] = Integer.toString( ( Integer ) obj );
+					else if ( obj instanceof Double )
+						content[ col ] = Double.toString( ( Double ) obj );
+					else if ( obj instanceof Boolean )
+						content[ col ] = ( ( Boolean ) obj ) ? "1" : "0";
+					else
+						content[ col ] = obj.toString();
+				}
+				writer.writeNext( content );
+			}
+		}
+	}
+}

--- a/src/main/java/org/mastodon/views/table/TableViewFrame.java
+++ b/src/main/java/org/mastodon/views/table/TableViewFrame.java
@@ -42,6 +42,7 @@ import org.mastodon.model.SelectionModel;
 import org.mastodon.model.tag.ObjTags;
 import org.mastodon.model.tag.TagSetModel;
 import org.mastodon.model.tag.TagSetStructure.TagSet;
+import org.mastodon.ui.coloring.GraphColorGenerator;
 import org.mastodon.ui.context.ContextChooserPanel;
 import org.mastodon.undo.UndoPointMarker;
 import org.mastodon.views.context.Context;
@@ -88,6 +89,12 @@ public class TableViewFrame<
 
 	private final E eref;
 
+	/** Used in coloring edges. */
+	private final V source;
+
+	/** Used in coloring edges. */
+	private final V target;
+
 	/**
 	 * If <code>true</code>, the selection in the {@link JTable}s will be used
 	 * to update the {@link SelectionModel} of this view.
@@ -113,7 +120,8 @@ public class TableViewFrame<
 			final BiConsumer< E, String > edgeLabelSetter,
 			final GroupHandle groupHandle,
 			final NavigationHandler< V, E > navigationHandler,
-			final UndoPointMarker undoPointMarker )
+			final UndoPointMarker undoPointMarker,
+			final GraphColorGenerator< V, E > coloring )
 	{
 		super( "Feature and tag table" );
 		this.featureModel = featureModel;
@@ -124,6 +132,8 @@ public class TableViewFrame<
 		final GraphIdBimap< V, E > graphIdBimap = appModel.getModel().getGraphIdBimap();
 		this.vref = graphIdBimap.vertexIdBimap().createRef();
 		this.eref = graphIdBimap.edgeIdBimap().createRef();
+		this.source = graphIdBimap.vertexIdBimap().createRef();
+		this.target = graphIdBimap.vertexIdBimap().createRef();
 		final List< TagSet > tagSets = tagSetModel.getTagSetStructure().getTagSets();
 		this.filterByVertices = new RefArrayList<>( graphIdBimap.vertexIdBimap() );
 		this.filterByEdges = new RefSetImp<>( graphIdBimap.edgeIdBimap() );
@@ -152,7 +162,8 @@ public class TableViewFrame<
 				vertexIdBimap,
 				vertexLabelGenerator,
 				vertexLabelSetter,
-				undoPointMarker );
+				undoPointMarker,
+				( v ) -> coloring.color( v ) );
 		final JTable vt = vertexTable.getTable();
 
 		vt.getSelectionModel().addListSelectionListener( new ListSelectionListener()
@@ -211,7 +222,8 @@ public class TableViewFrame<
 				edgeIdBimap,
 				edgeLabelGenerator,
 				edgeLabelSetter,
-				undoPointMarker );
+				undoPointMarker,
+				( e ) -> coloring.color( e, source, target ) );
 		final JTable et = edgeTable.getTable();
 		et.getSelectionModel().addListSelectionListener( new ListSelectionListener()
 		{

--- a/src/main/java/org/mastodon/views/table/TableViewFrame.java
+++ b/src/main/java/org/mastodon/views/table/TableViewFrame.java
@@ -1,0 +1,468 @@
+package org.mastodon.views.table;
+
+import java.awt.BorderLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.swing.Box;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+
+import org.mastodon.RefPool;
+import org.mastodon.app.MastodonAppModel;
+import org.mastodon.app.ViewGraph;
+import org.mastodon.app.ui.GroupLocksPanel;
+import org.mastodon.app.ui.ViewFrame;
+import org.mastodon.collection.RefSet;
+import org.mastodon.collection.ref.RefArrayList;
+import org.mastodon.collection.ref.RefSetImp;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureModel;
+import org.mastodon.feature.FeatureModel.FeatureModelListener;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.graph.GraphIdBimap;
+import org.mastodon.graph.ref.AbstractListenableEdge;
+import org.mastodon.grouping.GroupHandle;
+import org.mastodon.model.AbstractSpot;
+import org.mastodon.model.FocusListener;
+import org.mastodon.model.FocusModel;
+import org.mastodon.model.HighlightListener;
+import org.mastodon.model.HighlightModel;
+import org.mastodon.model.NavigationHandler;
+import org.mastodon.model.NavigationListener;
+import org.mastodon.model.SelectionListener;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.model.tag.ObjTags;
+import org.mastodon.model.tag.TagSetModel;
+import org.mastodon.model.tag.TagSetStructure.TagSet;
+import org.mastodon.ui.context.ContextChooserPanel;
+import org.mastodon.undo.UndoPointMarker;
+import org.mastodon.views.context.Context;
+import org.mastodon.views.context.ContextChooser;
+import org.mastodon.views.context.ContextListener;
+import org.scijava.ui.behaviour.util.InputActionBindings;
+
+public class TableViewFrame<
+		M extends MastodonAppModel< ?, V, E >,
+		VG extends ViewGraph< V, E, V, E >,
+		V extends AbstractSpot< V, E, ?, ?, ? >,
+		E extends AbstractListenableEdge< E, V, ?, ? > >
+	extends ViewFrame
+	implements
+		SelectionListener,
+		FocusListener,
+		HighlightListener,
+		TagSetModel.TagSetModelListener,
+		FeatureModelListener,
+		ContextListener< V >
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private final SelectionModel< V, E > selectionModel;
+
+	private final FocusModel< V, E > focusModel;
+
+	private final HighlightModel< V, E > highlightModel;
+
+	private final FeatureModel featureModel;
+
+	private final TagSetModel< V, E > tagSetModel;
+
+	private final FeatureTagTablePanel< V > vertexTable;
+
+	private final FeatureTagTablePanel< E > edgeTable;
+
+	private boolean ignoreTableSelectionChange = false;
+
+	private boolean ignoreSelectionChange = false;
+
+	private final V vref;
+
+	private final E eref;
+
+	/**
+	 * If <code>true</code>, the selection in the {@link JTable}s will be used
+	 * to update the {@link SelectionModel} of this view.
+	 */
+	private boolean mirrorSelection = false;
+
+	private final JTabbedPane pane;
+
+	private final RefArrayList< V > filterByVertices;
+
+	private final RefSetImp< E > filterByEdges;
+
+	private final ContextChooser< V > contextChooser;
+
+	public TableViewFrame(
+			final M appModel,
+			final VG viewGraph,
+			final FeatureModel featureModel,
+			final TagSetModel< V, E > tagSetModel,
+			final Function< V, String > vertexLabelGenerator,
+			final Function< E, String > edgeLabelGenerator,
+			final BiConsumer< V, String > vertexLabelSetter,
+			final BiConsumer< E, String > edgeLabelSetter,
+			final GroupHandle groupHandle,
+			final NavigationHandler< V, E > navigationHandler,
+			final UndoPointMarker undoPointMarker )
+	{
+		super( "Feature and tag table" );
+		this.featureModel = featureModel;
+		this.tagSetModel = tagSetModel;
+		this.selectionModel = appModel.getSelectionModel();
+		this.focusModel = appModel.getFocusModel();
+		this.highlightModel = appModel.getHighlightModel();
+		final GraphIdBimap< V, E > graphIdBimap = appModel.getModel().getGraphIdBimap();
+		this.vref = graphIdBimap.vertexIdBimap().createRef();
+		this.eref = graphIdBimap.edgeIdBimap().createRef();
+		final List< TagSet > tagSets = tagSetModel.getTagSetStructure().getTagSets();
+		this.filterByVertices = new RefArrayList<>( graphIdBimap.vertexIdBimap() );
+		this.filterByEdges = new RefSetImp<>( graphIdBimap.edgeIdBimap() );
+
+		/*
+		 * Settings panel.
+		 */
+
+		final GroupLocksPanel navigationLocksPanel = new GroupLocksPanel( groupHandle );
+		settingsPanel.add( navigationLocksPanel );
+		settingsPanel.add( Box.createHorizontalGlue() );
+
+		this.contextChooser = new ContextChooser<>( this );
+		final ContextChooserPanel< ? > contextChooserPanel = new ContextChooserPanel<>( contextChooser );
+		settingsPanel.add( contextChooserPanel );
+		add( settingsPanel, BorderLayout.NORTH );
+
+		/*
+		 * Vertices
+		 */
+
+		final ObjTags< V > vertexTags = tagSetModel.getVertexTags();
+		final RefPool< V > vertexIdBimap = graphIdBimap.vertexIdBimap();
+		vertexTable = new FeatureTagTablePanel<>(
+				vertexTags,
+				vertexIdBimap,
+				vertexLabelGenerator,
+				vertexLabelSetter,
+				undoPointMarker );
+		final JTable vt = vertexTable.getTable();
+
+		vt.getSelectionModel().addListSelectionListener( new ListSelectionListener()
+		{
+
+			private final V ref = viewGraph.vertexRef();
+
+			@Override
+			public void valueChanged( final ListSelectionEvent event )
+			{
+				if ( event.getValueIsAdjusting() || ignoreTableSelectionChange )
+					return;
+				ignoreSelectionChange = true;
+
+				// Selection.
+				if ( mirrorSelection )
+				{
+					selectionModel.pauseListeners();
+					final RefSet< E > selectedEdges = selectionModel.getSelectedEdges();
+					selectionModel.clearSelection();
+					final int[] selectedRows = vt.getSelectedRows();
+					for ( final int row : selectedRows )
+						selectionModel.setSelected( vertexTable.getObjectForViewRow( row, ref ), true );
+					for ( final E e : selectedEdges )
+						selectionModel.setSelected( e, true );
+					selectionModel.resumeListeners();
+				}
+
+				// Navigate and focus.
+				final int rowIndex = vt.getSelectionModel().getLeadSelectionIndex();
+				final V v = vertexTable.getObjectForViewRow( rowIndex, ref );
+				if ( null != v )
+				{
+					navigationHandler.notifyNavigateToVertex( v );
+					focusModel.focusVertex( v );
+				}
+
+				ignoreSelectionChange = false;
+			}
+		} );
+
+		@SuppressWarnings( "unchecked" )
+		final Class< V > vertexClass = ( Class< V > ) viewGraph.vertexRef().getClass();
+		final Map< FeatureSpec< ?, V >, Feature< V > > vertexFeatures = collectFeatureMap( featureModel, vertexClass );
+		vertexTable.setFeatures( vertexFeatures );
+		vertexTable.setTagSets( tagSets );
+
+		/*
+		 * Edges
+		 */
+
+		final ObjTags< E > edgeTags = tagSetModel.getEdgeTags();
+		final RefPool< E > edgeIdBimap = graphIdBimap.edgeIdBimap();
+		edgeTable = new FeatureTagTablePanel<>(
+				edgeTags,
+				edgeIdBimap,
+				edgeLabelGenerator,
+				edgeLabelSetter,
+				undoPointMarker );
+		final JTable et = edgeTable.getTable();
+		et.getSelectionModel().addListSelectionListener( new ListSelectionListener()
+		{
+
+			private final E eref = viewGraph.edgeRef();
+
+			private final V vref = viewGraph.vertexRef();
+
+			@Override
+			public void valueChanged( final ListSelectionEvent event )
+			{
+				if ( event.getValueIsAdjusting() || ignoreTableSelectionChange )
+					return;
+				ignoreSelectionChange = true;
+
+				// Selection.
+				if ( mirrorSelection )
+				{
+					selectionModel.pauseListeners();
+					final RefSet< V > selectedVertices = selectionModel.getSelectedVertices();
+					selectionModel.clearSelection();
+					final int[] selectedRows = et.getSelectedRows();
+					for ( final int row : selectedRows )
+						selectionModel.setSelected( edgeTable.getObjectForViewRow( row, eref ), true );
+					for ( final V v : selectedVertices )
+						selectionModel.setSelected( v, true );
+					selectionModel.resumeListeners();
+				}
+
+				// Navigate and focus.
+				final int rowIndex = et.getSelectionModel().getLeadSelectionIndex();
+				final E e = edgeTable.getObjectForViewRow( rowIndex, eref );
+				if ( null != e )
+				{
+					navigationHandler.notifyNavigateToEdge( e );
+					focusModel.focusVertex( e.getTarget( vref ) );
+				}
+
+				ignoreSelectionChange = false;
+			}
+		} );
+
+		@SuppressWarnings( "unchecked" )
+		final Class< E > edgeClass = ( Class< E > ) viewGraph.edgeRef().getClass();
+		final Map< FeatureSpec< ?, E >, Feature< E > > edgeFeatures = collectFeatureMap( featureModel, edgeClass);
+		edgeTable.setFeatures( edgeFeatures );
+		edgeTable.setTagSets( tagSets );
+
+		navigationHandler.listeners().add( new NavigationListener< V, E >()
+		{
+
+			@Override
+			public void navigateToVertex( final V vertex )
+			{
+				vertexTable.scrollToObject( vertex );
+			}
+
+			@Override
+			public void navigateToEdge( final E edge )
+			{
+				edgeTable.scrollToObject( edge );
+			}
+
+		} );
+
+		/*
+		 * Tab pane.
+		 */
+
+		pane = new JTabbedPane( JTabbedPane.LEFT );
+		pane.add( "Vertices", vertexTable );
+		pane.add( "Edges", edgeTable );
+		add( pane, BorderLayout.CENTER );
+	}
+
+	public InputActionBindings getKeybindings()
+	{
+		return keybindings;
+	}
+
+	/**
+	 * Exposes the vertex table of this view.
+	 *
+	 * @return the vertex table.
+	 */
+	public FeatureTagTablePanel< V > getVertexTable()
+	{
+		return vertexTable;
+	}
+
+	/**
+	 * Exposes the edge table of this view.
+	 *
+	 * @return the edge table.
+	 */
+	public FeatureTagTablePanel< E > getEdgeTable()
+	{
+		return edgeTable;
+	}
+
+	/**
+	 * Sets the selection mirroring settings. If <code>true</code>, the
+	 * selection in the {@link JTable}s will be used to update the
+	 * {@link SelectionModel} of this view.
+	 *
+	 * @param mirrorSelection
+	 *            whether the selection in the table should be mirrored on the
+	 *            {@link SelectionModel}.
+	 */
+	public void setMirrorSelection( final boolean mirrorSelection )
+	{
+		this.mirrorSelection = mirrorSelection;
+	}
+
+	@Override
+	public void selectionChanged()
+	{
+		if ( ignoreSelectionChange )
+			return;
+		ignoreTableSelectionChange = true;
+
+		// Vertices table.
+		final RefSet< V > selectedVertices = selectionModel.getSelectedVertices();
+		final JTable vt = vertexTable.getTable();
+		vt.getSelectionModel().clearSelection();
+		for ( final V v : selectedVertices )
+		{
+			final int row = vertexTable.getViewRowForObject( v );
+			vt.getSelectionModel().addSelectionInterval( row, row );
+		}
+
+		// Edges table.
+		final RefSet< E > selectedEdges = selectionModel.getSelectedEdges();
+		final JTable et = edgeTable.getTable();
+		et.getSelectionModel().clearSelection();
+		for ( final E e : selectedEdges )
+		{
+			final int row = edgeTable.getViewRowForObject( e );
+			et.getSelectionModel().addSelectionInterval( row, row );
+		}
+		ignoreTableSelectionChange = false;
+	}
+
+	@Override
+	public void focusChanged()
+	{
+		final V focusedVertex = focusModel.getFocusedVertex( vref );
+		vertexTable.focusObject( focusedVertex );
+	}
+
+	@Override
+	public void highlightChanged()
+	{
+		final V highlightedVertex = highlightModel.getHighlightedVertex( vref );
+		vertexTable.highlightObject( highlightedVertex );
+		final E highlightedEdge = highlightModel.getHighlightedEdge( eref );
+		edgeTable.highlightObject( highlightedEdge );
+	}
+
+	@Override
+	public void featureModelChanged()
+	{
+		ignoreTableSelectionChange = true;
+		final Map< ?, ? > map1 = collectFeatureMap( featureModel, vref.getClass() );
+		@SuppressWarnings( "unchecked" )
+		final Map< FeatureSpec< ?, V >, Feature< V > > vertexFeatures =  ( Map< FeatureSpec< ?, V >, Feature< V > > ) map1;
+		vertexTable.setFeatures( vertexFeatures );
+		final Map< ?, ? > map2 = collectFeatureMap( featureModel, eref.getClass() );
+		@SuppressWarnings( "unchecked" )
+		final Map< FeatureSpec< ?, E >, Feature< E > >  edgeFeatures = ( Map< FeatureSpec< ?, E >, Feature< E > > ) map2;
+		edgeTable.setFeatures( edgeFeatures );
+		if ( mirrorSelection )
+			selectionChanged();
+		ignoreTableSelectionChange = false;
+	}
+
+	@Override
+	public void tagSetStructureChanged()
+	{
+		ignoreTableSelectionChange = true;
+		final List< TagSet > tagSets = tagSetModel.getTagSetStructure().getTagSets();
+		vertexTable.setTagSets( tagSets );
+		edgeTable.setTagSets( tagSets );
+		if ( mirrorSelection )
+			selectionChanged();
+		ignoreTableSelectionChange = false;
+	}
+
+	private FeatureTagTablePanel< ? > getCurrentlyDisplayedTable()
+	{
+		final int selectedIndex = pane.getSelectedIndex();
+		return selectedIndex == 0 ? vertexTable : edgeTable;
+	}
+
+	public void editCurrentLabel()
+	{
+		getCurrentlyDisplayedTable().editCurrentLabel();
+	}
+
+	public void toggleTag()
+	{
+		getCurrentlyDisplayedTable().toggleCurrentTag();
+	}
+
+	@Override
+	public void contextChanged( final Context< V > context )
+	{
+		ignoreTableSelectionChange = true;
+		if ( null == context )
+		{
+			vertexTable.filter( null  );
+			edgeTable.filter( null );
+		}
+		else
+		{
+			filterByVertices.clear();
+			filterByEdges.clear();
+			final Iterable< V > insideVertices = context.getInsideVertices( context.getTimepoint() );
+			for ( final V v : insideVertices )
+			{
+				filterByVertices.add( v );
+				for ( final E e : v.edges() )
+					filterByEdges.add( e );
+			}
+			vertexTable.filter( filterByVertices );
+			edgeTable.filter( filterByEdges );
+		}
+		if ( mirrorSelection )
+			selectionChanged();
+		ignoreTableSelectionChange = false;
+	}
+
+	public ContextChooser< V > getContextChooser()
+	{
+		return contextChooser;
+	}
+
+	private static final < O > Map< FeatureSpec< ?, O >, Feature< O > > collectFeatureMap( final FeatureModel featureModel, final Class< O > clazz )
+	{
+		final Set< FeatureSpec< ?, ? > > featureSpecs = featureModel.getFeatureSpecs().stream()
+				.filter( ( fs ) -> fs.getTargetClass().isAssignableFrom( clazz ) )
+				.collect( Collectors.toSet() );
+		final Map< FeatureSpec< ?, O >, Feature< O > > featureMap = new HashMap<>();
+		for ( final FeatureSpec< ?, ? > fs : featureSpecs )
+		{
+			@SuppressWarnings( "unchecked" )
+			final Feature< O > feature = ( Feature< O > ) featureModel.getFeature( fs );
+			@SuppressWarnings( "unchecked" )
+			final FeatureSpec< ?, O > featureSpec = ( FeatureSpec< ?, O > ) fs;
+			featureMap.put( featureSpec, feature );
+		}
+		return featureMap;
+	}
+}

--- a/src/main/java/org/mastodon/views/trackscheme/TrackSchemeContextListener.java
+++ b/src/main/java/org/mastodon/views/trackscheme/TrackSchemeContextListener.java
@@ -124,5 +124,11 @@ public class TrackSchemeContextListener< V extends Vertex< ? > >  implements Con
 				}
 			};
 		}
+
+		@Override
+		public int getTimepoint()
+		{
+			return context.getTimepoint();
+		}
 	}
 }

--- a/src/test/java/org/mastodon/model/feature/ui/FeatureTagTableExample.java
+++ b/src/test/java/org/mastodon/model/feature/ui/FeatureTagTableExample.java
@@ -1,0 +1,96 @@
+package org.mastodon.model.feature.ui;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureModel;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.mamut.MamutAppModel;
+import org.mastodon.mamut.MamutViewTable;
+import org.mastodon.mamut.WindowManager;
+import org.mastodon.mamut.feature.MamutFeatureComputerService;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.project.MamutProject;
+import org.mastodon.mamut.project.MamutProjectIO;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.ui.ProgressListener;
+import org.scijava.Context;
+
+import mpicbg.spim.data.SpimDataException;
+
+public class FeatureTagTableExample
+{
+
+	public static void main( final String[] args ) throws IOException, SpimDataException, ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		Locale.setDefault( Locale.ROOT );
+		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+		final Context context = new Context();
+
+		final WindowManager windowManager = new WindowManager( context );
+		final String projectFile = "samples/drosophila_crop.mastodon";
+		final MamutProject project = new MamutProjectIO().load( projectFile );
+		windowManager.getProjectManager().open( project );
+
+		final MamutAppModel appModel = windowManager.getAppModel();
+		final Model model = windowManager.getAppModel().getModel();
+		final MamutFeatureComputerService computerService = context.getService( MamutFeatureComputerService.class );
+		computerService.setSharedBdvData( windowManager.getAppModel().getSharedBdvData() );
+		final Set< FeatureSpec< ?, ? > > featureSpecs = computerService.getFeatureSpecs();
+		final Map< FeatureSpec< ?, ? >, Feature< ? > > map = computerService.compute( featureSpecs );
+
+		final FeatureModel featureModel = model.getFeatureModel();
+		featureModel.pauseListeners();
+		for ( final Feature< ? > feature : map.values() )
+			featureModel.declareFeature(  feature );
+		featureModel.resumeListeners();
+
+		final TagSetStructure tss = new TagSetStructure();
+		final Random ran = new Random( 0l );
+		final TagSetStructure.TagSet reviewedByTag = tss.createTagSet( "Reviewed by" );
+		reviewedByTag.createTag( "Pavel", ran.nextInt() | 0xFF000000 );
+		reviewedByTag.createTag( "Mette", ran.nextInt() | 0xFF000000 );
+		reviewedByTag.createTag( "Tobias", ran.nextInt() | 0xFF000000 );
+		reviewedByTag.createTag( "JY", ran.nextInt() | 0xFF000000 );
+		final TagSetStructure.TagSet locationTag = tss.createTagSet( "Location" );
+		locationTag.createTag( "Anterior", ran.nextInt() | 0xFF000000 );
+		locationTag.createTag( "Posterior", ran.nextInt() | 0xFF000000 );
+		model.getTagSetModel().setTagSetStructure( tss );
+
+		final MamutViewTable view = new MamutViewTable( appModel );
+		view.getFrame().setMirrorSelection( true );
+		final ModelGraph graph = appModel.getModel().getGraph();
+		view.getFrame().getVertexTable().setRows( graph.vertices() );
+		view.getFrame().getEdgeTable().setRows( graph.edges() );
+		view.getFrame().setSize( 400, 400 );
+		view.getFrame().setVisible( true );
+	}
+
+	public static ProgressListener voidLogger()
+	{
+		return new ProgressListener()
+		{
+
+			@Override
+			public void showStatus( final String string )
+			{}
+
+			@Override
+			public void showProgress( final int current, final int total )
+			{}
+
+			@Override
+			public void clearStatus()
+			{}
+		};
+	}
+}


### PR DESCRIPTION
View model as a simple table.
-----------------------------

A new view is added by this PR. It reuses the `MamutView` framework already used for the BDV and TrackScheme views.  

There is two flavors of the table view, that can be found in the `Window` menu:
![mastodon_table_03](https://user-images.githubusercontent.com/3583203/40978364-bc6437cc-68d3-11e8-9332-485e303f5bf2.png)

The data table shows the full model as a two tables. They list object label, id, feature values and tags. There is one table for vertices:
![mastodon_table_01](https://user-images.githubusercontent.com/3583203/40978382-c9ed90fa-68d3-11e8-87e4-2adc6e34c800.png)
And one for edges:
![mastodon_table_02](https://user-images.githubusercontent.com/3583203/40978403-d8dbe3be-68d3-11e8-9b2a-ad37424a4dd4.png)

The columns are updated live when features are computed or when the tag structure is changed. The rows are changed when the graph is edited. 


Selection, Focus and Highlight view.
------------------------------------

The table is in sync with the selection model:
![mastodon_table_04](https://user-images.githubusercontent.com/3583203/40978484-090a553e-68d4-11e8-9fdb-bfdc650c840c.png)

And with the focus and the highlight models. The focused object is shown with a special font. The highlighted object with a thick border:
![mastodon_table_05](https://user-images.githubusercontent.com/3583203/40978651-2d795af0-68d4-11e8-8a0c-b3d8470cc183.png)


Table navigation.
-----------------

Using the group locks, the table can receive and send navigation events:
![mastodon_table-navigation](https://user-images.githubusercontent.com/3583203/40978870-911456dc-68d4-11e8-89c0-ca5882c6b47d.gif)


Table editors.
--------------

The table lets the user edit tags and the vertex labels:
![mastodon_table_06](https://user-images.githubusercontent.com/3583203/40978732-4413a9d2-68d4-11e8-9bc0-26ec511ff8c9.png)

![mastodon_table-edit](https://user-images.githubusercontent.com/3583203/40978739-49a14a1c-68d4-11e8-91eb-ce6b7182379a.gif)


Table context.
--------------

The table is a context listener. When a BDV context is chosen, it only displays the context content at current time-point:
![mastodon_table-context](https://user-images.githubusercontent.com/3583203/40978831-7d276b14-68d4-11e8-9425-9db854fca4f6.gif)


Selection Table.
----------------

The second flavor of the table is the selection table. It only displays the current selection and does not edit it:
![mastodon_table-selection-table](https://user-images.githubusercontent.com/3583203/40978919-aca94272-68d4-11e8-952e-9a7f65df2ab6.gif)


API changes.
-------------

For the context handling, I added a method in the `Context` interface that returns the current time-point:
```java
public interface Context< V >
{
	public Lock readLock();

	public Iterable< V > getInsideVertices( final int timepoint );

	public int getTimepoint();
}
```

Tags and feature-based coloring.
------------------------------------

There is now tag-set and feature based coloring for the table views:

![bl8w8-6n64z](https://user-images.githubusercontent.com/3583203/43958529-065a5abc-9cac-11e8-943f-1214b8da14f8.gif)


