### PR TITLE
Expose overlayCotextWrapper in BdvContextProvider

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -353,4 +353,14 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 	{
 		return coloringModel;
 	}
+
+	/**
+	 * Returns visible vertices in this BDV view.
+	 * 
+	 * @return {@code Iterable} of {@link Spot}
+	 */
+	public Iterable< Spot > getInsideVertices( final int timepoint )
+	{
+		return contextProvider.getOverlayContextWrapper().getInsideVertices( timepoint );
+	}
 }

--- a/src/main/java/org/mastodon/views/bdv/BdvContextProvider.java
+++ b/src/main/java/org/mastodon/views/bdv/BdvContextProvider.java
@@ -69,6 +69,8 @@ public class BdvContextProvider< V extends Vertex< E >, E extends Edge< V > >
 
 	private Context< V > context;
 
+	private final OverlayContextWrapper< V, E > overlayContextWrapper;
+
 	public BdvContextProvider( final String name,
 			final OverlayGraph< OverlayVertexWrapper< V, E >, OverlayEdgeWrapper< V, E > > overlayGraph,
 			final OverlayGraphRenderer< OverlayVertexWrapper< V, E >, OverlayEdgeWrapper< V, E > > renderer )
@@ -76,7 +78,7 @@ public class BdvContextProvider< V extends Vertex< E >, E extends Edge< V > >
 		this.name = name;
 		listeners = new Listeners.SynchronizedList<>( l -> l.contextChanged( context ) );
 		overlayContext = new OverlayContext<>( overlayGraph, renderer );
-		new OverlayContextWrapper<>( overlayContext, this::contextChanged );
+		overlayContextWrapper = new OverlayContextWrapper<>( overlayContext, this::contextChanged );
 	}
 
 	@Override
@@ -95,6 +97,16 @@ public class BdvContextProvider< V extends Vertex< E >, E extends Edge< V > >
 	public void transformChanged( final AffineTransform3D transform )
 	{
 		overlayContext.transformChanged( transform );
+	}
+
+	/**
+	 * Expose the {@link #overlayContextWrapper}.
+	 * 
+	 * @return {@link OverlayContextWrapper}
+	 */
+	public OverlayContextWrapper< V, E > getOverlayContextWrapper()
+	{
+		return overlayContextWrapper;
 	}
 
 	/**


### PR DESCRIPTION
This PR exposes `overlayContextWrapper` in `BdvContextProvider`.

I made this change to get visible vertices in a BDV.

Example of usage:
https://github.com/elephant-track/elephant-client/blob/main/src/main/java/org/elephant/actions/mixins/WindowManagerMixin.java#L63-L74

```
final MamutViewBdv bdv = getBdvWindows().get( 0 );
@SuppressWarnings( "unchecked" )
final OverlayContextWrapper< Spot, Link > overlayContextWrapper = ( ( BdvContextProvider< Spot, Link > ) bdv.getContextProvider() ).getOverlayContextWrapper();
final Iterable< Spot > vertices = overlayContextWrapper.getInsideVertices( timepoint );
```