### PR TITLE
Tiny fix, NullPointerException in FeatureComputationPanel/Model

### DIFF
--- a/src/main/java/org/mastodon/feature/ui/FeatureComputationModel.java
+++ b/src/main/java/org/mastodon/feature/ui/FeatureComputationModel.java
@@ -115,7 +115,7 @@ public class FeatureComputationModel
 	public Collection< FeatureSpec< ?, ? > > getFeatureSpecs( final Class< ? > target )
 	{
 		final Collection< FeatureSpec< ?, ? > > fs = featureSpecsTargetMap.get( target );
-		return null == fs ? null : Collections.unmodifiableCollection( fs );
+		return null == fs ? Collections.emptyList() : Collections.unmodifiableCollection( fs );
 	}
 
 	public FeatureSpec< ?, ? > getFeatureSpec( final String featureKey )


### PR DESCRIPTION
I get a NullPointerExcpetion when I execute Mastodon.main(...) from IntelliJ.
The exception is thrown at this line: https://github.com/mastodon-sc/mastodon/blob/2f1572c2d9715371b6e59974546c32bd86dd13d5/src/main/java/org/mastodon/feature/ui/FeatureComputationPanel.java#L193

The reason is FeatureComputationModel.getFeatureSpec(...). It returns null if no feature is installed. It's probably better for this method to return a empty list rather the the null value, if there are no features found.

@tinevez You probably didn't came across this problem, because you the features installed in your project.