### PR TITLE
Add an option to fill spots in rendering

### DIFF
--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayGraphRenderer.java
@@ -785,6 +785,11 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 	static void drawEllipse( final Graphics2D graphics, final Ellipse ellipse, AffineTransform torig )
 	{
+		drawEllipse( graphics, ellipse, torig, false );
+	}
+
+	static void drawEllipse( final Graphics2D graphics, final Ellipse ellipse, AffineTransform torig, final boolean fillSpots )
+	{
 		if ( torig == null )
 			torig = graphics.getTransform();
 
@@ -796,7 +801,18 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 		graphics.translate( tr[ 0 ], tr[ 1 ] );
 		graphics.rotate( theta );
-		graphics.draw( ellipse2D );
+		if ( fillSpots )
+		{
+			graphics.fill( ellipse2D );
+			final Color color = graphics.getColor();
+			graphics.setColor( Color.BLACK );
+			graphics.draw( ellipse2D );
+			graphics.setColor( color );	
+		}
+		else
+		{
+			graphics.draw( ellipse2D );
+		}
 
 		graphics.setTransform( torig );
 	}

--- a/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/RenderSettings.java
@@ -56,6 +56,7 @@ public class RenderSettings implements Style< RenderSettings >
 	public static final boolean DEFAULT_DRAW_POINTS = !DEFAULT_DRAW_ELLIPSE || (DEFAULT_DRAW_ELLIPSE && DEFAULT_DRAW_SLICE_INTERSECTION);
 	public static final boolean DEFAULT_DRAW_POINTS_FOR_ELLIPSE = false;
 	public static final boolean DEFAULT_DRAW_SPOT_LABELS = false;
+	public static final boolean DEFAULT_FILL_SPOTS = false;
 	public static final boolean DEFAULT_IS_FOCUS_LIMIT_RELATIVE = true;
 	public static final double DEFAULT_ELLIPSOID_FADE_DEPTH = 0.2;
 	public static final int DEFAULT_COLOR_SPOT_AND_PRESENT = Color.GREEN.getRGB();
@@ -112,6 +113,7 @@ public class RenderSettings implements Style< RenderSettings >
 		drawPoints = settings.drawPoints;
 		drawPointsForEllipses = settings.drawPointsForEllipses;
 		drawSpotLabels = settings.drawSpotLabels;
+		fillSpots = settings.fillSpots;
 		focusLimit = settings.focusLimit;
 		isFocusLimitViewRelative = settings.isFocusLimitViewRelative;
 		ellipsoidFadeDepth = settings.ellipsoidFadeDepth;
@@ -204,6 +206,11 @@ public class RenderSettings implements Style< RenderSettings >
 	 * Whether to draw spot labels next to ellipses.
 	 */
 	private boolean drawSpotLabels;
+
+	/**
+	 * Whether to fill spots.
+	 */
+	private boolean fillSpots;
 
 	/**
 	 * Maximum distance from view plane up to which to draw spots.
@@ -649,6 +656,31 @@ public class RenderSettings implements Style< RenderSettings >
 	}
 
 	/**
+	 * Get whether spots are filled.
+	 *
+	 * @return whether spots are filled.
+	 */
+	public boolean getFillSpots()
+	{
+		return fillSpots;
+	}
+
+	/**
+	 * Set whether spots are filled.
+	 *
+	 * @param fillSpots
+	 *            whether spots are filled.
+	 */
+	public void setFillSpots( final boolean fillSpots )
+	{
+		if ( this.fillSpots != fillSpots )
+		{
+			this.fillSpots = fillSpots;
+			notifyListeners();
+		}
+	}
+
+	/**
 	 * Get the maximum distance from the view plane up to which to spots are
 	 * drawn.
 	 * <p>
@@ -886,6 +918,7 @@ public class RenderSettings implements Style< RenderSettings >
 		df.drawPoints = DEFAULT_DRAW_POINTS;
 		df.drawPointsForEllipses = DEFAULT_DRAW_POINTS_FOR_ELLIPSE;
 		df.drawSpotLabels = DEFAULT_DRAW_SPOT_LABELS;
+		df.fillSpots = DEFAULT_FILL_SPOTS;
 		df.focusLimit = DEFAULT_LIMIT_FOCUS_RANGE;
 		df.isFocusLimitViewRelative = DEFAULT_IS_FOCUS_LIMIT_RELATIVE;
 		df.ellipsoidFadeDepth = DEFAULT_ELLIPSOID_FADE_DEPTH;

--- a/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsIO.java
@@ -191,6 +191,7 @@ public class RenderSettingsIO
 			mapping.put( "drawSpotCenters", s.getDrawSpotCenters() );
 			mapping.put( "drawSpotCentersForEllipses", s.getDrawSpotCentersForEllipses() );
 			mapping.put( "drawSpotLabels", s.getDrawSpotLabels() );
+			mapping.put( "fillSpots", s.getFillSpots() );
 			mapping.put( "focusLimit", s.getFocusLimit() );
 			mapping.put( "focusLimitViewRelative", s.getFocusLimitViewRelative() );
 			mapping.put( "ellipsoidFadeDepth", s.getEllipsoidFadeDepth() );
@@ -235,6 +236,7 @@ public class RenderSettingsIO
 				s.setDrawSpotCenters( ( boolean ) mapping.getOrDefault( "drawSpotCenters", RenderSettings.DEFAULT_DRAW_POINTS ) );
 				s.setDrawSpotCentersForEllipses( ( boolean ) mapping.getOrDefault( "drawSpotCentersForEllipses", RenderSettings.DEFAULT_DRAW_POINTS_FOR_ELLIPSE ) );
 				s.setDrawSpotLabels( ( boolean ) mapping.getOrDefault( "drawSpotLabels", RenderSettings.DEFAULT_DRAW_SPOT_LABELS ) );
+				s.setFillSpots( ( boolean ) mapping.getOrDefault( "fillSpots", RenderSettings.DEFAULT_FILL_SPOTS ) );
 				s.setFocusLimit( ( double ) mapping.getOrDefault( "focusLimit", RenderSettings.DEFAULT_LIMIT_FOCUS_RANGE ) );
 				s.setFocusLimitViewRelative( ( boolean ) mapping.getOrDefault( "focusLimitViewRelative", RenderSettings.DEFAULT_IS_FOCUS_LIMIT_RELATIVE ) );
 				s.setEllipsoidFadeDepth( ( double ) mapping.getOrDefault( "ellipsoidFadeDepth", RenderSettings.DEFAULT_ELLIPSOID_FADE_DEPTH ) );

--- a/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsPanel.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/ui/RenderSettingsPanel.java
@@ -198,6 +198,7 @@ public class RenderSettingsPanel extends JPanel
 				booleanElement( "draw spot centers", style::getDrawSpotCenters, style::setDrawSpotCenters ),
 				booleanElement( "draw spot centers for ellipses", style::getDrawSpotCentersForEllipses, style::setDrawSpotCentersForEllipses ),
 				booleanElement( "draw spot labels", style::getDrawSpotLabels, style::setDrawSpotLabels ),
+				booleanElement( "fill spots", style::getFillSpots, style::setFillSpots ),
 
 				separator(),
 


### PR DESCRIPTION
This PR allows users to set whether spots are filled or not from the settings dialog.
This option is helpful for visualization.
If this option is set, the spots will be drawn filled with the colour selected in `[View > Coloring]`, and the outline of the spots will be drawn in black.