### PR TITLE
open up the API a little to give plugins more info

### DIFF
--- a/src/main/java/org/mastodon/revised/mamut/MamutView.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutView.java
@@ -28,7 +28,9 @@ public class MamutView< VG extends ViewGraph< Spot, Link, V, E >, V extends Vert
 
 	/**
 	 * Sets up and registers the coloring menu item and related actions and
-	 * listeners.
+	 * listeners. A new instance of the {@code ColoringModel} is created here and
+	 * a reference on it is returned. This instance is bound to all relevant actions
+	 * and is therefore knowledgeable of the currently used coloring style.
 	 *
 	 * @param colorGeneratorAdapter
 	 *            adapts a (modifiable) model coloring to view vertices/edges.
@@ -37,8 +39,10 @@ public class MamutView< VG extends ViewGraph< Spot, Link, V, E >, V extends Vert
 	 *            Coloring options will be installed here.
 	 * @param refresh
 	 *            triggers repaint of the graph (called when coloring changes)
+     *
+	 * @return reference on the underlying {@code ColoringModel}
 	 */
-	protected void registerColoring(
+	protected ColoringModel registerColoring(
 			final GraphColorGeneratorAdapter< Spot, Link, V, E > colorGeneratorAdapter,
 			final JMenuHandle menuHandle,
 			final Runnable refresh )
@@ -72,6 +76,8 @@ public class MamutView< VG extends ViewGraph< Spot, Link, V, E >, V extends Vert
 			refresh.run();
 		};
 		coloringModel.listeners().add( coloringChangedListener );
+
+		return coloringModel;
 	}
 
 	protected void registerTagSetMenu(

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
@@ -13,6 +13,8 @@ import org.mastodon.app.ui.MastodonFrameViewActions;
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.model.AutoNavigateFocusModel;
+import org.mastodon.model.TimepointListener;
+import org.mastodon.model.TimepointModel;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraphTrackSchemeProperties;
@@ -32,6 +34,7 @@ import org.mastodon.revised.ui.EditTagActions;
 import org.mastodon.revised.ui.FocusActions;
 import org.mastodon.revised.ui.HighlightBehaviours;
 import org.mastodon.revised.ui.SelectionActions;
+import org.mastodon.revised.ui.coloring.ColoringModel;
 import org.mastodon.revised.ui.coloring.GraphColorGeneratorAdapter;
 import org.mastodon.views.context.ContextChooser;
 import org.scijava.ui.behaviour.KeyPressedManager;
@@ -39,6 +42,12 @@ import org.scijava.ui.behaviour.KeyPressedManager;
 public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Link >, TrackSchemeVertex, TrackSchemeEdge >
 {
 	private final ContextChooser< Spot > contextChooser;
+
+	/** a reference on the {@code GraphColorGeneratorAdapter} created and registered with this instance/window */
+	private final GraphColorGeneratorAdapter< Spot, Link, TrackSchemeVertex, TrackSchemeEdge > coloringAdapter;
+
+	/** a reference on a supervising instance of the {@code ColoringModel} that is bound to this instance/window */
+	private final ColoringModel coloringModel;
 
 	public MamutViewTrackScheme( final MamutAppModel appModel )
 	{
@@ -63,11 +72,11 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 		 * show TrackSchemeFrame
 		 */
 		final TrackSchemeStyle forwardDefaultStyle = appModel.getTrackSchemeStyleManager().getForwardDefaultStyle();
-		final GraphColorGeneratorAdapter< Spot, Link, TrackSchemeVertex, TrackSchemeEdge > coloring = new GraphColorGeneratorAdapter<>( viewGraph.getVertexMap(), viewGraph.getEdgeMap() );
+		coloringAdapter = new GraphColorGeneratorAdapter<>( viewGraph.getVertexMap(), viewGraph.getEdgeMap() );
 		final TrackSchemeOptions options = TrackSchemeOptions.options()
 				.shareKeyPressedEvents( keyPressedManager )
 				.style( forwardDefaultStyle )
-				.graphColorGenerator( coloring );
+				.graphColorGenerator( coloringAdapter );
 		final AutoNavigateFocusModel< TrackSchemeVertex, TrackSchemeEdge > navigateFocusModel = new AutoNavigateFocusModel<>( focusModel, navigationHandler );
 		final TrackSchemeFrame frame = new TrackSchemeFrame(
 				viewGraph,
@@ -142,7 +151,7 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 		);
 		appModel.getPlugins().addMenus( menu );
 
-		registerColoring( coloring, coloringMenuHandle,
+		coloringModel = registerColoring( coloringAdapter, coloringMenuHandle,
 				() -> frame.getTrackschemePanel().entitiesAttributesChanged() );
 
 		registerTagSetMenu( tagSetMenuHandle,
@@ -154,5 +163,20 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 	public ContextChooser< Spot > getContextChooser()
 	{
 		return contextChooser;
+	}
+
+	public GraphColorGeneratorAdapter< Spot, Link, TrackSchemeVertex, TrackSchemeEdge > getGraphColorGeneratorAdapter()
+	{
+		return coloringAdapter;
+	}
+
+	public ColoringModel getColoringModel()
+	{
+		return coloringModel;
+	}
+
+	public TimepointModel getTimepointModel()
+	{
+		return timepointModel;
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
@@ -13,7 +13,6 @@ import org.mastodon.app.ui.MastodonFrameViewActions;
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.model.AutoNavigateFocusModel;
-import org.mastodon.model.TimepointListener;
 import org.mastodon.model.TimepointModel;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
@@ -43,10 +42,16 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 {
 	private final ContextChooser< Spot > contextChooser;
 
-	/** a reference on the {@code GraphColorGeneratorAdapter} created and registered with this instance/window */
+	/**
+	 * a reference on the {@code GraphColorGeneratorAdapter} created and
+	 * registered with this instance/window
+	 */
 	private final GraphColorGeneratorAdapter< Spot, Link, TrackSchemeVertex, TrackSchemeEdge > coloringAdapter;
 
-	/** a reference on a supervising instance of the {@code ColoringModel} that is bound to this instance/window */
+	/**
+	 * a reference on a supervising instance of the {@code ColoringModel} that
+	 * is bound to this instance/window
+	 */
 	private final ColoringModel coloringModel;
 
 	public MamutViewTrackScheme( final MamutAppModel appModel )

--- a/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
+++ b/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
@@ -4,6 +4,24 @@ import org.mastodon.adapter.RefBimap;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Vertex;
 
+/**
+ * Adapts a {@code GraphColorGenerator<V, E>} as a {@code GraphColorGenerator<WV, WE>}.
+ * The mapping between source vertices/edges ({@code V, E}) and wrapped
+ * vertices/edges ({@code WV, WE}) is established by {@link RefBimap}s.
+ * <p>
+ * The adapted source coloring is modifiable.
+ *
+ * @param <V>
+ *            vertex type of wrapped source graph.
+ * @param <E>
+ *            edge type of wrapped source graph.
+ * @param <WV>
+ *            vertex type this {@code GraphColorGenerator}.
+ * @param <WE>
+ *            edge type this {@code GraphColorGenerator}.
+ *
+ * @author Tobias Pietzsch
+ */
 public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< V >, WV extends Vertex< WE >, WE extends Edge< WV > >
 		implements GraphColorGenerator< WV, WE >
 {
@@ -26,6 +44,11 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 		this.colorGenerator = colorGenerator;
 	}
 
+	/**
+	 * Get the currently adapted {@code ColorGenerator} (on model graph).
+	 *
+	 * @return the currently adapted {@code ColorGenerator}, maybe {@code null}
+	 */
 	public GraphColorGenerator< V, E > getColorGenerator()
 	{
 		return colorGenerator;

--- a/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
+++ b/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
@@ -26,7 +26,11 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 		this.colorGenerator = colorGenerator;
 	}
 
-	/** report current color for the view graph's vertex */
+	public GraphColorGenerator< V, E > getColorGenerator()
+	{
+		return colorGenerator;
+	}
+
 	@Override
 	public int color( final WV vertex )
 	{
@@ -36,7 +40,6 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 			return colorGenerator.color( vertexMap.getLeft( vertex ) );
 	}
 
-	/** report current color for the view graph's edge */
 	@Override
 	public int color( final WE edge, final WV source, final WV target )
 	{
@@ -44,23 +47,5 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 			return 0;
 		else
 			return colorGenerator.color( edgeMap.getLeft( edge ), vertexMap.getLeft( source ), vertexMap.getLeft( target ) );
-	}
-
-	/** report current color for the model graph's vertex */
-	public int spotColor( final V vertex )
-	{
-		if ( colorGenerator == null )
-			return 0;
-		else
-			return colorGenerator.color( vertex );
-	}
-
-	/** report current color for the model graph's edge */
-	public int edgeColor( final E edge, final V source, final V target )
-	{
-		if ( colorGenerator == null )
-			return 0;
-		else
-			return colorGenerator.color( edge, source, target );
 	}
 }

--- a/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
+++ b/src/main/java/org/mastodon/revised/ui/coloring/GraphColorGeneratorAdapter.java
@@ -26,6 +26,7 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 		this.colorGenerator = colorGenerator;
 	}
 
+	/** report current color for the view graph's vertex */
 	@Override
 	public int color( final WV vertex )
 	{
@@ -35,6 +36,7 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 			return colorGenerator.color( vertexMap.getLeft( vertex ) );
 	}
 
+	/** report current color for the view graph's edge */
 	@Override
 	public int color( final WE edge, final WV source, final WV target )
 	{
@@ -42,5 +44,23 @@ public class GraphColorGeneratorAdapter< V extends Vertex< E >, E extends Edge< 
 			return 0;
 		else
 			return colorGenerator.color( edgeMap.getLeft( edge ), vertexMap.getLeft( source ), vertexMap.getLeft( target ) );
+	}
+
+	/** report current color for the model graph's vertex */
+	public int spotColor( final V vertex )
+	{
+		if ( colorGenerator == null )
+			return 0;
+		else
+			return colorGenerator.color( vertex );
+	}
+
+	/** report current color for the model graph's edge */
+	public int edgeColor( final E edge, final V source, final V target )
+	{
+		if ( colorGenerator == null )
+			return 0;
+		else
+			return colorGenerator.color( edge, source, target );
 	}
 }


### PR DESCRIPTION
Hello,
I propose to open up the API a little bit **for reading** of some internals. This way, plugins can better read how the GUI is currently set up (e.g. what coloring scheme is active, what is the current time point, set up listeners to these) and they can adopt their behavior to it (in my story, resend the currently chosen time point to elsewhere for its vizu).

Here's how I envision the usage of the newly accessible API:

- [obtain handle](https://github.com/xulman/TomancakLab/blob/f15f3d3b64d5dae4c4cf5b8ce75103fc0994b799/Mastodon/src/main/java/de/mpicbg/tomancaklab/LineageToSimViewer.java#L95-L98) and [use it](https://github.com/xulman/TomancakLab/blob/f15f3d3b64d5dae4c4cf5b8ce75103fc0994b799/Mastodon/src/main/java/de/mpicbg/tomancaklab/LineageToSimViewer.java#L425-L430)
- [register listeners](https://github.com/xulman/TomancakLab/blob/f15f3d3b64d5dae4c4cf5b8ce75103fc0994b799/Mastodon/src/main/java/de/mpicbg/tomancaklab/LineageToSimViewer.java#L191-L197)

PS: I have just today, by chance, found [a commit of @tinevez](https://github.com/mastodon-sc/mastodon/pull/86/commits/c26d4677394f8ec489cd7cc8e2e5c3d9f8a01148) within a pull request #86. I think this PR is extending that commit (not that PR - that one focuses on a different thing).

Thanks for considering it... ;-)
Vlado