### PR TITLE
Auto-linking mode for BDV.

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -251,7 +251,7 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		final AutoNavigateFocusModel< OverlayVertexWrapper< Spot, Link >, OverlayEdgeWrapper< Spot, Link > > navigateFocusModel = new AutoNavigateFocusModel<>( focusModel, navigationHandler );
 
 		BdvSelectionBehaviours.install( viewBehaviours, viewGraph, tracksOverlay, selectionModel, focusModel, navigationHandler );
-		EditBehaviours.install( viewBehaviours, viewGraph, tracksOverlay, selectionModel, focusModel, model, getMinRadius( sharedBdvData ) );
+		EditBehaviours.install( viewBehaviours, viewer, viewGraph, tracksOverlay, selectionModel, focusModel, model, getMinRadius( sharedBdvData ) );
 		EditSpecialBehaviours.install( viewBehaviours, frame.getViewerPanel(), viewGraph, tracksOverlay, selectionModel, focusModel, model );
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );


### PR DESCRIPTION
When on (toggle with `control+L`), the next spot added will be automatically linked to the one in the selection, if there is exactly one in the selection.

MaMuT users seem to be very attached to this feature.
