### PR TITLE
Serialize gui state to the Mastodon project - take 2.

### DIFF
--- a/src/main/java/org/mastodon/app/MastodonView.java
+++ b/src/main/java/org/mastodon/app/MastodonView.java
@@ -116,4 +116,14 @@ public class MastodonView<
 		runOnClose.forEach( Runnable::run );
 		runOnClose.clear();
 	}
+
+	/**
+	 * Exposes the {@link GroupHandle} of this view.
+	 * 
+	 * @return the {@link GroupHandle} of this view.
+	 */
+	public GroupHandle getGroupHandle()
+	{
+		return groupHandle;
+	}
 }

--- a/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
@@ -2,6 +2,7 @@ package org.mastodon.mamut;
 
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -221,10 +222,10 @@ class MamutViewStateSerialization
 
 		// Edit position to reflect the fact that we store the TrackScheme panel
 		// width and height.
-		final Rectangle bounds = view.getFrame().getBounds();
+		final Point point = view.getFrame().getLocation();
 		guiState.put( FRAME_POSITION_KEY, new int[] {
-				( int ) bounds.getMinX(),
-				( int ) bounds.getMinY(),
+				point.x,
+				point.y,
 				trackschemePanel.getDisplay().getWidth(),
 				trackschemePanel.getDisplay().getHeight() } );
 

--- a/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
@@ -1,0 +1,349 @@
+package org.mastodon.mamut;
+
+import java.awt.Rectangle;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.jdom2.Element;
+import org.mastodon.app.ui.MastodonFrameView;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.ui.coloring.ColoringModel;
+import org.mastodon.views.bdv.ViewerPanelMamut;
+import org.mastodon.views.context.ContextChooser;
+import org.mastodon.views.context.ContextProvider;
+import org.mastodon.views.trackscheme.ScreenTransform;
+import org.mastodon.views.trackscheme.display.TrackSchemePanel;
+
+import bdv.viewer.ViewerState;
+import mpicbg.spim.data.XmlHelpers;
+import net.imglib2.realtransform.AffineGet;
+import net.imglib2.realtransform.AffineTransform3D;
+
+/**
+ * Collection of constants and utilities related to de/serializing a GUI state.
+ */
+class MamutViewStateSerialization
+{
+
+	static final String WINDOW_TAG = "Window";
+
+	/**
+	 * Key to the view type name. Value is a string.
+	 */
+	static final String VIEW_TYPE_KEY = "Type";
+
+	/**
+	 * Key to the parameter that stores the frame position for
+	 * {@link MastodonFrameView}s. Value is and <code>int[]</code> array of 4
+	 * elements: x, y, width and height.
+	 */
+	static final String FRAME_POSITION_KEY = "FramePosition";
+
+	/**
+	 * Key that specifies whether the settings panel is visible or not.
+	 */
+	static final String SETTINGS_PANEL_VISIBLE_KEY = "SettingsPanelVisible";
+
+	/**
+	 * Key to the lock group id. Value is an int.
+	 */
+	static final String GROUP_HANDLE_ID_KEY = "LockGroupId";
+
+	/**
+	 * Key for the {@link ViewerState} in a BDV view. Value is a XML
+	 * {@link Element} serialized from the state.
+	 *
+	 * @see ViewerPanelMamut#stateToXml()
+	 * @see ViewerPanelMamut#stateFromXml(Element)
+	 */
+	static final String BDV_STATE_KEY = "BdvState";
+
+	/**
+	 * Key for the transform in a BDV view. Value is an
+	 * {@link AffineTransform3D} instance.
+	 */
+	static final String BDV_TRANSFORM_KEY = "BdvTransform";
+
+	/**
+	 * Key for the transform in a TrackScheme view. Value is a
+	 * {@link ScreenTransform} instance.
+	 */
+	static final String TRACKSCHEME_TRANSFORM_KEY = "TrackSchemeTransform";
+
+	/**
+	 * Key that specifies whether we do not use a special coloring scheme on the
+	 * view. If <code>true</code>, then we do not use a special coloring scheme.
+	 *
+	 * @see #TAG_SET_KEY
+	 * @see #FEATURE_COLOR_MODE_KEY
+	 */
+	static final String NO_COLORING_KEY = "NoColoring";
+
+	/**
+	 * Key that specifies the name of the tag-set to use for coloring scheme
+	 * based on tag-sets. A non-<code>null</code> value means the coloring
+	 * scheme is based on tag-sets.
+	 *
+	 * @see #NO_COLORING_KEY
+	 * @see #FEATURE_COLOR_MODE_KEY
+	 */
+	static final String TAG_SET_KEY = "TagSet";
+
+	/**
+	 * Key that specifies the name of the feature color mode to use for coloring
+	 * scheme based on feature color modes. A non-<code>null</code> value means
+	 * the coloring scheme is based on feature values.
+	 *
+	 * @see #NO_COLORING_KEY
+	 * @see #TAG_SET_KEY
+	 */
+	static final String FEATURE_COLOR_MODE_KEY = "FeatureColorMode";
+
+	/**
+	 * Key that specifies the name of the chosen context provider. Values are
+	 * strings.
+	 */
+	static final String CHOSEN_CONTEXT_PROVIDER_KEY = "ContextProvider";
+
+	/**
+	 * Serializes a GUI state map into a XML element.
+	 *
+	 * @param guiState
+	 *            the GUI state to serialize.
+	 * @return a new XML element.
+	 */
+
+	static Element toXml( final MamutView< ?, ?, ? > view )
+	{
+		final Map< String, Object > guiState = getGuiState( view );
+
+		final Element element = new Element( WINDOW_TAG );
+		for ( final Entry< String, Object > entry : guiState.entrySet() )
+		{
+			final Object value = entry.getValue();
+			final Element el;
+			if ( value instanceof Integer )
+				el = XmlHelpers.intElement( entry.getKey(), ( Integer ) entry.getValue() );
+			else if ( value instanceof int[] )
+				el = XmlHelpers.intArrayElement( entry.getKey(), ( int[] ) entry.getValue() );
+			else if ( value instanceof Double )
+				el = XmlHelpers.doubleElement( entry.getKey(), ( Double ) entry.getValue() );
+			else if ( value instanceof double[] )
+				el = XmlHelpers.doubleArrayElement( entry.getKey(), ( double[] ) entry.getValue() );
+			else if ( value instanceof AffineGet )
+				el = XmlHelpers.affineTransform3DElement( entry.getKey(), ( AffineGet ) entry.getValue() );
+			else if ( value instanceof Boolean )
+				el = XmlHelpers.booleanElement( entry.getKey(), ( Boolean ) value );
+			else if ( value instanceof String )
+			{
+				el = new Element( entry.getKey() );
+				el.setText( value.toString() );
+			}
+			else if ( value instanceof ScreenTransform )
+			{
+				final ScreenTransform t = ( ScreenTransform ) value;
+				el = XmlHelpers.doubleArrayElement( entry.getKey(), new double[] {
+						t.getMinX(),
+						t.getMaxX(),
+						t.getMinY(),
+						t.getMaxY(),
+						t.getScreenWidth(),
+						t.getScreenHeight()
+				} );
+			}
+			else if ( value instanceof Element )
+			{
+				el = new Element( entry.getKey() );
+				el.setContent( ( Element ) value );
+			}
+			else
+			{
+				System.err.println( "Do not know how to serialize object " + value + " for key " + entry.getKey() + "." );
+				continue;
+			}
+			element.addContent( el );
+		}
+		return element;
+	}
+
+	private static Map< String, Object > getGuiState( final MamutView< ?, ?, ? > view )
+	{
+		final Map< String, Object > guiState = new LinkedHashMap<>();
+
+		// View type.
+		guiState.put( VIEW_TYPE_KEY, view.getClass().getSimpleName() );
+
+		// Frame position and size.
+		final Rectangle bounds = view.getFrame().getBounds();
+		guiState.put( FRAME_POSITION_KEY, new int[] {
+				( int ) bounds.getMinX(),
+				( int ) bounds.getMinY(),
+				( int ) bounds.getWidth(),
+				( int ) bounds.getHeight() } );
+
+		// Lock groups.
+		guiState.put( GROUP_HANDLE_ID_KEY, view.getGroupHandle().getGroupId() );
+
+		// Settings panel visibility.
+		guiState.put( SETTINGS_PANEL_VISIBLE_KEY, view.getFrame().isSettingsPanelVisible() );
+
+		// View-specifics.
+		if ( view instanceof MamutViewBdv )
+			getGuiStateBdv( ( MamutViewBdv ) view, guiState );
+		else if ( view instanceof MamutViewTrackScheme )
+			getGuiStateTrackScheme( ( MamutViewTrackScheme ) view, guiState );
+
+		return guiState;
+	}
+
+	private static void getGuiStateTrackScheme( final MamutViewTrackScheme view, final Map< String, Object > guiState )
+	{
+		final TrackSchemePanel trackschemePanel = view.getTrackschemePanel();
+
+		// Edit position to reflect the fact that we store the TrackScheme panel
+		// width and height.
+		final Rectangle bounds = view.getFrame().getBounds();
+		guiState.put( FRAME_POSITION_KEY, new int[] {
+				( int ) bounds.getMinX(),
+				( int ) bounds.getMinY(),
+				trackschemePanel.getDisplay().getWidth(),
+				trackschemePanel.getDisplay().getHeight() } );
+
+		// Transform.
+		final ScreenTransform t = trackschemePanel.getTransformEventHandler().getTransform().copy();
+		guiState.put( TRACKSCHEME_TRANSFORM_KEY, t );
+
+		// Coloring.
+		final ColoringModel coloringModel = view.getColoringModel();
+		getColoringState( coloringModel, guiState );
+
+		// Context provider.
+		guiState.put( CHOSEN_CONTEXT_PROVIDER_KEY, view.getContextChooser().getChosenProvider().getName() );
+	}
+
+	private static void getGuiStateBdv( final MamutViewBdv view, final Map< String, Object > guiState )
+	{
+		// Viewer state.
+		final Element stateEl = view.getViewer().stateToXml();
+		guiState.put( BDV_STATE_KEY, stateEl );
+		// Transform.
+		final AffineTransform3D t = new AffineTransform3D();
+		view.getViewer().state().getViewerTransform( t );
+		guiState.put( BDV_TRANSFORM_KEY, t );
+		// Coloring.
+		final ColoringModel coloringModel = view.getColoringModel();
+		getColoringState( coloringModel, guiState );
+	}
+
+	private static void getColoringState( final ColoringModel coloringModel, final Map< String, Object > guiState )
+	{
+		final boolean noColoring = coloringModel.noColoring();
+		guiState.put( NO_COLORING_KEY, noColoring );
+		if ( !noColoring )
+			if ( coloringModel.getTagSet() != null )
+				guiState.put( TAG_SET_KEY, coloringModel.getTagSet().getName() );
+			else if ( coloringModel.getFeatureColorMode() != null )
+				guiState.put( FEATURE_COLOR_MODE_KEY, coloringModel.getFeatureColorMode().getName() );
+	}
+
+	static void fromXml( final Element windowsEl, final WindowManager windowManager )
+	{
+		// To deal later with context providers.
+		final Map< String, ContextProvider< Spot > > contextProviders = new HashMap<>();
+		final Map< ContextChooser< Spot >, String > contextChosers = new HashMap<>();
+
+		final List< Element > viewEls = windowsEl.getChildren( WINDOW_TAG );
+		for ( final Element viewEl : viewEls )
+		{
+			final Map< String, Object > guiState = xmlToMap( viewEl );
+			final String typeStr = ( String ) guiState.get( VIEW_TYPE_KEY );
+			switch ( typeStr )
+			{
+			case "MamutViewBdv":
+			{
+				final MamutViewBdv bdv = windowManager.createBigDataViewer( guiState );
+
+				// Store context provider.
+				contextProviders.put( bdv.getContextProvider().getName(), bdv.getContextProvider() );
+				break;
+			}
+
+			case "MamutViewTrackScheme":
+			{
+				final MamutViewTrackScheme ts = windowManager.createTrackScheme( guiState );
+
+				// Deal with context chooser.
+				final String desiredProvider = ( String ) guiState.get( CHOSEN_CONTEXT_PROVIDER_KEY );
+				if ( null != desiredProvider )
+					contextChosers.put( ts.getContextChooser(), desiredProvider );
+				break;
+			}
+
+			default:
+				System.err.println( "Unknown window type: " + typeStr + "." );
+				continue;
+			}
+		}
+
+		/*
+		 * Loop again on context choosers and try to give them their desired
+		 * context provider.
+		 */
+
+		for ( final ContextChooser< Spot > contextChooser : contextChosers.keySet() )
+		{
+			final String desiredContextProvider = contextChosers.get( contextChooser );
+			final ContextProvider< Spot > contextProvider = contextProviders.get( desiredContextProvider );
+			if ( null != contextProvider )
+				contextChooser.choose( contextProvider );
+		}
+	}
+
+	private static Map< String, Object > xmlToMap( final Element viewEl )
+	{
+		final Map< String, Object > guiState = new HashMap<>();
+		final List< Element > children = viewEl.getChildren();
+		for ( final Element el : children )
+		{
+			final String key = el.getName();
+			final Object value;
+			switch ( key )
+			{
+			case BDV_STATE_KEY:
+				value = el;
+				break;
+			case BDV_TRANSFORM_KEY:
+				value = XmlHelpers.getAffineTransform3D( viewEl, key );
+				break;
+			case FRAME_POSITION_KEY:
+				value = XmlHelpers.getIntArray( viewEl, key );
+				break;
+			case TAG_SET_KEY:
+			case FEATURE_COLOR_MODE_KEY:
+			case VIEW_TYPE_KEY:
+			case CHOSEN_CONTEXT_PROVIDER_KEY:
+				value = el.getTextTrim();
+				break;
+			case TRACKSCHEME_TRANSFORM_KEY:
+				final double[] arr = XmlHelpers.getDoubleArray( viewEl, key );
+				value = new ScreenTransform( arr[ 0 ], arr[ 1 ], arr[ 2 ], arr[ 3 ], ( int ) arr[ 4 ], ( int ) arr[ 5 ] );
+				break;
+			case NO_COLORING_KEY:
+			case SETTINGS_PANEL_VISIBLE_KEY:
+				value = XmlHelpers.getBoolean( viewEl, key );
+				break;
+			case GROUP_HANDLE_ID_KEY:
+				value = XmlHelpers.getInt( viewEl, key );
+				break;
+			default:
+				System.err.println( "Unkown GUI config parameter: " + key + " found in GUI file." );
+				continue;
+			}
+			guiState.put( key, value );
+		}
+		return guiState;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
@@ -115,7 +115,6 @@ class MamutViewStateSerialization
 	 *            the GUI state to serialize.
 	 * @return a new XML element.
 	 */
-
 	static Element toXml( final MamutView< ?, ?, ? > view )
 	{
 		final Map< String, Object > guiState = getGuiState( view );
@@ -169,6 +168,13 @@ class MamutViewStateSerialization
 		return element;
 	}
 
+	/**
+	 * Wraps GUI state of a {@link MamutView} into a map.
+	 * 
+	 * @param view
+	 *            the view.
+	 * @return a new {@link Map}.
+	 */
 	private static Map< String, Object > getGuiState( final MamutView< ?, ?, ? > view )
 	{
 		final Map< String, Object > guiState = new LinkedHashMap<>();
@@ -199,6 +205,14 @@ class MamutViewStateSerialization
 		return guiState;
 	}
 
+	/**
+	 * Stores the {@link MamutViewTrackScheme} GUI state in the specified map.
+	 * 
+	 * @param view
+	 *            the {@link MamutViewTrackScheme}.
+	 * @param guiState
+	 *            the map to store info into.
+	 */
 	private static void getGuiStateTrackScheme( final MamutViewTrackScheme view, final Map< String, Object > guiState )
 	{
 		final TrackSchemePanel trackschemePanel = view.getTrackschemePanel();
@@ -224,6 +238,14 @@ class MamutViewStateSerialization
 		guiState.put( CHOSEN_CONTEXT_PROVIDER_KEY, view.getContextChooser().getChosenProvider().getName() );
 	}
 
+	/**
+	 * Stores the {@link MamutViewBdv} GUI state in the specified map.
+	 * 
+	 * @param view
+	 *            the {@link MamutViewBdv}.
+	 * @param guiState
+	 *            the map to store info into.
+	 */
 	private static void getGuiStateBdv( final MamutViewBdv view, final Map< String, Object > guiState )
 	{
 		// Viewer state.
@@ -238,6 +260,14 @@ class MamutViewStateSerialization
 		getColoringState( coloringModel, guiState );
 	}
 
+	/**
+	 * Reads the coloring state of a view and stores it into the specified map.
+	 * 
+	 * @param coloringModel
+	 *            the coloring model to read from.
+	 * @param guiState
+	 *            the map to store it to.
+	 */
 	private static void getColoringState( final ColoringModel coloringModel, final Map< String, Object > guiState )
 	{
 		final boolean noColoring = coloringModel.noColoring();
@@ -249,6 +279,14 @@ class MamutViewStateSerialization
 				guiState.put( FEATURE_COLOR_MODE_KEY, coloringModel.getFeatureColorMode().getName() );
 	}
 
+	/**
+	 * Deserializes a GUI state from XML and recreate view windows as specified.
+	 * 
+	 * @param windowsEl
+	 *            the XML element that stores the GUI state of a view.
+	 * @param windowManager
+	 *            the application {@link WindowManager}.
+	 */
 	static void fromXml( final Element windowsEl, final WindowManager windowManager )
 	{
 		// To deal later with context providers.

--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -1,9 +1,19 @@
 package org.mastodon.mamut;
 
+import static org.mastodon.mamut.project.MamutProjectIO.MAMUTPROJECT_VERSION_ATTRIBUTE_CURRENT;
+import static org.mastodon.mamut.project.MamutProjectIO.MAMUTPROJECT_VERSION_ATTRIBUTE_NAME;
+
 import java.awt.Component;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
 import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.mamut.feature.MamutRawFeatureModelIO;
@@ -16,6 +26,8 @@ import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.plugin.MamutPlugins;
 import org.mastodon.mamut.project.MamutProject;
+import org.mastodon.mamut.project.MamutProject.ProjectReader;
+import org.mastodon.mamut.project.MamutProject.ProjectWriter;
 import org.mastodon.mamut.project.MamutProjectIO;
 import org.mastodon.ui.coloring.feature.FeatureColorModeManager;
 import org.mastodon.ui.keymap.CommandDescriptionProvider;
@@ -24,8 +36,8 @@ import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.ui.keymap.KeymapManager;
 import org.mastodon.ui.util.ExtensionFileFilter;
 import org.mastodon.ui.util.FileChooser;
-import org.mastodon.ui.util.XmlFileFilter;
 import org.mastodon.ui.util.FileChooser.SelectionMode;
+import org.mastodon.ui.util.XmlFileFilter;
 import org.mastodon.util.DummySpimData;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.mastodon.views.bdv.overlay.ui.RenderSettingsManager;
@@ -60,6 +72,10 @@ public class ProjectManager
 	static final String[] IMPORT_SIMI_KEYS = new String[] { "not mapped" };
 	static final String[] IMPORT_MAMUT_KEYS = new String[] { "not mapped" };
 	static final String[] EXPORT_MAMUT_KEYS = new String[] { "not mapped" };
+
+	private static final String GUI_TAG = "MamutGui";
+
+	private static final String WINDOWS_TAG = "Windows";
 
 	/*
 	 * Command descriptions for all provided commands
@@ -249,6 +265,8 @@ public class ProjectManager
 			final GraphToFileIdMap< Spot, Link > idmap = model.saveRaw( writer );
 			// Serialize feature model.
 			MamutRawFeatureModelIO.serialize( windowManager.getContext(), model.getFeatureModel(), idmap, writer );
+			// Serialize GUI state.
+			saveGUI( writer );
 		}
 		updateEnabledActions();
 	}
@@ -279,7 +297,7 @@ public class ProjectManager
 			{
 				spimData = new XmlIoSpimDataMinimal().load( spimDataXmlFilename );
 			}
-			catch ( SpimDataIOException e )
+			catch ( final SpimDataIOException e )
 			{
 				e.printStackTrace();
 				System.err.println( "Could not open image data file. Opening with dummy dataset. Please fix dataset path!" );
@@ -357,6 +375,23 @@ public class ProjectManager
 				globalAppActions );
 
 		windowManager.setAppModel( appModel );
+
+		// Restore GUI state if loaded project, now that we have an App model.
+		if ( !isNewProject )
+		{
+			try (final MamutProject.ProjectReader reader = project.openForReading())
+			{
+				try
+				{
+					loadGUI( reader );
+				}
+				catch ( final FileNotFoundException fnfe )
+				{
+					// Ignore missing gui file.
+				}
+			}
+		}
+
 		this.project = project;
 		updateEnabledActions();
 	}
@@ -477,4 +512,51 @@ public class ProjectManager
 			return new File( f.getParentFile(), fn + EXT_DOT_MASTODON ).getAbsolutePath();
 		}
 	}
+
+	/*
+	 * GUI IO methods.
+	 */
+
+	/**
+	 * Serialize window positions and states.
+	 *
+	 * @throws IOException
+	 * @throws FileNotFoundException
+	 */
+	private void saveGUI( final ProjectWriter writer ) throws FileNotFoundException, IOException
+	{
+		final Element guiRoot = new Element( GUI_TAG );
+		guiRoot.setAttribute( MAMUTPROJECT_VERSION_ATTRIBUTE_NAME, MAMUTPROJECT_VERSION_ATTRIBUTE_CURRENT );
+		final Element windows = new Element( WINDOWS_TAG );
+		windowManager.forEachView( ( view ) -> windows.addContent(
+				MamutViewStateSerialization.toXml( view ) ) );
+		guiRoot.addContent( windows );
+		final Document doc = new Document( guiRoot );
+		final XMLOutputter xout = new XMLOutputter( Format.getPrettyFormat() );
+		xout.output( doc, writer.getGuiOutputStream() );
+	}
+
+	private void loadGUI( final ProjectReader reader ) throws IOException
+	{
+		final SAXBuilder sax = new SAXBuilder();
+		Document guiDoc;
+		try
+		{
+			guiDoc = sax.build( reader.getGuiInputStream() );
+		}
+		catch ( final JDOMException e )
+		{
+			throw new IOException( e );
+		}
+		final Element root = guiDoc.getRootElement();
+		if ( !GUI_TAG.equals( root.getName() ) )
+			throw new IOException( "expected <" + GUI_TAG + "> root element. wrong file?" );
+
+		final Element windowsEl = root.getChild( WINDOWS_TAG );
+		if ( null == windowsEl )
+			return;
+
+		MamutViewStateSerialization.fromXml( windowsEl, windowManager );
+	}
+
 }

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -3,7 +3,9 @@ package org.mastodon.mamut;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.swing.JDialog;
@@ -288,9 +290,14 @@ public class WindowManager
 
 	public MamutViewBdv createBigDataViewer()
 	{
+		return createBigDataViewer( new HashMap<>() );
+	}
+
+	public MamutViewBdv createBigDataViewer( final Map< String, Object > guiState )
+	{
 		if ( appModel != null )
 		{
-			final MamutViewBdv view = new MamutViewBdv( appModel );
+			final MamutViewBdv view = new MamutViewBdv( appModel, guiState );
 			addBdvWindow( view );
 			return view;
 		}
@@ -299,9 +306,14 @@ public class WindowManager
 
 	public MamutViewTrackScheme createTrackScheme()
 	{
+		return createTrackScheme( new HashMap<>() );
+	}
+
+	public MamutViewTrackScheme createTrackScheme( final Map< String, Object > guiState )
+	{
 		if ( appModel != null )
 		{
-			final MamutViewTrackScheme view = new MamutViewTrackScheme( appModel );
+			final MamutViewTrackScheme view = new MamutViewTrackScheme( appModel, guiState );
 			addTsWindow( view );
 			return view;
 		}

--- a/src/main/java/org/mastodon/mamut/project/MamutProject.java
+++ b/src/main/java/org/mastodon/mamut/project/MamutProject.java
@@ -46,6 +46,8 @@ public class MamutProject
 
 	static final String FEATURE_FOLDER_NAME = "features";
 
+	static final String GUI_FILE_NAME = "gui.xml";
+
 	public MamutProject( final String projectRoot )
 	{
 		this( new File( projectRoot ), null );
@@ -159,6 +161,8 @@ public class MamutProject
 		 * @return the collection of feature keys.
 		 */
 		Collection< String > getFeatureKeys();
+		
+		InputStream getGuiInputStream() throws IOException;
 	}
 
 	public interface ProjectWriter extends Closeable
@@ -170,6 +174,8 @@ public class MamutProject
 		OutputStream getRawTagsOutputStream() throws IOException;
 
 		OutputStream getFeatureOutputStream( String featureKey ) throws IOException;
+
+		OutputStream getGuiOutputStream() throws IOException;
 	}
 
 	private class ReadFromDirectory implements ProjectReader
@@ -211,6 +217,12 @@ public class MamutProject
 				.map( s -> s.replace( ".raw", "" ) )
 				.collect( Collectors.toList() );
 			return featureKeys;
+		}
+
+		@Override
+		public InputStream getGuiInputStream() throws IOException
+		{
+			return new FileInputStream( new File( projectRoot, GUI_FILE_NAME ) );
 		}
 
 		@Override
@@ -260,6 +272,12 @@ public class MamutProject
 		}
 
 		@Override
+		public InputStream getGuiInputStream() throws IOException
+		{
+			return zip.getInputStream( GUI_FILE_NAME );
+		}
+
+		@Override
 		public void close() throws IOException
 		{
 			zip.close();
@@ -294,6 +312,12 @@ public class MamutProject
 			if ( !featureFolder.exists() )
 				featureFolder.mkdir();
 			return new FileOutputStream( new File( featureFolder, featureKey + ".raw" ) );
+		}
+
+		@Override
+		public OutputStream getGuiOutputStream() throws IOException
+		{
+			return new FileOutputStream( new File( projectRoot, GUI_FILE_NAME ) );
 		}
 
 		@Override
@@ -332,6 +356,12 @@ public class MamutProject
 		public OutputStream getFeatureOutputStream( final String featureKey ) throws IOException
 		{
 			return zip.getOutputStream( FEATURE_FOLDER_NAME + "/" + featureKey + ".raw" );
+		}
+
+		@Override
+		public OutputStream getGuiOutputStream() throws IOException
+		{
+			return zip.getOutputStream( GUI_FILE_NAME );
 		}
 
 		@Override

--- a/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeFrame.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeFrame.java
@@ -46,6 +46,7 @@ public class TrackSchemeFrame extends ViewFrame
 			final TrackSchemeOptions optional )
 	{
 		super( "TrackScheme" );
+		setLocation( optional.values.getX(), optional.values.getY() );
 
 		trackschemePanel = new TrackSchemePanel(
 				graph,

--- a/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeFrame.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeFrame.java
@@ -46,7 +46,6 @@ public class TrackSchemeFrame extends ViewFrame
 			final TrackSchemeOptions optional )
 	{
 		super( "TrackScheme" );
-		setLocation( optional.values.getX(), optional.values.getY() );
 
 		trackschemePanel = new TrackSchemePanel(
 				graph,
@@ -84,6 +83,7 @@ public class TrackSchemeFrame extends ViewFrame
 		mouseAndKeyHandler.setBehaviourMap( triggerbindings.getConcatenatedBehaviourMap() );
 		mouseAndKeyHandler.setKeypressManager( optional.values.getKeyPressedManager(), trackschemePanel.getDisplay() );
 		trackschemePanel.getDisplay().addHandler( mouseAndKeyHandler );
+		setLocation( optional.values.getX(), optional.values.getY() );
 	}
 
 	public TrackSchemePanel getTrackschemePanel()

--- a/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeOptions.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemeOptions.java
@@ -58,6 +58,34 @@ public class TrackSchemeOptions
 	}
 
 	/**
+	 * Sets the X position of the top-left corner of the
+	 * {@link TrackSchemeFrame}.
+	 * 
+	 * @param x
+	 *            the X position.
+	 * @return this instance.
+	 */
+	public TrackSchemeOptions x( final int x )
+	{
+		values.x = x;
+		return this;
+	}
+
+	/**
+	 * Sets the Y position of the top-left corner of the
+	 * {@link TrackSchemeFrame}.
+	 * 
+	 * @param y
+	 *            the Y position.
+	 * @return this instance.
+	 */
+	public TrackSchemeOptions y( final int y )
+	{
+		values.y = y;
+		return this;
+	}
+
+	/**
 	 * Sets the width of {@link TrackSchemePanel} canvas.
 	 *
 	 * @param w
@@ -173,6 +201,10 @@ public class TrackSchemeOptions
 	 */
 	public static class Values
 	{
+		private int x = 0;
+
+		private int y = 0;
+
 		private int width = 800;
 
 		private int height = 600;
@@ -192,6 +224,8 @@ public class TrackSchemeOptions
 		public TrackSchemeOptions optionsFromValues()
 		{
 			return new TrackSchemeOptions().
+				x( x ).
+				y( y ).
 				width( width ).
 				height( height ).
 				animationDurationMillis( animationDurationMillis ).
@@ -199,6 +233,16 @@ public class TrackSchemeOptions
 				style( style ).
 				trackSchemeOverlayFactory( trackSchemeOverlayFactory ).
 				graphColorGenerator( graphColorGenerator );
+		}
+
+		public int getX()
+		{
+			return x;
+		}
+
+		public int getY()
+		{
+			return y;
 		}
 
 		public int getWidth()


### PR DESCRIPTION
The state of each opened view is serialized with the Mastodon project. The state includes window position, transform, current coloring, ...

Serialization is made in a XML file in the project file:
```bash
(base) tinevez@mastodon:~/Development/Mastodon/mastodon/samples$ unzip -c test-serialize-gui.mastodon gui.xml
Archive:  test-serialize-gui.mastodon
  inflating: gui.xml               
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<MamutGui version="0.3">
  <Windows>
    <Window>
      <Type>MamutViewBdv</Type>
      <FramePosition>393 441 432 424</FramePosition>
      <LockGroupId>-1</LockGroupId>
      <SettingsPanelVisible>false</SettingsPanelVisible>
      <BdvState>
        <ViewerState>
          <Sources>
            <Source>
              <active>true</active>
            </Source>
          </Sources>
          <SourceGroups>
            <SourceGroup>
              <active>true</active>
              <name>group 1</name>
              <id>0</id>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 2</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 3</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 4</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 5</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 6</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 7</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 8</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 9</name>
            </SourceGroup>
            <SourceGroup>
              <active>true</active>
              <name>group 10</name>
            </SourceGroup>
          </SourceGroups>
          <DisplayMode>ss</DisplayMode>
          <Interpolation>nlinear</Interpolation>
          <CurrentSource>0</CurrentSource>
          <CurrentGroup>0</CurrentGroup>
          <CurrentTimePoint>15</CurrentTimePoint>
        </ViewerState>
      </BdvState>
      <BdvTransform>10.68114656457987 0.0 0.0 -629.6109506413089 0.0 10.68114656457987 0.0 -240.48014109552344 0.0 0.0 10.68114656457987 -610.9531886710823</BdvTransform>
      <NoColoring>false</NoColoring>
      <TagSet>Evil</TagSet>
    </Window>
    <Window>
      <Type>MamutViewTrackScheme</Type>
      <FramePosition>826 124 420 667</FramePosition>
      <LockGroupId>-1</LockGroupId>
      <SettingsPanelVisible>true</SettingsPanelVisible>
      <TrackSchemeTransform>-0.8475935828877006 12.8475935828877 -0.7919020715630882 30.791902071563086 395.0 647.0</TrackSchemeTransform>
      <NoColoring>false</NoColoring>
      <TagSet>Evil</TagSet>
      <ContextProvider>BigDataViewer 1</ContextProvider>
    </Window>
  </Windows>
</MamutGui>
```

To access this data, the `MamutViews` exposes their content (trackscheme or bdv + coloringModel). 

Deserialization is made by unmarshalling the XML into a `Map<String, Object>` that is passed to the constructors of `MamutViewBdv` and `MamutViewTrackScheme`, setting the state adequately, and when possible before the `JFrame` is made visible.
