### PR TITLE
Explicitly define DEFALULT_POINT_FADE_DEPTH

### DIFF
--- a/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
@@ -58,6 +58,7 @@ public class RenderSettings implements Style< RenderSettings >
 	public static final boolean DEFAULT_DRAW_SPOT_LABELS = false;
 	public static final boolean DEFAULT_IS_FOCUS_LIMIT_RELATIVE = true;
 	public static final double DEFAULT_ELLIPSOID_FADE_DEPTH = 0.2;
+	public static final double DEFAULT_POINT_FADE_DEPTH = 0.;
 	public static final int DEFAULT_COLOR_SPOT_AND_PRESENT = Color.GREEN.getRGB();
 	public static final int DEFAULT_COLOR_PAST = Color.RED.getRGB();
 	public static final int DEFAULT_COLOR_FUTURE = Color.BLUE.getRGB();
@@ -889,6 +890,7 @@ public class RenderSettings implements Style< RenderSettings >
 		df.focusLimit = DEFAULT_LIMIT_FOCUS_RANGE;
 		df.isFocusLimitViewRelative = DEFAULT_IS_FOCUS_LIMIT_RELATIVE;
 		df.ellipsoidFadeDepth = DEFAULT_ELLIPSOID_FADE_DEPTH;
+		df.pointFadeDepth = DEFAULT_POINT_FADE_DEPTH;
 		df.colorSpot = DEFAULT_COLOR_SPOT_AND_PRESENT;
 		df.colorPast = DEFAULT_COLOR_PAST;
 		df.colorFuture = DEFAULT_COLOR_FUTURE;

--- a/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
@@ -238,7 +238,7 @@ public class RenderSettingsIO
 				s.setFocusLimit( ( double ) mapping.getOrDefault( "focusLimit", RenderSettings.DEFAULT_LIMIT_FOCUS_RANGE ) );
 				s.setFocusLimitViewRelative( ( boolean ) mapping.getOrDefault( "focusLimitViewRelative", RenderSettings.DEFAULT_IS_FOCUS_LIMIT_RELATIVE ) );
 				s.setEllipsoidFadeDepth( ( double ) mapping.getOrDefault( "ellipsoidFadeDepth", RenderSettings.DEFAULT_ELLIPSOID_FADE_DEPTH ) );
-				s.setPointFadeDepth( ( double ) mapping.getOrDefault( "pointFadeDepth", RenderSettings.DEFAULT_ELLIPSOID_FADE_DEPTH ) );
+				s.setPointFadeDepth( ( double ) mapping.getOrDefault( "pointFadeDepth", RenderSettings.DEFAULT_POINT_FADE_DEPTH ) );
 				s.setColorSpot( ( int ) mapping.getOrDefault( "colorSpot", RenderSettings.DEFAULT_COLOR_SPOT_AND_PRESENT ) );
 				s.setColorPast( ( int ) mapping.getOrDefault( "colorPast", RenderSettings.DEFAULT_COLOR_PAST ) );
 				s.setColorFuture( ( int ) mapping.getOrDefault( "colorFuture", RenderSettings.DEFAULT_COLOR_FUTURE ) );


### PR DESCRIPTION
In `mastodon.views.bdv.overlay.RenderSettings`, the default value for `pointFadeDepth` was not set, while in `mastodon.views.bdv.overlay.ui.RenderSettingsIO.ConstructRenderSettings`, the default value was set as `DEFAULT_ELLIPSOID_FADE_DEPTH`.
In this PR, `DEFAULT_POINT_FADE_DEPTH` is defined as `0.0` and used in both classes.