### PR TITLE
Settings to allow changing the stroke width

### DIFF
--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
@@ -545,10 +545,10 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			return;
 
 		final Graphics2D graphics = ( Graphics2D ) g;
-		final BasicStroke defaultVertexStroke = new BasicStroke();
+		final BasicStroke defaultVertexStroke = new BasicStroke( ( float ) settings.getSpotStrokeWidth() );
 		final BasicStroke highlightedVertexStroke = new BasicStroke( 4f );
 		final BasicStroke focusedVertexStroke = new BasicStroke( 2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, new float[] { 8f, 3f }, 0 );
-		final BasicStroke defaultEdgeStroke = new BasicStroke();
+		final BasicStroke defaultEdgeStroke = new BasicStroke( ( float ) settings.getLinkStrokeWidth() );
 		final BasicStroke highlightedEdgeStroke = new BasicStroke( 3f );
 
 		final AffineTransform3D transform = getRenderTransformCopy();

--- a/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
@@ -58,6 +58,8 @@ public class RenderSettings implements Style< RenderSettings >
 	public static final boolean DEFAULT_DRAW_SPOT_LABELS = false;
 	public static final boolean DEFAULT_IS_FOCUS_LIMIT_RELATIVE = true;
 	public static final double DEFAULT_ELLIPSOID_FADE_DEPTH = 0.2;
+	public static final double DEFAULT_SPOT_STROKE_WIDTH = 1f;
+	public static final double DEFAULT_LINK_STROKE_WIDTH = 1f;
 	public static final int DEFAULT_COLOR_SPOT_AND_PRESENT = Color.GREEN.getRGB();
 	public static final int DEFAULT_COLOR_PAST = Color.RED.getRGB();
 	public static final int DEFAULT_COLOR_FUTURE = Color.BLUE.getRGB();
@@ -116,6 +118,8 @@ public class RenderSettings implements Style< RenderSettings >
 		isFocusLimitViewRelative = settings.isFocusLimitViewRelative;
 		ellipsoidFadeDepth = settings.ellipsoidFadeDepth;
 		pointFadeDepth = settings.pointFadeDepth;
+		spotStrokeWidth = settings.spotStrokeWidth;
+		linkStrokeWidth = settings.linkStrokeWidth;
 		colorSpot = settings.colorSpot;
 		colorPast = settings.colorPast;
 		colorFuture = settings.colorFuture;
@@ -254,6 +258,16 @@ public class RenderSettings implements Style< RenderSettings >
 	 * they are fully opaque, then their alpha value goes to 0 linearly.
 	 */
 	private double pointFadeDepth;
+
+	/**
+	 * The stroke with of spots.
+	 */
+	private double spotStrokeWidth;
+	
+	/**
+	 * The stroke with of links.
+	 */
+	private double linkStrokeWidth;
 
 	/**
 	 * The color used to paint spots and links in the current time-point.
@@ -789,6 +803,56 @@ public class RenderSettings implements Style< RenderSettings >
 	}
 
 	/**
+	 * Get stroke width for spots.
+	 *
+	 * @return stroke width for spots.
+	 */
+	public double getSpotStrokeWidth()
+	{
+		return spotStrokeWidth;
+	}
+
+	/**
+	 * Set stroke width for spots.
+	 *
+	 * @param spotStrokeWidth
+	 *            stroke width for spots.
+	 */
+	public void setSpotStrokeWidth( final double spotStrokeWidth )
+	{
+		if ( this.spotStrokeWidth != spotStrokeWidth )
+		{
+			this.spotStrokeWidth = spotStrokeWidth;
+			notifyListeners();
+		}
+	}
+
+	/**
+	 * Get stroke width for links.
+	 *
+	 * @return stroke width for links.
+	 */
+	public double getLinkStrokeWidth()
+	{
+		return linkStrokeWidth;
+	}
+
+	/**
+	 * Set stroke width for links.
+	 *
+	 * @param linkStrokeWidth
+	 *            stroke width for links.
+	 */
+	public void setLinkStrokeWidth( final double linkStrokeWidth )
+	{
+		if ( this.linkStrokeWidth != linkStrokeWidth )
+		{
+			this.linkStrokeWidth = linkStrokeWidth;
+			notifyListeners();
+		}
+	}
+
+	/**
 	 * Returns the color used to paint spots and links in the current
 	 * time-point.
 	 * 
@@ -889,6 +953,8 @@ public class RenderSettings implements Style< RenderSettings >
 		df.focusLimit = DEFAULT_LIMIT_FOCUS_RANGE;
 		df.isFocusLimitViewRelative = DEFAULT_IS_FOCUS_LIMIT_RELATIVE;
 		df.ellipsoidFadeDepth = DEFAULT_ELLIPSOID_FADE_DEPTH;
+		df.spotStrokeWidth = DEFAULT_SPOT_STROKE_WIDTH;
+		df.linkStrokeWidth = DEFAULT_LINK_STROKE_WIDTH;
 		df.colorSpot = DEFAULT_COLOR_SPOT_AND_PRESENT;
 		df.colorPast = DEFAULT_COLOR_PAST;
 		df.colorFuture = DEFAULT_COLOR_FUTURE;

--- a/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
@@ -58,8 +58,8 @@ public class RenderSettings implements Style< RenderSettings >
 	public static final boolean DEFAULT_DRAW_SPOT_LABELS = false;
 	public static final boolean DEFAULT_IS_FOCUS_LIMIT_RELATIVE = true;
 	public static final double DEFAULT_ELLIPSOID_FADE_DEPTH = 0.2;
-	public static final double DEFAULT_SPOT_STROKE_WIDTH = 1f;
-	public static final double DEFAULT_LINK_STROKE_WIDTH = 1f;
+	public static final double DEFAULT_SPOT_STROKE_WIDTH = 1.0;
+	public static final double DEFAULT_LINK_STROKE_WIDTH = 1.0;
 	public static final int DEFAULT_COLOR_SPOT_AND_PRESENT = Color.GREEN.getRGB();
 	public static final int DEFAULT_COLOR_PAST = Color.RED.getRGB();
 	public static final int DEFAULT_COLOR_FUTURE = Color.BLUE.getRGB();

--- a/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
@@ -195,6 +195,8 @@ public class RenderSettingsIO
 			mapping.put( "focusLimitViewRelative", s.getFocusLimitViewRelative() );
 			mapping.put( "ellipsoidFadeDepth", s.getEllipsoidFadeDepth() );
 			mapping.put( "pointFadeDepth", s.getPointFadeDepth() );
+			mapping.put( "spotStrokeWidth", s.getSpotStrokeWidth() );
+			mapping.put( "linkStrokeWidth", s.getLinkStrokeWidth() );
 			mapping.put( "colorSpot", s.getColorSpot() );
 			mapping.put( "colorPast", s.getColorPast() );
 			mapping.put( "colorFuture", s.getColorFuture() );
@@ -239,6 +241,8 @@ public class RenderSettingsIO
 				s.setFocusLimitViewRelative( ( boolean ) mapping.getOrDefault( "focusLimitViewRelative", RenderSettings.DEFAULT_IS_FOCUS_LIMIT_RELATIVE ) );
 				s.setEllipsoidFadeDepth( ( double ) mapping.getOrDefault( "ellipsoidFadeDepth", RenderSettings.DEFAULT_ELLIPSOID_FADE_DEPTH ) );
 				s.setPointFadeDepth( ( double ) mapping.getOrDefault( "pointFadeDepth", RenderSettings.DEFAULT_ELLIPSOID_FADE_DEPTH ) );
+				s.setSpotStrokeWidth( ( double ) mapping.getOrDefault( "spotStrokeWidth", RenderSettings.DEFAULT_SPOT_STROKE_WIDTH ) );
+				s.setLinkStrokeWidth( ( double ) mapping.getOrDefault( "linkStrokeWidth", RenderSettings.DEFAULT_LINK_STROKE_WIDTH ) );
 				s.setColorSpot( ( int ) mapping.getOrDefault( "colorSpot", RenderSettings.DEFAULT_COLOR_SPOT_AND_PRESENT ) );
 				s.setColorPast( ( int ) mapping.getOrDefault( "colorPast", RenderSettings.DEFAULT_COLOR_PAST ) );
 				s.setColorFuture( ( int ) mapping.getOrDefault( "colorFuture", RenderSettings.DEFAULT_COLOR_FUTURE ) );

--- a/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsPanel.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsPanel.java
@@ -189,6 +189,7 @@ public class RenderSettingsPanel extends JPanel
 				booleanElement( "gradients for links", style::getUseGradient, style::setUseGradient ),
 				booleanElement( "arrow heads", style::getDrawArrowHeads, style::setDrawArrowHeads ),
 				booleanElement( "draw links ahead in time", style::getDrawLinksAheadInTime, style::setDrawLinksAheadInTime ),
+				doubleElement( "link stroke width", 1, 100, style::getLinkStrokeWidth, style::setLinkStrokeWidth ),
 
 				separator(),
 
@@ -198,6 +199,7 @@ public class RenderSettingsPanel extends JPanel
 				booleanElement( "draw spot centers", style::getDrawSpotCenters, style::setDrawSpotCenters ),
 				booleanElement( "draw spot centers for ellipses", style::getDrawSpotCentersForEllipses, style::setDrawSpotCentersForEllipses ),
 				booleanElement( "draw spot labels", style::getDrawSpotLabels, style::setDrawSpotLabels ),
+				doubleElement( "spot stroke width", 1, 100, style::getSpotStrokeWidth, style::setSpotStrokeWidth ),
 
 				separator(),
 


### PR DESCRIPTION
This PR allows users to set the stroke widths of spots and links from the settings dialog, which is useful if the lines are too fine to see.
The following parameters are added to the render settings panel. Both parameters are set to `1.0` by default.

- spot stroke width
- link stroke width