### PR TITLE
Improve quality of life when loading Mastodon projects.

### DIFF
--- a/src/main/java/org/mastodon/app/MastodonIcons.java
+++ b/src/main/java/org/mastodon/app/MastodonIcons.java
@@ -36,6 +36,7 @@ import javax.swing.ImageIcon;
 
 import org.mastodon.feature.ui.FeatureComputationPanel;
 import org.mastodon.feature.ui.FeatureTable;
+import org.mastodon.model.tag.ui.AbstractTagTable;
 
 /**
  * Collection of static fields pointing to the icons to use in the Mastodon-app.
@@ -183,5 +184,9 @@ public class MastodonIcons
 	public static final ImageIcon UP_TO_DATE_ICON = new ImageIcon( FeatureTable.class.getResource( "bullet_green.png" ) );
 
 	public static final ImageIcon NOT_UP_TO_DATE_ICON = new ImageIcon( FeatureTable.class.getResource( "time.png" ) );
+
+	public static final ImageIcon ADD_ICON = new ImageIcon( AbstractTagTable.class.getResource( "add.png" ) );
+
+	public static final ImageIcon REMOVE_ICON = new ImageIcon( AbstractTagTable.class.getResource( "delete.png" ) );
 
 }

--- a/src/main/java/org/mastodon/mamut/feature/MamutPlayground.java
+++ b/src/main/java/org/mastodon/mamut/feature/MamutPlayground.java
@@ -56,7 +56,7 @@ public class MamutPlayground
 		final Context context = new Context();
 		final MamutProject project = new MamutProjectIO().load( "../TrackMate3/samples/mamutproject.mastodon" );
 		final WindowManager windowManager = new WindowManager( context );
-		windowManager.getProjectManager().open( project );
+		windowManager.getProjectManager().open( project, true );
 		final Model model = windowManager.getAppModel().getModel();
 
 		System.out.println( "\n\n\n___________________________________\nData loaded.\n" );

--- a/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
+++ b/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.function.Consumer;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -76,6 +77,8 @@ class LauncherGUI extends JPanel
 	static final String NEW_FROM_URL_KEY = "NewFromURL";
 
 	static final String LOAD_MASTODON_PROJECT_KEY = "LoadMastodonProject";
+
+	static final String RECENT_PROJECTS_KEY = "MastodonRecentProjects";
 
 	static final String IMPORT_TGMM_KEY = "ImportTGMM";
 
@@ -113,7 +116,9 @@ class LauncherGUI extends JPanel
 
 	final JButton btnHelp;
 
-	public LauncherGUI()
+	private final RecentProjectsPanel recentProjectsPanel;
+
+	public LauncherGUI( final Consumer< String > projectOpener )
 	{
 		setLayout( new BorderLayout( 5, 5 ) );
 
@@ -208,6 +213,9 @@ class LauncherGUI extends JPanel
 
 		newMastodonProjectPanel = new OpenBDVPanel( "New Mastodon project", "create" );
 		centralPanel.add( newMastodonProjectPanel, NEW_MASTODON_PROJECT_KEY );
+
+		recentProjectsPanel = new RecentProjectsPanel( projectOpener );
+		centralPanel.add( recentProjectsPanel, RECENT_PROJECTS_KEY );
 
 		openRemoteURLPanel = new OpenRemoteURLPanel();
 		centralPanel.add( openRemoteURLPanel, NEW_FROM_URL_KEY );

--- a/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
+++ b/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
@@ -496,7 +496,7 @@ public class MastodonLauncher extends JFrame
 					try
 					{
 						final MamutProject project = new MamutProjectIO().load( file.getAbsolutePath() );
-						windowManager.getProjectManager().open( project );
+						windowManager.getProjectManager().open( project, true );
 						new MainWindow( windowManager ).setVisible( true );
 						dispose();
 					}

--- a/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
@@ -1,0 +1,143 @@
+package org.mastodon.mamut.launcher;
+
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSeparator;
+import javax.swing.JTextArea;
+import javax.swing.SwingConstants;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.ui.util.RecentProjects;
+
+public class RecentProjectsPanel extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	static final RecentProjects recentProjects = new RecentProjects();
+
+	public RecentProjectsPanel( final Consumer< String > projectOpener )
+	{
+		remakeGUI( projectOpener );
+	}
+
+	private void remakeGUI( final Consumer< String > projectOpener )
+	{
+		removeAll();
+
+		/*
+		 * Row heights and weights.
+		 */
+
+		final int[] rowHeights = new int[ 1 // title.
+				+ ( recentProjects.isempty() ? 1 : recentProjects.size() )
+				+ 1 // separator
+				+ 1 // open other
+				+ 1 ]; // fill blank
+
+		rowHeights[ 0 ] = 35;
+		for ( int i = 0; i < Math.max( 1, recentProjects.size() ); i++ )
+			rowHeights[ 0 ] = 60;
+
+		rowHeights[ rowHeights.length - 3 ] = 65;
+		rowHeights[ rowHeights.length - 2 ] = 35;
+		rowHeights[ rowHeights.length - 1 ] = 10;
+
+		final double[] rowWeights = new double[ rowHeights.length ];
+		Arrays.fill( rowWeights, 0. );
+		rowWeights[ rowWeights.length - 1 ] = 1.;
+
+		/*
+		 * GUI
+		 */
+
+		final GridBagLayout gbl = new GridBagLayout();
+		gbl.columnWeights = new double[] { 1., 0., 0. };
+		gbl.rowHeights = rowHeights;
+		gbl.rowWeights = rowWeights;
+		setLayout( gbl );
+
+		final GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridx = 0;
+		gbc.gridy = 0;
+		gbc.insets = new Insets( 5, 5, 5, 5 );
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+
+		final JLabel lblTitle = new JLabel( "Recent projects" );
+		lblTitle.setFont( lblTitle.getFont().deriveFont( lblTitle.getFont().getStyle() | Font.BOLD ) );
+		lblTitle.setHorizontalAlignment( SwingConstants.CENTER );
+		add( lblTitle, gbc );
+
+		/*
+		 * List of recent projects.
+		 */
+
+		if ( recentProjects != null && !recentProjects.isempty() )
+		{
+			for ( final String projectPath : recentProjects )
+			{
+				gbc.gridy++;
+				gbc.gridx = 0;
+				final JTextArea ta = new JTextArea( projectPath );
+				ta.setEditable( false );
+				ta.setLineWrap( true );
+				add( ta, gbc );
+
+				gbc.gridx = 1;
+				final JButton btnOpen = new JButton( MastodonIcons.LOAD_ICON_SMALL );
+				btnOpen.addActionListener( l -> {
+					projectOpener.accept( projectPath );
+					// Recent projects will be updated in the launcher method.
+				} );
+				add( btnOpen, gbc );
+
+				gbc.gridx = 2;
+				final JButton btnClear = new JButton( MastodonIcons.REMOVE_ICON );
+				btnClear.addActionListener( l -> {
+					recentProjects.remove( projectPath );
+					remakeGUI( projectOpener );
+				} );
+				add( btnClear, gbc );
+			}
+		}
+		else
+		{
+			final JLabel lblNo = new JLabel( "No recent projects." );
+			lblNo.setFont( getFont().deriveFont( getFont().getStyle() | Font.ITALIC ) );
+			lblNo.setHorizontalAlignment( SwingConstants.CENTER );
+
+			gbc.gridy++;
+			gbc.gridwidth = 3;
+			add( lblNo, gbc );
+			gbc.gridwidth = 1;
+		}
+
+		gbc.gridy++;
+		gbc.gridx = 0;
+		gbc.gridwidth = 2;
+		add( new JSeparator(), gbc );
+
+		gbc.gridy++;
+		gbc.gridwidth = 1;
+		final JLabel lblTitle2 = new JLabel( "Open another project" );
+		lblTitle2.setHorizontalAlignment( SwingConstants.CENTER );
+		lblTitle2.setFont( lblTitle2.getFont().deriveFont( lblTitle2.getFont().getStyle() | Font.BOLD ) );
+		add( lblTitle2, gbc );
+
+		gbc.gridx = 1;
+		final JButton btnBrowse = new JButton( MastodonIcons.LOAD_ICON_SMALL );
+		btnBrowse.addActionListener( l -> projectOpener.accept( null ) );
+		add( btnBrowse, gbc );
+
+		revalidate();
+		repaint();
+	}
+}

--- a/src/main/java/org/mastodon/ui/DndHandler.java
+++ b/src/main/java/org/mastodon/ui/DndHandler.java
@@ -55,7 +55,7 @@ public class DndHandler extends AbstractIOPlugin< Object >
 		{
 			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
 			final WindowManager windowManager = new WindowManager( getContext() );
-			windowManager.getProjectManager().open( new MamutProjectIO().load( projectFile ) );
+			windowManager.getProjectManager().open( new MamutProjectIO().load( projectFile ), true );
 			new MainWindow( windowManager ).setVisible( true );
 		}
 		catch ( IOException | SpimDataException e )

--- a/src/main/java/org/mastodon/ui/util/RecentProjects.java
+++ b/src/main/java/org/mastodon/ui/util/RecentProjects.java
@@ -1,0 +1,122 @@
+package org.mastodon.ui.util;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Maintain a list of the Nth most recent project paths manipulated with this
+ * object.
+ */
+public class RecentProjects implements Iterable< String >
+{
+
+	private static final String RECENT_PROJECTS_FILE = System.getProperty( "user.home" ) + "/.mastodon/recentprojects.yaml";
+
+	private static final int MAX_N_RECENT_PROJECTS = 10;
+
+	private final List< String > recent;
+
+	private final int maxLength;
+
+	public RecentProjects()
+	{
+		this.recent = new ArrayList< String >();
+		this.maxLength = MAX_N_RECENT_PROJECTS;
+		load( RECENT_PROJECTS_FILE );
+	}
+
+	public void add( final String element )
+	{
+		recent.remove( element );
+		recent.add( 0, element );
+		reduce();
+		save( RECENT_PROJECTS_FILE );
+	}
+
+	private void reduce()
+	{
+		while ( recent.size() > maxLength )
+			recent.remove( recent.size() - 1 );
+	}
+
+	public void clear()
+	{
+		recent.clear();
+		save( RECENT_PROJECTS_FILE );
+	}
+
+	@Override
+	public Iterator< String > iterator()
+	{
+		return Collections.unmodifiableCollection( recent ).iterator();
+	}
+
+	public boolean isempty()
+	{
+		return recent.isEmpty();
+	}
+
+	public int size()
+	{
+		return recent.size();
+	}
+
+	public boolean remove( final String element )
+	{
+		final boolean removed = recent.remove( element );
+		save( RECENT_PROJECTS_FILE );
+		return removed;
+	}
+
+	@Override
+	public String toString()
+	{
+		return recent.toString();
+	}
+
+	private static Yaml createYaml()
+	{
+		final DumperOptions dumperOptions = new DumperOptions();
+		final Yaml yaml = new Yaml( dumperOptions );
+		return yaml;
+	}
+
+	private void save( final String filename )
+	{
+		try (final FileWriter output = new FileWriter( filename ))
+		{
+			final Yaml yaml = createYaml();
+			yaml.dumpAll( recent.iterator(), output );
+		}
+		catch ( final IOException e )
+		{}
+	}
+
+	private void load( final String filename )
+	{
+		recent.clear();
+		try (final FileReader input = new FileReader( filename ))
+		{
+			final Yaml yaml = createYaml();
+			final Iterable< Object > objs = yaml.loadAll( input );
+			for ( final Object obj : objs )
+			{
+				if ( obj instanceof String )
+					recent.add( ( String ) obj );
+			}
+		}
+		catch ( final FileNotFoundException e )
+		{}
+		catch ( final IOException e )
+		{}
+	}
+}

--- a/src/test/java/org/mastodon/graph/BranchGraphExample.java
+++ b/src/test/java/org/mastodon/graph/BranchGraphExample.java
@@ -26,7 +26,7 @@ public class BranchGraphExample
 			final MamutProject project = new MamutProjectIO().load( projectPath );
 
 			final WindowManager wm = new WindowManager( context );
-			wm.getProjectManager().open( project );
+			wm.getProjectManager().open( project, true );
 			wm.getAppModel().getBranchGraphSync().sync();
 			new MainWindow( wm ).setVisible( true );
 		}

--- a/src/test/java/org/mastodon/mamut/Mastodon.java
+++ b/src/test/java/org/mastodon/mamut/Mastodon.java
@@ -98,7 +98,7 @@ public class Mastodon extends ContextCommand
 			final MamutProject project = new MamutProjectIO().load( "samples/drosophila_crop_3_spots.mastodon" );
 
 			final WindowManager windowManager = mastodon.windowManager;
-			windowManager.projectManager.open( project );
+			windowManager.projectManager.open( project, true );
 
 //			mw.proposedProjectFile = new File( "/Users/pietzsch/Desktop/data/TGMM_METTE/project2.xml" );
 //			mw.loadProject( new File( "/Users/pietzsch/Desktop/data/TGMM_METTE/project.xml" ) );


### PR DESCRIPTION
- Add a flag that specifies whether to restore the GUI state when opening a project.

By default, we do not restore the GUI state. Restoring the GUI state might be unwanted when scripting of using Mastodon in a headless manner. The launcher and DND entry points do however restore the GUI state.


- Add a 'recent projects' feature to the launcher.

Store up to 10 most recent Mastodon projects that opened successfully.
Serialized to a YAML file in the .mastodon folder.
Is not updated when the user creates a new project with 'save as'.

![image](https://user-images.githubusercontent.com/3583203/170867820-4add8d6f-4c72-4e66-8d52-fae8c615d335.png)

```sh
tinevez@METALLICA MINGW64 ~/.mastodon
$ ls
colormodes.yaml          debug.yaml  **recentprojects.yaml**               trackschemestyles.yaml
colormodes-post-pr.yaml  keymaps/    rendersettings.yaml
datagraphstyles.yaml     Plugins/    selectioncreatorexpressions.yaml
```

```yaml
$ cat recentprojects.yaml
C:\Users\tinevez\Development\Mastodon\mastodon\samples\Celegans.mastodon
--- C:\Users\tinevez\Google Drive\Mastodon\FromVlado\mette_e1.mastodon
--- C:\Users\tinevez\Google Drive\Cours\MastodonI2K\CTC_TRIF_trainingVideo02_jy-tracked.mastodon
--- C:\Users\tinevez\Development\Mastodon\mastodon\samples\drosophila_crop.mastodon
```