### PR TITLE
Avoid deadlock in trackscheme

### DIFF
--- a/src/main/java/org/mastodon/views/trackscheme/TrackSchemeGraph.java
+++ b/src/main/java/org/mastodon/views/trackscheme/TrackSchemeGraph.java
@@ -231,9 +231,17 @@ public class TrackSchemeGraph<
 		vertexMap = new TrackSchemeVertexBimap<>( this );
 		edgeMap = new TrackSchemeEdgeBimap<>( this );
 
-		modelGraph.addGraphListener( this );
-		modelGraph.addGraphChangeListener( this );
-		graphRebuilt();
+		lock.writeLock().lock();
+		try
+		{
+			graphRebuilt();
+		}
+		finally
+		{
+			lock.writeLock().unlock();
+			modelGraph.addGraphListener( this );
+			modelGraph.addGraphChangeListener( this );
+		}
 	}
 
 	/**

--- a/src/main/java/org/mastodon/views/trackscheme/TrackSchemeGraph.java
+++ b/src/main/java/org/mastodon/views/trackscheme/TrackSchemeGraph.java
@@ -231,6 +231,8 @@ public class TrackSchemeGraph<
 		vertexMap = new TrackSchemeVertexBimap<>( this );
 		edgeMap = new TrackSchemeEdgeBimap<>( this );
 
+		modelGraph.addGraphListener( this );
+		modelGraph.addGraphChangeListener( this );
 		lock.writeLock().lock();
 		try
 		{
@@ -239,8 +241,6 @@ public class TrackSchemeGraph<
 		finally
 		{
 			lock.writeLock().unlock();
-			modelGraph.addGraphListener( this );
-			modelGraph.addGraphChangeListener( this );
 		}
 	}
 

--- a/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemePanel.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemePanel.java
@@ -420,29 +420,28 @@ public class TrackSchemePanel extends JPanel implements
 			entityAnimator.setTime( System.currentTimeMillis() );
 			entityAnimator.setPaintEntities( graphOverlay );
 			display.repaint();
-
-			// adjust scrollbars sizes
-			final ScreenTransform t = new ScreenTransform();
-			entityAnimator.getLastComputedScreenEntities().getScreenTransform( t );
-			xScrollScale = 10000.0 / ( layoutMaxX - layoutMinX + 2 );
-			final int xval = ( int ) ( xScrollScale * t.getMinX() );
-			final int xext = ( int ) ( xScrollScale * ( t.getMaxX() - t.getMinX() ) );
-			final int xmin = ( int ) ( xScrollScale * ( layoutMinX - boundXLayoutBorder ) );
-			final int xmax = ( int ) ( xScrollScale * ( layoutMaxX + boundXLayoutBorder ) );
-			yScrollScale = 10000.0 / ( layoutMaxY - layoutMinY + 2 );
-			final int yval = ( int ) ( yScrollScale * t.getMinY() );
-			final int yext = ( int ) ( yScrollScale * ( t.getMaxY() - t.getMinY() ) );
-			final int ymin = ( int ) ( yScrollScale * ( layoutMinY - boundYLayoutBorder ) );
-			final int ymax = ( int ) ( yScrollScale * ( layoutMaxY + boundYLayoutBorder ) );
-			ignoreScrollBarChanges = true;
-			xScrollBar.setValues( xval, xext, xmin, xmax );
-			yScrollBar.setValues( yval, yext, ymin, ymax );
-			ignoreScrollBarChanges = false;
 		}
 		finally
 		{
 			lock.readLock().unlock();
 		}
+		// adjust scrollbars sizes
+		final ScreenTransform t = new ScreenTransform();
+		entityAnimator.getLastComputedScreenEntities().getScreenTransform( t );
+		xScrollScale = 10000.0 / ( layoutMaxX - layoutMinX + 2 );
+		final int xval = ( int ) ( xScrollScale * t.getMinX() );
+		final int xext = ( int ) ( xScrollScale * ( t.getMaxX() - t.getMinX() ) );
+		final int xmin = ( int ) ( xScrollScale * ( layoutMinX - boundXLayoutBorder ) );
+		final int xmax = ( int ) ( xScrollScale * ( layoutMaxX + boundXLayoutBorder ) );
+		yScrollScale = 10000.0 / ( layoutMaxY - layoutMinY + 2 );
+		final int yval = ( int ) ( yScrollScale * t.getMinY() );
+		final int yext = ( int ) ( yScrollScale * ( t.getMaxY() - t.getMinY() ) );
+		final int ymin = ( int ) ( yScrollScale * ( layoutMinY - boundYLayoutBorder ) );
+		final int ymax = ( int ) ( yScrollScale * ( layoutMaxY + boundYLayoutBorder ) );
+		ignoreScrollBarChanges = true;
+		xScrollBar.setValues( xval, xext, xmin, xmax );
+		yScrollBar.setValues( yval, yext, ymin, ymax );
+		ignoreScrollBarChanges = false;
 	}
 
 	@Override


### PR DESCRIPTION
This PR is for avoiding deadlock in trackscheme.

### Issue
Opening the TrackScheme window while programmatically generating spots or links can cause a deadlock.

### Possible causes
- `graphRebuiilt()` might require writeLock because it affects Vertex and Edge models
- `JScrollBar.setValues()` inside readLock can cause a deadlock