### PR TITLE
Let the user select what sources they want to compute feature on.

### DIFF
--- a/src/main/java/org/mastodon/feature/FeatureComputationSettings.java
+++ b/src/main/java/org/mastodon/feature/FeatureComputationSettings.java
@@ -1,0 +1,117 @@
+package org.mastodon.feature;
+
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
+import net.imglib2.util.ValuePair;
+
+/**
+ * A model that manages a collection of computation settings for feature
+ * computers identified with their {@link FeatureSpec}s.
+ *
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class FeatureComputationSettings
+{
+
+	private final Map< FeatureSpec< ?, ? >, Object > settingsMap = new HashMap< FeatureSpec< ?, ? >, Object >();
+
+	/**
+	 * The description of the image data. Required to create a proper source
+	 * settings.
+	 */
+	private final AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
+
+	public FeatureComputationSettings( final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
+	{
+		this.sequenceDescription = sequenceDescription;
+	}
+
+	public SourceSelection getSourceSelection( final FeatureSpec< ?, ? > spec )
+	{
+		return ( SourceSelection ) settingsMap.computeIfAbsent( spec, k -> new SourceSelection( sequenceDescription ) );
+	}
+
+	public SourcePairSelection getSourcePairSelection( final FeatureSpec< ?, ? > spec )
+	{
+		return ( SourcePairSelection ) settingsMap.computeIfAbsent( spec, k -> new SourcePairSelection( sequenceDescription ) );
+	}
+
+	public static class SourceSelection
+	{
+
+		private final BitSet selectedSources;
+
+		private final AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
+
+		public SourceSelection( final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
+		{
+			this.sequenceDescription = sequenceDescription;
+			this.selectedSources = new BitSet( sequenceDescription.getViewSetupsOrdered().size() );
+			selectedSources.set( 0, sequenceDescription.getViewSetupsOrdered().size(), true );
+		}
+
+		public AbstractSequenceDescription< ?, ?, ? > getSequenceDescription()
+		{
+			return sequenceDescription;
+		}
+
+		public boolean isSourceSelected( final int source )
+		{
+			return selectedSources.get( source );
+		}
+
+		public void setSourceSelected( final int source, final boolean selected )
+		{
+			selectedSources.set( source, selected );
+		}
+
+		@Override
+		public String toString()
+		{
+			final StringBuilder str = new StringBuilder();
+			str.append( super.toString() + "\n" );
+			for ( int i = 0; i < sequenceDescription.getViewSetupsOrdered().size(); i++ )
+				str.append( " - " + i + ": " + sequenceDescription.getViewSetupsOrdered().get( i ).getName() + " -> " + isSourceSelected( i ) + "\n" );
+
+			return str.toString();
+		}
+	}
+
+	public static class SourcePairSelection
+	{
+
+		private final Set< ValuePair< Integer, Integer > > sourcePairs = new HashSet<>();
+
+		private final AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
+
+		public SourcePairSelection( final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
+		{
+			this.sequenceDescription = sequenceDescription;
+		}
+
+		public AbstractSequenceDescription< ?, ?, ? > getSequenceDescription()
+		{
+			return sequenceDescription;
+		}
+
+		public boolean isSourcePairSelected( final int source1, final int source2 )
+		{
+			return sourcePairs.contains( new ValuePair<>( Integer.valueOf( source1 ), Integer.valueOf( source2 ) ) );
+		}
+
+		public void setSourcePairSelected( final int source1, final int source2, final boolean selected )
+		{
+			final ValuePair< Integer, Integer > pair = new ValuePair<>( Integer.valueOf( source1 ), Integer.valueOf( source2 ) );
+			if ( selected )
+				sourcePairs.add( pair );
+			else
+				sourcePairs.remove( pair );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/feature/FeatureSpec.java
+++ b/src/main/java/org/mastodon/feature/FeatureSpec.java
@@ -107,4 +107,18 @@ public abstract class FeatureSpec< F extends Feature< T >, T > implements SciJav
 	{
 		return key.hashCode();
 	}
+
+	/**
+	 * Returns <code>true</code> when a feature should be selected by default in
+	 * a user interface. It is a good idea override the default implementation,
+	 * that returns <code>true</code>, when a feature computer is known to take
+	 * very long to compute.
+	 *
+	 * @return whether a feature should be selected by default in an user
+	 *         interface.
+	 */
+	public boolean isDefaultSelected()
+	{
+		return true;
+	}
 }

--- a/src/main/java/org/mastodon/feature/ui/FeatureComputationController.java
+++ b/src/main/java/org/mastodon/feature/ui/FeatureComputationController.java
@@ -11,12 +11,15 @@ import javax.swing.SwingUtilities;
 
 import org.mastodon.feature.DefaultFeatureComputerService.FeatureComputationStatusListener;
 import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureComputationSettings;
 import org.mastodon.feature.FeatureComputer;
 import org.mastodon.feature.FeatureComputerService;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.graph.GraphChangeListener;
 import org.mastodon.revised.ui.util.EverythingDisablerAndReenabler;
 import org.scijava.command.CommandService;
+
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 
 public class FeatureComputationController implements GraphChangeListener
 {
@@ -31,9 +34,33 @@ public class FeatureComputationController implements GraphChangeListener
 
 	private final FeatureComputationStatusListener computationStatusListener;
 
-	public FeatureComputationController( final FeatureComputerService computerService, final Collection< Class< ? > > targets )
+	/**
+	 * Description of the image data. Required to create a proper feature
+	 * computation settings.
+	 */
+	private final AbstractSequenceDescription< ?, ?, ? > sequenceDescription;
+
+	/**
+	 * Creates a new controller for feature computation.
+	 *
+	 * @param computerService
+	 *            the feature computation service to be called by this
+	 *            controller.
+	 * @param targets
+	 *            the collection of target classes. Only feature computers that
+	 *            compute features for the specified target will be managed by
+	 *            this controller.
+	 * @param sequenceDescription
+	 *            the description of the image data. Required to create a
+	 *            proper feature computation settings.
+	 */
+	public FeatureComputationController(
+			final FeatureComputerService computerService,
+			final Collection< Class< ? > > targets,
+			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
 	{
 		this.computerService = computerService;
+		this.sequenceDescription = sequenceDescription;
 		model = createModel( targets );
 		dialog = new JDialog( ( JFrame ) null, "Feature calculation" );
 		gui = new FeatureComputationPanel( model, targets );
@@ -109,7 +136,7 @@ public class FeatureComputationController implements GraphChangeListener
 	private FeatureComputationModel createModel( final Collection< Class< ? > > targets )
 	{
 		final CommandService commandService = computerService.getContext().getService( CommandService.class );
-		final FeatureComputationModel model = new FeatureComputationModel();
+		final FeatureComputationModel model = new FeatureComputationModel( sequenceDescription );
 		for ( final FeatureSpec< ?, ? > spec : computerService.getFeatureSpecs() )
 		{
 			// Only add the features with specified targets.
@@ -137,5 +164,10 @@ public class FeatureComputationController implements GraphChangeListener
 	public JDialog getDialog()
 	{
 		return dialog;
+	}
+
+	public FeatureComputationSettings getFeatureComputationSettings()
+	{
+		return model.getFeatureComputationSettings();
 	}
 }

--- a/src/main/java/org/mastodon/feature/ui/FeatureComputationModel.java
+++ b/src/main/java/org/mastodon/feature/ui/FeatureComputationModel.java
@@ -8,8 +8,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.feature.FeatureComputationSettings;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.util.Listeners;
+
+import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 
 public class FeatureComputationModel
 {
@@ -32,8 +35,9 @@ public class FeatureComputationModel
 
 	private final Map< FeatureSpec< ?, ? >, Collection< FeatureSpec< ?, ? > > > deps;
 
+	private final FeatureComputationSettings featureComputationSettings;
 
-	public FeatureComputationModel()
+	public FeatureComputationModel( final AbstractSequenceDescription< ?, ?, ? > sequenceDescription )
 	{
 		this.updateListeners = new Listeners.SynchronizedList<>();
 		this.selectedFeatures = new HashSet<>();
@@ -42,6 +46,7 @@ public class FeatureComputationModel
 		this.featureSpecsKeys = new HashMap<>();
 		this.uptodateMap = new HashMap<>();
 		this.deps = new HashMap<>();
+		this.featureComputationSettings = new FeatureComputationSettings( sequenceDescription );
 	}
 
 	private void notifyListeners()
@@ -148,5 +153,10 @@ public class FeatureComputationModel
 	public Collection< FeatureSpec< ?, ? > > getDependencies( final FeatureSpec< ?, ? > spec )
 	{
 		return Collections.unmodifiableCollection( deps.computeIfAbsent( spec, s -> Collections.emptyList() ) );
+	}
+
+	public FeatureComputationSettings getFeatureComputationSettings()
+	{
+		return featureComputationSettings;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/feature/MamutFeatureComputerService.java
+++ b/src/main/java/org/mastodon/mamut/feature/MamutFeatureComputerService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.mastodon.feature.DefaultFeatureComputerService;
 import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureComputationSettings;
 import org.mastodon.feature.FeatureModel;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.feature.FeatureSpecsService;
@@ -27,6 +28,8 @@ public class MamutFeatureComputerService extends DefaultFeatureComputerService
 	private SharedBigDataViewerData sharedBdvData;
 
 	private Model model;
+
+	private FeatureComputationSettings featureComputationSettings;
 
 	@Parameter
 	private FeatureSpecsService featureSpecsService;
@@ -80,6 +83,14 @@ public class MamutFeatureComputerService extends DefaultFeatureComputerService
 			return;
 		}
 
+		if ( FeatureComputationSettings.class.isAssignableFrom( parameterClass ) )
+		{
+			@SuppressWarnings( "unchecked" )
+			final ModuleItem< FeatureComputationSettings > settingsItem = ( ModuleItem< FeatureComputationSettings > ) item;
+			settingsItem.setValue( module, featureComputationSettings );
+			return;
+		}
+
 		super.provideParameters( item, module, parameterClass, featureModel );
 	}
 
@@ -121,5 +132,10 @@ public class MamutFeatureComputerService extends DefaultFeatureComputerService
 		final PropertyChangeListener< Spot > vertexPropertyListener = GraphFeatureUpdateListeners.vertexPropertyListener( spotUpdates, linkUpdates );
 		spotPool.covarianceProperty().addPropertyChangeListener( vertexPropertyListener );
 		spotPool.positionProperty().addPropertyChangeListener( vertexPropertyListener );
+	}
+
+	public void setFeatureComputationSettings( final FeatureComputationSettings featureComputationSettings )
+	{
+		this.featureComputationSettings = featureComputationSettings;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/feature/SpotGaussFilteredIntensityFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotGaussFilteredIntensityFeature.java
@@ -51,6 +51,12 @@ public class SpotGaussFilteredIntensityFeature implements Feature< Spot >
 					Multiplicity.ON_SOURCES,
 					MEAN_PROJECTION_SPEC, STD_PROJECTION_SPEC );
 		}
+
+		@Override
+		public final boolean isDefaultSelected()
+		{
+			return false;
+		}
 	}
 
 	private final Map< FeatureProjectionKey, FeatureProjection< Spot > > projectionMap;

--- a/src/main/java/org/mastodon/revised/mamut/MamutFeatureComputation.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutFeatureComputation.java
@@ -35,8 +35,12 @@ public class MamutFeatureComputation
 
 		// Controller.
 		final Collection< Class< ? > > targets = Arrays.asList( Spot.class, Link.class );
-		final FeatureComputationController controller = new FeatureComputationController( myComputerService, targets );
+		final FeatureComputationController controller = new FeatureComputationController(
+				myComputerService,
+				targets,
+				appModel.getSharedBdvData().getSpimData().getSequenceDescription() );
 		computerService.computationStatusListeners().add( controller.getComputationStatusListener() );
+		computerService.setFeatureComputationSettings( controller.getFeatureComputationSettings() );
 
 		// Listen to model changes and echo in the GUI
 		final ModelGraph graph = appModel.getModel().getGraph();

--- a/src/main/java/org/mastodon/revised/mamut/Mastodon.java
+++ b/src/main/java/org/mastodon/revised/mamut/Mastodon.java
@@ -66,7 +66,8 @@ public class Mastodon extends ContextCommand
 //		final MamutProject project = new MamutProject( new File( "samples/mamutproject" ), new File( bdvFile ) );
 //		final MamutProject project = new MamutProjectIO().load( "/Volumes/External/Data/Mastodon/Tassos200" );
 //		final MamutProject project = new MamutProject( null, new File( "x=1000 y=1000 z=100 sx=1 sy=1 sz=10 t=400.dummy" ) );
-		final MamutProject project = new MamutProjectIO().load( "samples/mamutproject.mastodon" );
+//		final MamutProject project = new MamutProjectIO().load( "samples/mamutproject.mastodon" );
+		final MamutProject project = new MamutProjectIO().load( "/Users/tinevez/Projects/JYTinevez/MaMuT/Mastodon-dataset/MaMuT_Parhyale_demo.mastodon" );
 
 		windowManager.projectManager.open( project );
 //		mw.proposedProjectFile = new File( "/Users/pietzsch/Desktop/data/TGMM_METTE/project2.xml" );


### PR DESCRIPTION
The features that have a `ON_SOURCES` mutiplicity can now be configured to compute the feature only on certain sources. 

It looks like this in the feature computation dialog:
![Screen Shot 2019-12-13 at 13 44 36](https://user-images.githubusercontent.com/3583203/70801273-c089e900-1dae-11ea-9b2b-bc343c5c7abc.png)

There is a model class that stores what the user selects, and that can be added as dependency in feature computation:
![Screen Shot 2019-12-13 at 13 46 22](https://user-images.githubusercontent.com/3583203/70801386-0d6dbf80-1daf-11ea-99e6-33eb08c8a873.png)

From this class, the computer must retrieve the specific settings for the feature they compute:
![Screen Shot 2019-12-13 at 13 47 42](https://user-images.githubusercontent.com/3583203/70801423-29716100-1daf-11ea-89e5-8d935991c56d.png)

And use it in the computation loop:

![Screen Shot 2019-12-13 at 13 48 30](https://user-images.githubusercontent.com/3583203/70801453-39894080-1daf-11ea-9a9b-3a8a5174b4a2.png)
