### PR TITLE
Add BdvViewCreatedListener

### DIFF
--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -187,6 +187,8 @@ public class WindowManager
 
 	final ProjectManager projectManager;
 
+	private final List< BdvViewCreatedListener > listeners;
+
 	public WindowManager( final Context context )
 	{
 		this.context = context;
@@ -246,6 +248,8 @@ public class WindowManager
 		globalAppActions.namedAction( tooglePreferencesDialogAction, PREFERENCES_DIALOG_KEYS );
 
 		updateEnabledActions();
+
+		listeners = new ArrayList<>();
 	}
 
 	private void discoverPlugins()
@@ -385,6 +389,7 @@ public class WindowManager
 			final MamutViewBdv view = new MamutViewBdv( appModel, guiState );
 			view.getFrame().setIconImage( BDV_VIEW_ICON );
 			addBdvWindow( view );
+			notifyListeners( view );
 			return view;
 		}
 		return null;
@@ -535,6 +540,16 @@ public class WindowManager
 	}
 
 	/**
+	 * Exposes currently open BigDataViewer windows.
+	 *
+	 * @return a {@link List} of {@link MamutViewBdv}.
+	 */
+	public List< MamutViewBdv > getBdvWindows()
+	{
+		return bdvWindows;
+	}
+
+	/**
 	 * Exposes the {@link ProjectManager} of this window manager, that handles
 	 * project files.
 	 *
@@ -551,5 +566,35 @@ public class WindowManager
 		context.inject( builder );
 		builder.discoverProviders();
 		return builder.build();
+	}
+
+	/**
+	 * Classes that implement {@link BdvViewCreatedListener} get a notification
+	 * when a new {@link MamutViewBdv} instance is created.
+	 */
+	public interface BdvViewCreatedListener
+	{
+		void bdvViewCreated( final MamutViewBdv view );
+	}
+
+	public synchronized boolean addBdvViewCreatedListner( final BdvViewCreatedListener listener )
+	{
+		if ( !listeners.contains( listener ) )
+		{
+			listeners.add( listener );
+			return true;
+		}
+		return false;
+	}
+
+	public synchronized boolean removeBdvViewCreatedListner( final BdvViewCreatedListener listener )
+	{
+		return listeners.remove( listener );
+	}
+
+	private void notifyListeners( final MamutViewBdv view )
+	{
+		for ( final BdvViewCreatedListener l : listeners )
+			l.bdvViewCreated( view );
 	}
 }

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -73,6 +73,7 @@ import org.mastodon.views.trackscheme.display.style.TrackSchemeStyleManager;
 import org.mastodon.views.trackscheme.display.style.TrackSchemeStyleSettingsPage;
 import org.scijava.Context;
 import org.scijava.InstantiableException;
+import org.scijava.listeners.Listeners;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.PluginInfo;
 import org.scijava.plugin.PluginService;
@@ -187,7 +188,7 @@ public class WindowManager
 
 	final ProjectManager projectManager;
 
-	private final List< BdvViewCreatedListener > listeners;
+	private final Listeners.List< BdvViewCreatedListener > bdvViewCreatedListeners;
 
 	public WindowManager( final Context context )
 	{
@@ -249,7 +250,7 @@ public class WindowManager
 
 		updateEnabledActions();
 
-		listeners = new ArrayList<>();
+		bdvViewCreatedListeners = new Listeners.SynchronizedList<>();
 	}
 
 	private void discoverPlugins()
@@ -389,7 +390,7 @@ public class WindowManager
 			final MamutViewBdv view = new MamutViewBdv( appModel, guiState );
 			view.getFrame().setIconImage( BDV_VIEW_ICON );
 			addBdvWindow( view );
-			notifyListeners( view );
+			bdvViewCreatedListeners.list.forEach( l -> l.bdvViewCreated( view ) );
 			return view;
 		}
 		return null;
@@ -569,32 +570,16 @@ public class WindowManager
 	}
 
 	/**
-	 * Classes that implement {@link BdvViewCreatedListener} get a notification
-	 * when a new {@link MamutViewBdv} instance is created.
+	 * Classes that implement {@link BdvViewCreatedListener} get a notification when
+	 * a new {@link MamutViewBdv} instance is created.
 	 */
 	public interface BdvViewCreatedListener
 	{
 		void bdvViewCreated( final MamutViewBdv view );
 	}
 
-	public synchronized boolean addBdvViewCreatedListner( final BdvViewCreatedListener listener )
+	public Listeners< BdvViewCreatedListener > bdvViewCreatedListners()
 	{
-		if ( !listeners.contains( listener ) )
-		{
-			listeners.add( listener );
-			return true;
-		}
-		return false;
-	}
-
-	public synchronized boolean removeBdvViewCreatedListner( final BdvViewCreatedListener listener )
-	{
-		return listeners.remove( listener );
-	}
-
-	private void notifyListeners( final MamutViewBdv view )
-	{
-		for ( final BdvViewCreatedListener l : listeners )
-			l.bdvViewCreated( view );
+		return bdvViewCreatedListeners;
 	}
 }


### PR DESCRIPTION
This PR adds the following functionalities to `org.mastodon.mamut.WindowManager`.

- Classes that implement `BdvViewCreatedListener` get a notification when a new `MamutViewBdv` instance is created.
- `getBdvWindows()` exposes currently open BigDataViewer windows.