### PR TITLE
Use more general type in all @Plugin annotations

### DIFF
--- a/src/main/java/org/mastodon/app/ui/CloseWindowActions.java
+++ b/src/main/java/org/mastodon/app/ui/CloseWindowActions.java
@@ -26,7 +26,7 @@ public class CloseWindowActions
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
+++ b/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
@@ -25,7 +25,7 @@ public class MastodonFrameViewActions
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureComputer.java
@@ -10,7 +10,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkDisplacementFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class LinkDisplacementFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureSerializer.java
@@ -15,7 +15,7 @@ import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.mamut.Link;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkDisplacementFeatureSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class LinkDisplacementFeatureSerializer implements FeatureSerializer< LinkDisplacementFeature, Link >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkUpdateStackComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkUpdateStackComputer.java
@@ -5,7 +5,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkUpdateStackComputer.class, visible = false )
+@Plugin( type = MamutFeatureComputer.class, visible = false )
 public class LinkUpdateStackComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkUpdateStackSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkUpdateStackSerializer.java
@@ -4,13 +4,14 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 
 import org.mastodon.collection.RefCollection;
+import org.mastodon.feature.io.FeatureSerializer;
 import org.mastodon.feature.update.UpdateStackSerializer;
 import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.mamut.feature.LinkUpdateStack.Spec;
 import org.mastodon.revised.model.mamut.Link;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkUpdateStackSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class LinkUpdateStackSerializer extends UpdateStackSerializer< LinkUpdateStack, Link >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureComputer.java
@@ -10,7 +10,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkVelocityFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class LinkVelocityFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureSerializer.java
@@ -15,7 +15,7 @@ import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.mamut.Link;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = LinkVelocityFeatureSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class LinkVelocityFeatureSerializer implements FeatureSerializer< LinkVelocityFeature, Link >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotFrameFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotFrameFeatureComputer.java
@@ -5,7 +5,7 @@ import static org.scijava.ItemIO.OUTPUT;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotFrameFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class SpotFrameFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotGaussFilteredIntensityFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotGaussFilteredIntensityFeatureComputer.java
@@ -33,7 +33,7 @@ import net.imglib2.RealPoint;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.RealType;
 
-@Plugin( type = SpotGaussFilteredIntensityFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class SpotGaussFilteredIntensityFeatureComputer implements MamutFeatureComputer, Cancelable
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotNLinksFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotNLinksFeatureComputer.java
@@ -7,7 +7,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotNLinksFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class SpotNLinksFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotNLinksFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotNLinksFeatureSerializer.java
@@ -14,7 +14,7 @@ import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotNLinksFeatureSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class SpotNLinksFeatureSerializer implements FeatureSerializer< SpotNLinksFeature, Spot >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotTrackIDFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotTrackIDFeatureComputer.java
@@ -11,7 +11,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotTrackIDFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class SpotTrackIDFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotTrackIDFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotTrackIDFeatureSerializer.java
@@ -14,7 +14,7 @@ import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotTrackIDFeatureSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class SpotTrackIDFeatureSerializer implements FeatureSerializer< SpotTrackIDFeature, Spot >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotUpdateStackComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotUpdateStackComputer.java
@@ -5,7 +5,7 @@ import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotUpdateStackComputer.class, visible = false )
+@Plugin( type = MamutFeatureComputer.class, visible = false )
 public class SpotUpdateStackComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/SpotUpdateStackSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotUpdateStackSerializer.java
@@ -4,13 +4,14 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 
 import org.mastodon.collection.RefCollection;
+import org.mastodon.feature.io.FeatureSerializer;
 import org.mastodon.feature.update.UpdateStackSerializer;
 import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.mamut.feature.SpotUpdateStack.Spec;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = SpotUpdateStackSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class SpotUpdateStackSerializer extends UpdateStackSerializer< SpotUpdateStack, Spot >
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/TrackSizeFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/TrackSizeFeatureComputer.java
@@ -11,7 +11,7 @@ import org.scijava.plugin.Plugin;
 import gnu.trove.map.TIntIntMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 
-@Plugin( type = TrackSizeFeatureComputer.class )
+@Plugin( type = MamutFeatureComputer.class )
 public class TrackSizeFeatureComputer implements MamutFeatureComputer
 {
 

--- a/src/main/java/org/mastodon/mamut/feature/TrackSizeFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/TrackSizeFeatureSerializer.java
@@ -14,7 +14,7 @@ import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = TrackSizeFeatureSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class TrackSizeFeatureSerializer implements FeatureSerializer< TrackSizeFeature, Spot >
 {
 

--- a/src/main/java/org/mastodon/plugin/MastodonTestPlugin.java
+++ b/src/main/java/org/mastodon/plugin/MastodonTestPlugin.java
@@ -14,7 +14,7 @@ import org.mastodon.revised.ui.keymap.CommandDescriptions;
 import org.scijava.ui.behaviour.util.AbstractNamedAction;
 import org.scijava.ui.behaviour.util.Actions;
 
-//@Plugin( type = MastodonTestPlugin.class )
+//@Plugin( type = MastodonPlugin.class )
 public class MastodonTestPlugin implements MastodonPlugin
 {
 	private static final String ACTION_1 = "[testplugin] action1";
@@ -24,7 +24,7 @@ public class MastodonTestPlugin implements MastodonPlugin
 	/*
 	 * Command descriptions for all provided commands
 	 */
-//	@Plugin( type = Descriptions.class )
+//	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler2DMamut.java
@@ -73,7 +73,7 @@ public class BehaviourTransformEventHandler2DMamut implements BehaviourTransform
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler3DMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BehaviourTransformEventHandler3DMamut.java
@@ -122,7 +122,7 @@ public class BehaviourTransformEventHandler3DMamut implements BehaviourTransform
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/BigDataViewerActionsMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/BigDataViewerActionsMamut.java
@@ -77,7 +77,7 @@ public class BigDataViewerActionsMamut
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/NavigationActionsMamut.java
+++ b/src/main/java/org/mastodon/revised/bdv/NavigationActionsMamut.java
@@ -67,7 +67,7 @@ public class NavigationActionsMamut
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/overlay/BdvSelectionBehaviours.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/BdvSelectionBehaviours.java
@@ -28,7 +28,7 @@ public class BdvSelectionBehaviours< V extends OverlayVertex< V, E >, E extends 
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/overlay/EditBehaviours.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/EditBehaviours.java
@@ -51,7 +51,7 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/EditSpecialBehaviours.java
@@ -44,7 +44,7 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
@@ -60,7 +60,7 @@ public class ProjectManager
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/mamut/UndoActions.java
+++ b/src/main/java/org/mastodon/revised/mamut/UndoActions.java
@@ -17,7 +17,7 @@ public class UndoActions
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/WindowManager.java
@@ -61,7 +61,7 @@ public class WindowManager
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImportedLinkFeaturesSerializer.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImportedLinkFeaturesSerializer.java
@@ -5,11 +5,12 @@ import java.io.ObjectInputStream;
 
 import org.mastodon.collection.RefCollection;
 import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.io.FeatureSerializer;
 import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.revised.model.mamut.Link;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = TrackMateImportedLinkFeaturesSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class TrackMateImportedLinkFeaturesSerializer extends TrackMateImportedFeaturesSerializer< TrackMateImportedLinkFeatures, Link >
 {
 

--- a/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImportedSpotFeaturesSerializer.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImportedSpotFeaturesSerializer.java
@@ -5,11 +5,12 @@ import java.io.ObjectInputStream;
 
 import org.mastodon.collection.RefCollection;
 import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.io.FeatureSerializer;
 import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = TrackMateImportedSpotFeaturesSerializer.class )
+@Plugin( type = FeatureSerializer.class )
 public class TrackMateImportedSpotFeaturesSerializer extends TrackMateImportedFeaturesSerializer< TrackMateImportedSpotFeatures, Spot >
 {
 

--- a/src/main/java/org/mastodon/revised/trackscheme/display/EditFocusVertexLabelAction.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/EditFocusVertexLabelAction.java
@@ -53,7 +53,7 @@ public class EditFocusVertexLabelAction extends AbstractNamedAction implements T
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/trackscheme/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/InertialScreenTransformEventHandler.java
@@ -43,7 +43,7 @@ public class InertialScreenTransformEventHandler
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/trackscheme/display/ToggleLinkBehaviour.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/ToggleLinkBehaviour.java
@@ -51,7 +51,7 @@ public class ToggleLinkBehaviour< V extends Vertex< E > & HasTimepoint, E extend
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeNavigationActions.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeNavigationActions.java
@@ -47,7 +47,7 @@ public class TrackSchemeNavigationActions
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeNavigationBehaviours.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeNavigationBehaviours.java
@@ -52,7 +52,7 @@ public class TrackSchemeNavigationBehaviours implements TransformListener< Scree
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeZoom.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemeZoom.java
@@ -46,7 +46,7 @@ public class TrackSchemeZoom< V extends Vertex< E > & HasTimepoint, E extends Ed
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/ui/EditTagActions.java
+++ b/src/main/java/org/mastodon/revised/ui/EditTagActions.java
@@ -63,7 +63,7 @@ public class EditTagActions< V extends Vertex< E >, E extends Edge< V > >
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/ui/FocusActions.java
+++ b/src/main/java/org/mastodon/revised/ui/FocusActions.java
@@ -64,7 +64,7 @@ public class FocusActions< V extends Vertex< E > & Ref< V >, E extends Edge< V >
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/ui/HighlightBehaviours.java
+++ b/src/main/java/org/mastodon/revised/ui/HighlightBehaviours.java
@@ -38,7 +38,7 @@ public class HighlightBehaviours< V extends Vertex< E >, E extends Edge< V > >
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/main/java/org/mastodon/revised/ui/SelectionActions.java
+++ b/src/main/java/org/mastodon/revised/ui/SelectionActions.java
@@ -49,7 +49,7 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 	/*
 	 * Command descriptions for all provided commands
 	 */
-	@Plugin( type = Descriptions.class )
+	@Plugin( type = CommandDescriptionProvider.class )
 	public static class Descriptions extends CommandDescriptionProvider
 	{
 		public Descriptions()

--- a/src/test/java/org/mastodon/feature/FeatureDiscoveryExample.java
+++ b/src/test/java/org/mastodon/feature/FeatureDiscoveryExample.java
@@ -164,7 +164,7 @@ public class FeatureDiscoveryExample
 		}
 	}
 
-	@Plugin( type = FC1.class )
+	@Plugin( type = FeatureComputer.class )
 	public static class FC1 implements FeatureComputer
 	{
 		@Parameter( type = OUTPUT )
@@ -181,7 +181,7 @@ public class FeatureDiscoveryExample
 		}
 	}
 
-	@Plugin( type = FC2.class )
+	@Plugin( type = FeatureComputer.class )
 	public static class FC2 implements FeatureComputer
 	{
 		@Parameter
@@ -203,7 +203,7 @@ public class FeatureDiscoveryExample
 		}
 	}
 
-	@Plugin( type = FC3.class )
+	@Plugin( type = FeatureComputer.class )
 	public static class FC3 implements FeatureComputer
 	{
 		@Parameter
@@ -228,7 +228,7 @@ public class FeatureDiscoveryExample
 		}
 	}
 
-	@Plugin( type = FC4.class )
+	@Plugin( type = FeatureComputer.class )
 	public static class FC4 implements FeatureComputer
 	{
 		@Parameter

--- a/src/test/java/org/mastodon/feature/update/GraphUpdateStackTest.java
+++ b/src/test/java/org/mastodon/feature/update/GraphUpdateStackTest.java
@@ -274,7 +274,7 @@ public class GraphUpdateStackTest
 		}
 	}
 
-	@Plugin( type = FT1computer.class )
+	@Plugin( type = MamutFeatureComputer.class )
 	public static class FT1computer extends TestFeatureComputer
 	{
 
@@ -357,7 +357,7 @@ public class GraphUpdateStackTest
 		}
 	}
 
-	@Plugin( type = FT2computer.class )
+	@Plugin( type = MamutFeatureComputer.class )
 	public static class FT2computer extends TestFeatureComputer
 	{
 
@@ -432,7 +432,7 @@ public class GraphUpdateStackTest
 		}
 	}
 
-	@Plugin( type = FT3computer.class )
+	@Plugin( type = MamutFeatureComputer.class )
 	public static class FT3computer extends TestFeatureComputer
 	{
 

--- a/src/test/java/org/mastodon/feature/update/UpdateStackSerializationTest.java
+++ b/src/test/java/org/mastodon/feature/update/UpdateStackSerializationTest.java
@@ -26,6 +26,7 @@ import org.mastodon.graph.io.RawGraphIO;
 import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.io.ObjectToFileIdMap;
 import org.mastodon.io.properties.DoublePropertyMapSerializer;
+import org.mastodon.mamut.feature.MamutFeatureComputer;
 import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.project.MamutProject;
 import org.mastodon.project.MamutProjectIO;
@@ -284,7 +285,7 @@ public class UpdateStackSerializationTest
 		}
 	}
 
-	@Plugin( type = FT4computer.class )
+	@Plugin( type = MamutFeatureComputer.class )
 	public static class FT4computer extends TestFeatureComputer
 	{
 


### PR DESCRIPTION
Every class that is listed as a @Plugin's type will be loaded by the class
loader. So putting the concrete types here defeats the purpose of the
plugin index. Thanks @ctrueden for pointing it out.