### PR TITLE
Record movie commands for BDV views.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,13 @@
 			<artifactId>jackson-core</artifactId>
 			<version>2.13.1</version>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>io.humble</groupId>
+			<artifactId>humble-video-all</artifactId>
+			<version>0.3.0</version>
+		</dependency>
+	
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
+++ b/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
@@ -38,6 +38,8 @@ import org.mastodon.app.ui.MastodonFrameViewActions;
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.ui.SelectionActions;
+import org.mastodon.views.bdv.export.RecordMaxProjectionMovieDialog;
+import org.mastodon.views.bdv.export.RecordMovieDialog;
 import org.mastodon.views.table.TableViewActions;
 import org.mastodon.views.trackscheme.display.EditFocusVertexLabelAction;
 import org.mastodon.views.trackscheme.display.TrackSchemeNavigationActions;
@@ -86,6 +88,9 @@ public class MamutMenuBuilder extends ViewMenuBuilder
 		menuTexts.put( BigDataViewerActions.SAVE_SETTINGS, "Save Bdv Settings" );
 		menuTexts.put( BigDataViewerActions.BRIGHTNESS_SETTINGS, "Brightness & Color" );
 		menuTexts.put( BigDataViewerActions.VISIBILITY_AND_GROUPING, "Visibility & Grouping" );
+
+		menuTexts.put( RecordMovieDialog.RECORD_MOVIE_DIALOG, "Record BDV movie" );
+		menuTexts.put( RecordMaxProjectionMovieDialog.RECORD_MIP_MOVIE_DIALOG, "Record BDV max projection movie" );
 
 		menuTexts.put( TrackSchemeNavigationActions.NAVIGATE_CHILD, "Navigate to Child" );
 		menuTexts.put( TrackSchemeNavigationActions.NAVIGATE_PARENT, "Navigate to Parent" );

--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -75,6 +75,7 @@ import org.mastodon.views.bdv.BigDataViewerActionsMamut;
 import org.mastodon.views.bdv.BigDataViewerMamut;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.mastodon.views.bdv.ViewerFrameMamut;
+import org.mastodon.views.bdv.export.RecordMovieDialog;
 import org.mastodon.views.bdv.overlay.BdvHighlightHandler;
 import org.mastodon.views.bdv.overlay.BdvSelectionBehaviours;
 import org.mastodon.views.bdv.overlay.EditBehaviours;
@@ -256,6 +257,7 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
 		OverlayActions.install( viewActions, viewer, tracksOverlay );
+		RecordMovieDialog.install( viewActions, bdv, tracksOverlay, colorBarOverlay );
 
 		/*
 		 * We must make a search action using the underlying model graph,

--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -166,7 +166,10 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 				fileMenu(
 						separator(),
 						item( BigDataViewerActions.LOAD_SETTINGS ),
-						item( BigDataViewerActions.SAVE_SETTINGS ) ),
+						item( BigDataViewerActions.SAVE_SETTINGS ),
+						separator(),
+						item( RecordMovieDialog.RECORD_MOVIE_DIALOG ),
+						item( RecordMaxProjectionMovieDialog.RECORD_MIP_MOVIE_DIALOG ) ),
 				viewMenu(
 						colorMenu( menuHandle ),
 						colorbarMenu( colorbarMenuHandle ),

--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -257,7 +257,8 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		HighlightBehaviours.install( viewBehaviours, viewGraph, viewGraph.getLock(), viewGraph, highlightModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
 		OverlayActions.install( viewActions, viewer, tracksOverlay );
-		RecordMovieDialog.install( viewActions, bdv, tracksOverlay, colorBarOverlay );
+		final Runnable onCloseDialog = RecordMovieDialog.install( viewActions, bdv, tracksOverlay, colorBarOverlay, appModel.getKeymap() );
+		onClose( onCloseDialog );
 
 		/*
 		 * We must make a search action using the underlying model graph,

--- a/src/main/java/org/mastodon/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewBdv.java
@@ -75,6 +75,7 @@ import org.mastodon.views.bdv.BigDataViewerActionsMamut;
 import org.mastodon.views.bdv.BigDataViewerMamut;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.mastodon.views.bdv.ViewerFrameMamut;
+import org.mastodon.views.bdv.export.RecordMaxProjectionMovieDialog;
 import org.mastodon.views.bdv.export.RecordMovieDialog;
 import org.mastodon.views.bdv.overlay.BdvHighlightHandler;
 import org.mastodon.views.bdv.overlay.BdvSelectionBehaviours;
@@ -259,6 +260,8 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		OverlayActions.install( viewActions, viewer, tracksOverlay );
 		final Runnable onCloseDialog = RecordMovieDialog.install( viewActions, bdv, tracksOverlay, colorBarOverlay, appModel.getKeymap() );
 		onClose( onCloseDialog );
+		final Runnable onCloseMIPDialog = RecordMaxProjectionMovieDialog.install( viewActions, bdv, tracksOverlay, colorBarOverlay, appModel.getKeymap() );
+		onClose( onCloseMIPDialog );
 
 		/*
 		 * We must make a search action using the underlying model graph,

--- a/src/main/java/org/mastodon/views/bdv/export/AbstractBDVRecorder.java
+++ b/src/main/java/org/mastodon/views/bdv/export/AbstractBDVRecorder.java
@@ -3,6 +3,7 @@ package org.mastodon.views.bdv.export;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 
 import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
 import org.mastodon.views.trackscheme.display.ColorBarOverlay;
@@ -17,7 +18,13 @@ import bdv.viewer.overlay.ScaleBarOverlayRenderer;
 import bdv.viewer.render.MultiResolutionRenderer;
 import bdv.viewer.render.RenderTarget;
 import bdv.viewer.render.awt.BufferedImageRenderResult;
+import net.imglib2.Cursor;
+import net.imglib2.display.screenimage.awt.ARGBScreenImage;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.util.LinAlgHelpers;
 
 public abstract class AbstractBDVRecorder
 {
@@ -41,6 +48,182 @@ public abstract class AbstractBDVRecorder
 		this.progressWriter = progressWriter;
 	}
 
+	public void recordMaxProjectionMovie(
+			final int width, final int height,
+			final int minTimepointIndex, final int maxTimepointIndex,
+			final double stepSize, final int numSteps,
+			final boolean projectOverlay )
+	{
+		initializeRecorder( width, height );
+
+		final ViewerState renderState = new BasicViewerState( viewer.state().snapshot() );
+		final int canvasW = viewer.getDisplay().getWidth();
+		final int canvasH = viewer.getDisplay().getHeight();
+
+		final AffineTransform3D tGV = new AffineTransform3D();
+		renderState.getViewerTransform( tGV );
+		tGV.set( tGV.get( 0, 3 ) - canvasW / 2, 0, 3 );
+		tGV.set( tGV.get( 1, 3 ) - canvasH / 2, 1, 3 );
+		tGV.scale( ( double ) width / canvasW );
+		tGV.set( tGV.get( 0, 3 ) + width / 2, 0, 3 );
+		tGV.set( tGV.get( 1, 3 ) + height / 2, 1, 3 );
+
+		final AffineTransform3D affine = new AffineTransform3D();
+
+		// get voxel width transformed to current viewer coordinates
+		final AffineTransform3D tSV = new AffineTransform3D();
+		renderState.getSources().get( 0 ).getSpimSource().getSourceTransform( 0, 0, tSV );
+		tSV.preConcatenate( tGV );
+		final double[] sO = new double[] { 0, 0, 0 };
+		final double[] sX = new double[] { 1, 0, 0 };
+		final double[] vO = new double[ 3 ];
+		final double[] vX = new double[ 3 ];
+		tSV.apply( sO, vO );
+		tSV.apply( sX, vX );
+		LinAlgHelpers.subtract( vO, vX, vO );
+		final double dd = LinAlgHelpers.length( vO );
+
+		final ScaleBarOverlayRenderer scalebar = Prefs.showScaleBarInMovie() ? new ScaleBarOverlayRenderer() : null;
+
+		class MyTarget implements RenderTarget< BufferedImageRenderResult >
+		{
+			final ARGBScreenImage accumulated = new ARGBScreenImage( width, height );
+
+			final BufferedImageRenderResult renderResult = new BufferedImageRenderResult();
+
+			public void clear()
+			{
+				for ( final ARGBType acc : accumulated )
+					acc.setZero();
+			}
+
+			@Override
+			public BufferedImageRenderResult getReusableRenderResult()
+			{
+				return renderResult;
+			}
+
+			@Override
+			public BufferedImageRenderResult createRenderResult()
+			{
+				return new BufferedImageRenderResult();
+			}
+
+			@Override
+			public void setRenderResult( final BufferedImageRenderResult renderResult )
+			{
+				final BufferedImage bufferedImage = renderResult.getBufferedImage();
+				final Img< ARGBType > argbs = ArrayImgs.argbs( ( ( DataBufferInt ) bufferedImage.getData().getDataBuffer() ).getData(), width, height );
+				final Cursor< ARGBType > c = argbs.cursor();
+				for ( final ARGBType acc : accumulated )
+				{
+					final int current = acc.get();
+					final int in = c.next().get();
+					acc.set( ARGBType.rgba(
+							Math.max( ARGBType.red( in ), ARGBType.red( current ) ),
+							Math.max( ARGBType.green( in ), ARGBType.green( current ) ),
+							Math.max( ARGBType.blue( in ), ARGBType.blue( current ) ),
+							Math.max( ARGBType.alpha( in ), ARGBType.alpha( current ) ) ) );
+				}
+			}
+
+			@Override
+			public final int getWidth()
+			{
+				return width;
+			}
+
+			@Override
+			public int getHeight()
+			{
+				return height;
+			}
+		}
+		final MyTarget target = new MyTarget();
+		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+				target, () -> {}, new double[] { 1 }, 0, 1, null, false,
+				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
+
+		// Mastodon overlays.
+		if ( tracksOverlay != null )
+			tracksOverlay.setCanvasSize( width, height );
+
+		if ( colorBarOverlay != null )
+			colorBarOverlay.setCanvasSize( width, height );
+
+		// Loop over time.
+		progressWriter.setProgress( 0 );
+		for ( int timepoint = minTimepointIndex; timepoint <= maxTimepointIndex; ++timepoint )
+		{
+			target.clear();
+			renderState.setCurrentTimepoint( timepoint );
+
+			for ( int step = 0; step < numSteps; ++step )
+			{
+				affine.set(
+						1, 0, 0, 0,
+						0, 1, 0, 0,
+						0, 0, 1, -dd * stepSize * ( step - numSteps / 2 ) );
+				affine.concatenate( tGV );
+				renderState.setViewerTransform( affine );
+				renderer.requestRepaint();
+				renderer.paint( renderState );
+			}
+
+			final BufferedImage bi = target.accumulated.image();
+			final Graphics2D g2 = bi.createGraphics();
+			g2.setRenderingHint( RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON );
+
+			if ( Prefs.showScaleBarInMovie() )
+			{
+				g2.setClip( 0, 0, width, height );
+				scalebar.setViewerState( renderState );
+				scalebar.paint( g2 );
+			}
+
+			/*
+			 * Mastodon overlays.
+			 */
+
+			g2.setClip( 0, 0, width, height );
+			g2.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
+
+			if ( tracksOverlay != null )
+			{
+				tracksOverlay.timePointChanged( timepoint );
+				if ( projectOverlay )
+				{
+					for ( int step = 0; step < numSteps; ++step )
+					{
+						affine.set(
+								1, 0, 0, 0,
+								0, 1, 0, 0,
+								0, 0, 1, -dd * stepSize * ( step - numSteps / 2 ) );
+						affine.concatenate( tGV );
+
+						if ( tracksOverlay != null )
+						{
+							tracksOverlay.transformChanged( affine );
+							tracksOverlay.drawOverlays( g2 );
+						}
+					}
+				}
+				else
+				{
+					tracksOverlay.transformChanged( tGV );
+					tracksOverlay.drawOverlays( g2 );
+				}
+			}
+			if ( colorBarOverlay != null )
+				colorBarOverlay.drawOverlays( g2 );
+
+			writeFrame( bi, timepoint );
+			progressWriter.setProgress( ( double ) ( timepoint - minTimepointIndex + 1 ) / ( maxTimepointIndex - minTimepointIndex + 1 ) );
+		}
+
+		closeRecorder();
+	}
+
 	public void record(
 			final int width,
 			final int height,
@@ -48,7 +231,7 @@ public abstract class AbstractBDVRecorder
 			final int maxTimepointIndex )
 	{
 		initializeRecorder( width, height );
-		
+
 		final ViewerState renderState = new BasicViewerState( viewer.state().snapshot() );
 		final int canvasW = viewer.getDisplay().getWidth();
 		final int canvasH = viewer.getDisplay().getHeight();

--- a/src/main/java/org/mastodon/views/bdv/export/AbstractBDVRecorder.java
+++ b/src/main/java/org/mastodon/views/bdv/export/AbstractBDVRecorder.java
@@ -1,0 +1,165 @@
+package org.mastodon.views.bdv.export;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.views.trackscheme.display.ColorBarOverlay;
+
+import bdv.cache.CacheControl;
+import bdv.export.ProgressWriter;
+import bdv.util.Prefs;
+import bdv.viewer.BasicViewerState;
+import bdv.viewer.ViewerPanel;
+import bdv.viewer.ViewerState;
+import bdv.viewer.overlay.ScaleBarOverlayRenderer;
+import bdv.viewer.render.MultiResolutionRenderer;
+import bdv.viewer.render.RenderTarget;
+import bdv.viewer.render.awt.BufferedImageRenderResult;
+import net.imglib2.realtransform.AffineTransform3D;
+
+public abstract class AbstractBDVRecorder
+{
+	protected final ViewerPanel viewer;
+
+	protected final OverlayGraphRenderer< ?, ? > tracksOverlay;
+
+	protected final ColorBarOverlay colorBarOverlay;
+
+	protected final ProgressWriter progressWriter;
+
+	protected AbstractBDVRecorder(
+			final ViewerPanel viewer,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay,
+			final ProgressWriter progressWriter )
+	{
+		this.viewer = viewer;
+		this.tracksOverlay = tracksOverlay;
+		this.colorBarOverlay = colorBarOverlay;
+		this.progressWriter = progressWriter;
+	}
+
+	public void record(
+			final int width,
+			final int height,
+			final int minTimepointIndex,
+			final int maxTimepointIndex )
+	{
+		initializeRecorder( width, height );
+		
+		final ViewerState renderState = new BasicViewerState( viewer.state().snapshot() );
+		final int canvasW = viewer.getDisplay().getWidth();
+		final int canvasH = viewer.getDisplay().getHeight();
+
+		final AffineTransform3D affine = new AffineTransform3D();
+		renderState.getViewerTransform( affine );
+		affine.set( affine.get( 0, 3 ) - canvasW / 2, 0, 3 );
+		affine.set( affine.get( 1, 3 ) - canvasH / 2, 1, 3 );
+		affine.scale( ( double ) width / canvasW );
+		affine.set( affine.get( 0, 3 ) + width / 2, 0, 3 );
+		affine.set( affine.get( 1, 3 ) + height / 2, 1, 3 );
+		renderState.setViewerTransform( affine );
+
+		// Scale bar.
+		final ScaleBarOverlayRenderer scalebar = Prefs.showScaleBarInMovie() ? new ScaleBarOverlayRenderer() : null;
+
+		// BDV image.
+		class MyTarget implements RenderTarget< BufferedImageRenderResult >
+		{
+			final BufferedImageRenderResult renderResult = new BufferedImageRenderResult();
+
+			@Override
+			public BufferedImageRenderResult getReusableRenderResult()
+			{
+				return renderResult;
+			}
+
+			@Override
+			public BufferedImageRenderResult createRenderResult()
+			{
+				return new BufferedImageRenderResult();
+			}
+
+			@Override
+			public void setRenderResult( final BufferedImageRenderResult renderResult )
+			{}
+
+			@Override
+			public int getWidth()
+			{
+				return width;
+			}
+
+			@Override
+			public int getHeight()
+			{
+				return height;
+			}
+		}
+		final MyTarget target = new MyTarget();
+		final MultiResolutionRenderer renderer = new MultiResolutionRenderer(
+				target, () -> {}, new double[] { 1 }, 0, 1, null, false,
+				viewer.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
+
+		// Mastodon overlays.
+		if ( tracksOverlay != null )
+		{
+			tracksOverlay.setCanvasSize( width, height );
+			tracksOverlay.transformChanged( affine );
+		}
+		if ( colorBarOverlay != null )
+		{
+			colorBarOverlay.setCanvasSize( width, height );
+		}
+
+		// Loop over time.
+		progressWriter.setProgress( 0 );
+		for ( int timepoint = minTimepointIndex; timepoint <= maxTimepointIndex; ++timepoint )
+		{
+			renderState.setCurrentTimepoint( timepoint );
+			renderer.requestRepaint();
+			renderer.paint( renderState );
+
+			final BufferedImage bi = target.renderResult.getBufferedImage();
+			final Graphics2D g2 = bi.createGraphics();
+			g2.setRenderingHint( RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON );
+
+			if ( Prefs.showScaleBarInMovie() )
+			{
+				g2.setClip( 0, 0, width, height );
+				scalebar.setViewerState( renderState );
+				scalebar.paint( g2 );
+			}
+
+			/*
+			 * Mastodon overlays.
+			 */
+
+			g2.setClip( 0, 0, width, height );
+			g2.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
+
+			if ( tracksOverlay != null )
+			{
+				tracksOverlay.timePointChanged( timepoint );
+				tracksOverlay.drawOverlays( g2 );
+			}
+			if ( colorBarOverlay != null )
+			{
+				colorBarOverlay.drawOverlays( g2 );
+			}
+
+			writeFrame( bi, timepoint );
+			progressWriter.setProgress( ( double ) ( timepoint - minTimepointIndex + 1 ) / ( maxTimepointIndex - minTimepointIndex + 1 ) );
+		}
+
+		closeRecorder();
+	}
+
+	protected abstract void closeRecorder();
+
+	protected abstract void initializeRecorder( int width, int height );
+
+	protected abstract void writeFrame( BufferedImage frame, int timepoint );
+}

--- a/src/main/java/org/mastodon/views/bdv/export/MovieFileBDVRecorder.java
+++ b/src/main/java/org/mastodon/views/bdv/export/MovieFileBDVRecorder.java
@@ -50,8 +50,14 @@ public class MovieFileBDVRecorder extends AbstractBDVRecorder
 	}
 
 	@Override
-	protected void initializeRecorder( final int width, final int height )
+	protected void initializeRecorder( final int w, final int h )
 	{
+		/*
+		 * Make sure we only get even numbers for width and height.
+		 */
+		final int width = Math.round( w / 2 ) * 2;
+		final int height = Math.round( h / 2 ) * 2;
+
 		/*
 		 * First we create a muxer using the filename to determine code and
 		 * format.
@@ -105,10 +111,13 @@ public class MovieFileBDVRecorder extends AbstractBDVRecorder
 	protected void writeFrame( final BufferedImage frame, final int timepoint )
 	{
 		// Convert BI type to something Humble can harness.
-		final BufferedImage convertedImg = new BufferedImage( frame.getWidth(), frame.getHeight(), BufferedImage.TYPE_3BYTE_BGR );
+		// Also crop in case we had non-even dimensions.
+		final BufferedImage convertedImg = new BufferedImage( picture.getWidth(), picture.getHeight(), BufferedImage.TYPE_3BYTE_BGR );
 		convertedImg.getGraphics().drawImage( frame, 0, 0, null );
+
 		if ( converter == null )
 			converter = MediaPictureConverterFactory.createConverter( convertedImg, picture );
+
 		converter.toPicture( picture, convertedImg, timepoint );
 
 		// Write to output video stream.

--- a/src/main/java/org/mastodon/views/bdv/export/MovieFileBDVRecorder.java
+++ b/src/main/java/org/mastodon/views/bdv/export/MovieFileBDVRecorder.java
@@ -1,0 +1,146 @@
+package org.mastodon.views.bdv.export;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.views.trackscheme.display.ColorBarOverlay;
+
+import bdv.export.ProgressWriter;
+import bdv.viewer.ViewerPanel;
+import io.humble.video.Codec;
+import io.humble.video.Encoder;
+import io.humble.video.MediaPacket;
+import io.humble.video.MediaPicture;
+import io.humble.video.Muxer;
+import io.humble.video.MuxerFormat;
+import io.humble.video.PixelFormat;
+import io.humble.video.Rational;
+import io.humble.video.awt.MediaPictureConverter;
+import io.humble.video.awt.MediaPictureConverterFactory;
+
+public class MovieFileBDVRecorder extends AbstractBDVRecorder
+{
+
+	private final String filename;
+
+	private final int fps;
+
+	private Muxer muxer;
+
+	private MediaPicture picture;
+
+	private MediaPictureConverter converter;
+
+	private Encoder encoder;
+
+	private MediaPacket packet;
+
+	protected MovieFileBDVRecorder(
+			final ViewerPanel viewer,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay,
+			final ProgressWriter progressWriter,
+			final String filename,
+			final int fps )
+	{
+		super( viewer, tracksOverlay, colorBarOverlay, progressWriter );
+		this.filename = filename;
+		this.fps = fps;
+	}
+
+	@Override
+	protected void initializeRecorder( final int width, final int height )
+	{
+		/*
+		 * First we create a muxer using the filename to determine code and
+		 * format.
+		 */
+		final Rational framerate = Rational.make( 1, fps );
+		this.muxer = Muxer.make( filename, null, null );
+
+		// Determine codec.
+		final MuxerFormat format = muxer.getFormat();
+		final Codec codec = Codec.findEncodingCodec( format.getDefaultVideoCodecId() );
+
+		// Create an encoder.
+		encoder = Encoder.make( codec );
+		encoder.setWidth( width );
+		encoder.setHeight( height );
+		// Default pixel format, assuming it's the most used by codecs.
+		final PixelFormat.Type pixelformat = PixelFormat.Type.PIX_FMT_YUV420P;
+		encoder.setPixelFormat( pixelformat );
+		encoder.setTimeBase( framerate );
+
+		// Global headers if needed.
+		if ( format.getFlag( MuxerFormat.Flag.GLOBAL_HEADER ) )
+			encoder.setFlag( Encoder.Flag.FLAG_GLOBAL_HEADER, true );
+
+		// Open the encoder.
+		encoder.open( null, null );
+
+		// Add this stream to the muxer.
+		muxer.addNewStream( encoder );
+
+		// And open the muxer for business.
+		try
+		{
+			muxer.open( null, null );
+		}
+		catch ( InterruptedException | IOException e )
+		{
+			e.printStackTrace();
+		}
+
+		this.picture = MediaPicture.make(
+				encoder.getWidth(),
+				encoder.getHeight(),
+				pixelformat );
+		picture.setTimeBase( framerate );
+
+		packet = MediaPacket.make();
+	}
+
+	@Override
+	protected void writeFrame( final BufferedImage frame, final int timepoint )
+	{
+		// Convert BI type to something Humble can harness.
+		final BufferedImage convertedImg = new BufferedImage( frame.getWidth(), frame.getHeight(), BufferedImage.TYPE_3BYTE_BGR );
+		convertedImg.getGraphics().drawImage( frame, 0, 0, null );
+		if ( converter == null )
+			converter = MediaPictureConverterFactory.createConverter( convertedImg, picture );
+		converter.toPicture( picture, convertedImg, timepoint );
+
+		// Write to output video stream.
+		do
+		{
+			encoder.encode( packet, picture );
+			if ( packet.isComplete() )
+				muxer.write( packet, false );
+		}
+		while ( packet.isComplete() );
+	}
+
+	@Override
+	protected void closeRecorder()
+	{
+		// Flush.
+		do
+		{
+			encoder.encode( packet, null );
+			if ( packet.isComplete() )
+				muxer.write( packet, false );
+		}
+		while ( packet.isComplete() );
+
+		// Close.
+		muxer.close();
+
+		// Nullify everything.
+		converter = null;
+		encoder = null;
+		muxer = null;
+		packet = null;
+		picture = null;
+	}
+}

--- a/src/main/java/org/mastodon/views/bdv/export/PNGFolderBDVRecorder.java
+++ b/src/main/java/org/mastodon/views/bdv/export/PNGFolderBDVRecorder.java
@@ -1,0 +1,51 @@
+package org.mastodon.views.bdv.export;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.views.trackscheme.display.ColorBarOverlay;
+
+import bdv.export.ProgressWriter;
+import bdv.viewer.ViewerPanel;
+
+public class PNGFolderBDVRecorder extends AbstractBDVRecorder
+{
+
+	private final File targetFolder;
+
+	protected PNGFolderBDVRecorder(
+			final ViewerPanel viewer,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay,
+			final ProgressWriter progressWriter,
+			final File targetFolder )
+	{
+		super( viewer, tracksOverlay, colorBarOverlay, progressWriter );
+		this.targetFolder = targetFolder;
+	}
+
+	@Override
+	protected void initializeRecorder( final int width, final int height )
+	{}
+
+	@Override
+	protected void writeFrame( final BufferedImage bi, final int timepoint )
+	{
+		try
+		{
+			ImageIO.write( bi, "png", new File( String.format( "%s/img-%03d.png", targetFolder, timepoint ) ) );
+		}
+		catch ( final IOException e )
+		{
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected void closeRecorder()
+	{}
+}

--- a/src/main/java/org/mastodon/views/bdv/export/RecordMaxProjectionMovieDialog.java
+++ b/src/main/java/org/mastodon/views/bdv/export/RecordMaxProjectionMovieDialog.java
@@ -1,0 +1,619 @@
+package org.mastodon.views.bdv.export;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.io.File;
+import java.io.PrintStream;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.JRadioButton;
+import javax.swing.JSeparator;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.ui.keymap.Keymap;
+import org.mastodon.ui.keymap.Keymap.UpdateListener;
+import org.mastodon.ui.util.FileChooser;
+import org.mastodon.ui.util.FileChooser.DialogType;
+import org.mastodon.ui.util.FileChooser.SelectionMode;
+import org.mastodon.views.bdv.BigDataViewerMamut;
+import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.views.trackscheme.display.ColorBarOverlay;
+import org.scijava.plugin.Plugin;
+import org.scijava.prefs.DefaultPrefService;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.InputActionBindings;
+
+import bdv.export.ProgressWriter;
+import bdv.util.DelayedPackDialog;
+import bdv.viewer.OverlayRenderer;
+import bdv.viewer.ViewerPanel;
+import ij.io.LogStream;
+
+/**
+ * Adapted from BDV {@code RecordMaxProjectionDialog} to also record the MaMuT
+ * overlay.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class RecordMaxProjectionMovieDialog extends DelayedPackDialog implements OverlayRenderer
+{
+
+	private static final String RECORD_MIP_MOVIE_DIALOG = "record max projection movie dialog";
+
+	private static final String[] RECORD_MIP_MOVIE_DIALOG_KEYS = { "ctrl shift R" };
+
+	/*
+	 * Command descriptions for all provided commands
+	 */
+	@Plugin( type = CommandDescriptionProvider.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+
+		public Descriptions()
+		{
+			super( KeyConfigContexts.BIGDATAVIEWER );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( RECORD_MIP_MOVIE_DIALOG, RECORD_MIP_MOVIE_DIALOG_KEYS, "Show the record max-projection movie dialog." );
+		}
+	}
+
+	/**
+	 * Install the record dialog on the specified BDV window.
+	 * 
+	 * @param actions
+	 *            the actions to register the toggle dialog visibility action.
+	 * @param bdv
+	 *            the BDV frame to capture.
+	 * @param tracksOverlay
+	 *            the track overlay displayed on the BDV.
+	 * @param colorBarOverlay
+	 *            the colorbar overlay displayed on the BDV.
+	 * @param keymap
+	 *            the keymap of the application. If not <code>null</code>, the
+	 *            toggle visibility key bindings will also be registered to the
+	 *            dialog window.
+	 * @return a runnable that should be executed when the BDV window is closed,
+	 *         and that closes this dialog and de-registers its listeners.
+	 */
+	public static Runnable install(
+			final Actions actions,
+			final BigDataViewerMamut bdv,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay,
+			final Keymap keymap )
+	{
+		final RecordMaxProjectionMovieDialog dialog = new RecordMaxProjectionMovieDialog(
+				bdv.getViewerFrame(),
+				bdv.getViewer(),
+				tracksOverlay,
+				colorBarOverlay );
+		dialog.setTitle( "Record max projection movie on " + bdv.getViewerFrame().getTitle() );
+		bdv.getViewer().getDisplay().overlays().add( dialog );
+		actions.namedAction( new RecordMovieDialog.MyToggleDialogAction( RECORD_MIP_MOVIE_DIALOG, dialog ), RECORD_MIP_MOVIE_DIALOG_KEYS );
+
+		// Register some keymaps to the dialog itself.
+		if ( keymap != null )
+		{
+			final InputActionBindings keybindings = new InputActionBindings();
+			SwingUtilities.replaceUIActionMap( dialog.rootPane, keybindings.getConcatenatedActionMap() );
+			SwingUtilities.replaceUIInputMap( dialog.rootPane, JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT, keybindings.getConcatenatedInputMap() );
+
+			final Actions dialogActions = new Actions( keymap.getConfig(), KeyConfigContexts.BIGDATAVIEWER );
+			dialogActions.install( keybindings, "view" );
+			final UpdateListener updateListener = () -> dialogActions.updateKeyConfig( keymap.getConfig() );
+			keymap.updateListeners().add( updateListener );
+			updateListener.keymapChanged();
+			final Runnable onClose = () -> {
+				keymap.updateListeners().remove( updateListener );
+				dialog.setVisible( false );
+				dialog.dispose();
+			};
+
+			dialogActions.namedAction( new RecordMovieDialog.MyToggleDialogAction( RECORD_MIP_MOVIE_DIALOG, dialog ), RECORD_MIP_MOVIE_DIALOG_KEYS );
+			return onClose;
+		}
+		
+		return () -> {
+			dialog.setVisible( false );
+			dialog.dispose();
+		};
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String EXPORT_TO_MOVIE_KEY = "ExportToMovie";
+	private static final String PNG_EXPORT_PATH_KEY = "PNGExportPath";
+	private static final String MOVIE_EXPORT_PATH_KEY = "MovieExportPath";
+	private static final String FPS_KEY = "FPS";
+	private static final String NUM_STEPS_KEY = "NumSteps";
+	private static final String STEP_SIZE_KEY = "StepSize";
+	private static final String PROJECT_OVERLAY_KEY = "ProjectOverlay";
+
+	private final int maxTimepoint;
+
+	private final JTextField tfPathPNGs;
+
+	private final JSpinner spinnerMinTimepoint;
+
+	private final JSpinner spinnerMaxTimepoint;
+
+	private final JSpinner spinnerWidth;
+
+	private final JSpinner spinnerHeight;
+
+	private JTextField tfPathMovie;
+
+	public RecordMaxProjectionMovieDialog(
+			final Frame owner,
+			final ViewerPanel viewer,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay )
+	{
+		super( owner, "Record BDV max projection movie", false );
+		maxTimepoint = ( null == viewer ) ? 10 : viewer.state().getNumTimepoints() - 1;
+		final DefaultPrefService prefService = new DefaultPrefService();
+
+		final JPanel boxes = new JPanel();
+		boxes.setBorder( new EmptyBorder( 5, 5, 5, 5 ) );
+		getContentPane().add( boxes, BorderLayout.CENTER );
+		final GridBagLayout gblBoxes = new GridBagLayout();
+		gblBoxes.columnWidths = new int[] { 309, 0 };
+		gblBoxes.rowHeights = new int[] { 0, 0, 0, 0, 30, 0, 25, 30, 0, 0, 30, 10, 30, 0 };
+		gblBoxes.columnWeights = new double[] { 1.0, Double.MIN_VALUE };
+		gblBoxes.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, Double.MIN_VALUE };
+		boxes.setLayout( gblBoxes );
+
+		final JPanel timepointsPanel = new JPanel();
+		final GridBagConstraints gbcTimepointsPanel = new GridBagConstraints();
+		gbcTimepointsPanel.fill = GridBagConstraints.BOTH;
+		gbcTimepointsPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcTimepointsPanel.gridx = 0;
+		gbcTimepointsPanel.gridy = 0;
+		boxes.add( timepointsPanel, gbcTimepointsPanel );
+		timepointsPanel.setLayout( new BoxLayout( timepointsPanel, BoxLayout.X_AXIS ) );
+
+		timepointsPanel.add( new JLabel( "Record from timepoint" ) );
+
+		final Component horizontalGlue = Box.createHorizontalGlue();
+		timepointsPanel.add( horizontalGlue );
+
+		spinnerMinTimepoint = new JSpinner();
+		spinnerMinTimepoint.setModel( new SpinnerNumberModel( 0, 0, maxTimepoint, 1 ) );
+		timepointsPanel.add( spinnerMinTimepoint );
+
+		timepointsPanel.add( Box.createHorizontalGlue() );
+		timepointsPanel.add( new JLabel( "to" ) );
+
+		timepointsPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerMaxTimepoint = new JSpinner();
+		spinnerMaxTimepoint.setModel( new SpinnerNumberModel( maxTimepoint, 0, maxTimepoint, 1 ) );
+		timepointsPanel.add( spinnerMaxTimepoint );
+
+		final JPanel widthPanel = new JPanel();
+		final GridBagConstraints gbcWidthPanel = new GridBagConstraints();
+		gbcWidthPanel.fill = GridBagConstraints.BOTH;
+		gbcWidthPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcWidthPanel.gridx = 0;
+		gbcWidthPanel.gridy = 1;
+		boxes.add( widthPanel, gbcWidthPanel );
+		widthPanel.setLayout( new BoxLayout( widthPanel, BoxLayout.X_AXIS ) );
+
+		final JLabel lblTargetSize = new JLabel( "Target Size" );
+		widthPanel.add( lblTargetSize );
+
+		widthPanel.add( Box.createHorizontalGlue() );
+		widthPanel.add( new JLabel( "width" ) );
+
+		widthPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerWidth = new JSpinner();
+		spinnerWidth.setModel( new SpinnerNumberModel( 800, 10, 5000, 1 ) );
+		widthPanel.add( spinnerWidth );
+
+		widthPanel.add( Box.createHorizontalGlue() );
+		final JLabel label = new JLabel( "height" );
+		widthPanel.add( label );
+
+		widthPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerHeight = new JSpinner();
+		widthPanel.add( spinnerHeight );
+		spinnerHeight.setModel( new SpinnerNumberModel( 600, 10, 5000, 1 ) );
+
+		final JPanel panelProjection = new JPanel();
+		final GridBagConstraints gbcPanelProjection = new GridBagConstraints();
+		gbcPanelProjection.insets = new Insets( 0, 0, 5, 0 );
+		gbcPanelProjection.fill = GridBagConstraints.BOTH;
+		gbcPanelProjection.gridx = 0;
+		gbcPanelProjection.gridy = 2;
+		boxes.add( panelProjection, gbcPanelProjection );
+		panelProjection.setLayout( new BoxLayout( panelProjection, BoxLayout.X_AXIS ) );
+
+		panelProjection.add( new JLabel( "Projection" ) );
+
+		panelProjection.add( Box.createHorizontalGlue() );
+		panelProjection.add( new JLabel( "N slices" ) );
+
+		panelProjection.add( Box.createHorizontalStrut( 5 ) );
+
+		final JSpinner spinnerNumSteps = new JSpinner();
+		spinnerNumSteps.setModel( new SpinnerNumberModel( 10, 1, 10000, 1 ) );
+		panelProjection.add( spinnerNumSteps );
+
+		panelProjection.add( Box.createHorizontalGlue() );
+		panelProjection.add( new JLabel( "step size" ) );
+
+		panelProjection.add( Box.createHorizontalStrut( 5 ) );
+		final JSpinner spinnerStepSize = new JSpinner();
+		spinnerStepSize.setModel( new SpinnerNumberModel( 1., 0.001, 20, 0.1 ) );
+		panelProjection.add( spinnerStepSize );
+
+		final JCheckBox chckbxProjectOverlay = new JCheckBox( "also project overlay" );
+		final GridBagConstraints gbc_chckbxProjectOverlay = new GridBagConstraints();
+		gbc_chckbxProjectOverlay.anchor = GridBagConstraints.EAST;
+		gbc_chckbxProjectOverlay.insets = new Insets( 0, 0, 5, 0 );
+		gbc_chckbxProjectOverlay.gridx = 0;
+		gbc_chckbxProjectOverlay.gridy = 3;
+		boxes.add( chckbxProjectOverlay, gbc_chckbxProjectOverlay );
+
+		final GridBagConstraints gbcSeparator = new GridBagConstraints();
+		gbcSeparator.anchor = GridBagConstraints.SOUTH;
+		gbcSeparator.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator.gridx = 0;
+		gbcSeparator.gridy = 4;
+		boxes.add( new JSeparator(), gbcSeparator );
+
+		final JRadioButton rdbtnToPNG = new JRadioButton( "Record as a folder of PNGs " );
+		final GridBagConstraints gbcRdbtnToPNG = new GridBagConstraints();
+		gbcRdbtnToPNG.anchor = GridBagConstraints.WEST;
+		gbcRdbtnToPNG.insets = new Insets( 0, 0, 5, 0 );
+		gbcRdbtnToPNG.gridx = 0;
+		gbcRdbtnToPNG.gridy = 5;
+		boxes.add( rdbtnToPNG, gbcRdbtnToPNG );
+
+		final JPanel saveAsPanel = new JPanel();
+		final GridBagConstraints gbcSaveAsPanel = new GridBagConstraints();
+		gbcSaveAsPanel.fill = GridBagConstraints.BOTH;
+		gbcSaveAsPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcSaveAsPanel.gridx = 0;
+		gbcSaveAsPanel.gridy = 6;
+		boxes.add( saveAsPanel, gbcSaveAsPanel );
+		saveAsPanel.setLayout( new BoxLayout( saveAsPanel, BoxLayout.X_AXIS ) );
+
+		saveAsPanel.add( new JLabel( "save to" ) );
+
+		saveAsPanel.add( Box.createHorizontalStrut( 5 ) );
+		tfPathPNGs = new JTextField();
+		saveAsPanel.add( tfPathPNGs );
+		tfPathPNGs.setColumns( 20 );
+
+		saveAsPanel.add( Box.createHorizontalStrut( 10 ) );
+
+		final JButton btnBrowsePNGs = new JButton( "Browse" );
+		saveAsPanel.add( btnBrowsePNGs );
+
+		final GridBagConstraints gbcSeparator1 = new GridBagConstraints();
+		gbcSeparator1.anchor = GridBagConstraints.SOUTH;
+		gbcSeparator1.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator1.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator1.gridx = 0;
+		gbcSeparator1.gridy = 7;
+		boxes.add( new JSeparator(), gbcSeparator1 );
+
+		final JRadioButton rdbtnToMovie = new JRadioButton( "Record to a movie file" );
+		final GridBagConstraints gbcRdbtnToMovie = new GridBagConstraints();
+		gbcRdbtnToMovie.anchor = GridBagConstraints.WEST;
+		gbcRdbtnToMovie.insets = new Insets( 0, 0, 5, 0 );
+		gbcRdbtnToMovie.gridx = 0;
+		gbcRdbtnToMovie.gridy = 8;
+		boxes.add( rdbtnToMovie, gbcRdbtnToMovie );
+
+		final JPanel panelSaveTo2 = new JPanel();
+		final GridBagConstraints gbcPanelSaveTo2 = new GridBagConstraints();
+		gbcPanelSaveTo2.insets = new Insets( 0, 0, 5, 0 );
+		gbcPanelSaveTo2.fill = GridBagConstraints.BOTH;
+		gbcPanelSaveTo2.gridx = 0;
+		gbcPanelSaveTo2.gridy = 9;
+		boxes.add( panelSaveTo2, gbcPanelSaveTo2 );
+		panelSaveTo2.setLayout( new BoxLayout( panelSaveTo2, BoxLayout.X_AXIS ) );
+
+		final JLabel lblSaveTo2 = new JLabel( "save to" );
+		panelSaveTo2.add( lblSaveTo2 );
+
+		panelSaveTo2.add( Box.createHorizontalStrut( 5 ) );
+
+		tfPathMovie = new JTextField();
+		panelSaveTo2.add( tfPathMovie );
+		tfPathMovie.setColumns( 10 );
+
+		panelSaveTo2.add( Box.createHorizontalStrut( 10 ) );
+
+		final JButton btnBrowseMovie = new JButton( "Browse" );
+		panelSaveTo2.add( btnBrowseMovie );
+
+		final JPanel panelFPS = new JPanel();
+		final FlowLayout flowLayout = ( FlowLayout ) panelFPS.getLayout();
+		flowLayout.setAlignment( FlowLayout.RIGHT );
+		final GridBagConstraints gbcPanelFPS = new GridBagConstraints();
+		gbcPanelFPS.insets = new Insets( 0, 0, 5, 0 );
+		gbcPanelFPS.fill = GridBagConstraints.BOTH;
+		gbcPanelFPS.gridx = 0;
+		gbcPanelFPS.gridy = 10;
+		boxes.add( panelFPS, gbcPanelFPS );
+
+		panelFPS.add( new JLabel( "fps" ) );
+		panelFPS.add( Box.createHorizontalStrut( 10 ) );
+
+		final JSpinner spinnerFPS = new JSpinner();
+		spinnerFPS.setModel( new SpinnerNumberModel( 10, 1, 200, 1 ) );
+		panelFPS.add( spinnerFPS );
+
+		final GridBagConstraints gbcSeparator2 = new GridBagConstraints();
+		gbcSeparator2.anchor = GridBagConstraints.NORTH;
+		gbcSeparator2.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator2.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator2.gridx = 0;
+		gbcSeparator2.gridy = 11;
+		boxes.add( new JSeparator(), gbcSeparator2 );
+
+		final JPanel panelRecord = new JPanel();
+		final GridBagConstraints gbcPanelRecord = new GridBagConstraints();
+		gbcPanelRecord.anchor = GridBagConstraints.SOUTH;
+		gbcPanelRecord.fill = GridBagConstraints.HORIZONTAL;
+		gbcPanelRecord.gridx = 0;
+		gbcPanelRecord.gridy = 12;
+		boxes.add( panelRecord, gbcPanelRecord );
+		panelRecord.setLayout( new BoxLayout( panelRecord, BoxLayout.X_AXIS ) );
+
+		final JProgressBar progressBar = new JProgressBar();
+		panelRecord.add( progressBar );
+
+		final JButton recordButton = new JButton( "Record" );
+		panelRecord.add( recordButton );
+
+		/*
+		 * Progress bar.
+		 */
+
+		progressBar.getModel().setMinimum( 0 );
+		progressBar.getModel().setMaximum( 100 );
+		progressBar.setStringPainted( true );
+		final ProgressWriter progressWriter = new ProgressWriter()
+		{
+			private final LogStream ls = new LogStream();
+
+			@Override
+			public void setProgress( final double completionRatio )
+			{
+				progressBar.setValue( ( int ) ( 100 * completionRatio ) );
+			}
+
+			@Override
+			public PrintStream out()
+			{
+				return ls;
+			}
+
+			@Override
+			public PrintStream err()
+			{
+				return ls;
+			}
+		};
+
+		/*
+		 * Listeners.
+		 */
+
+		spinnerMinTimepoint.addChangeListener( new ChangeListener()
+		{
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final int min = ( Integer ) spinnerMinTimepoint.getValue();
+				final int max = ( Integer ) spinnerMaxTimepoint.getValue();
+				if ( max < min )
+					spinnerMaxTimepoint.setValue( min );
+			}
+		} );
+
+		spinnerMaxTimepoint.addChangeListener( new ChangeListener()
+		{
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final int min = ( Integer ) spinnerMinTimepoint.getValue();
+				final int max = ( Integer ) spinnerMaxTimepoint.getValue();
+				if ( min > max )
+					spinnerMinTimepoint.setValue( max );
+			}
+		} );
+
+
+		btnBrowsePNGs.addActionListener( e -> {
+			final File file = FileChooser.chooseFile(
+					FileChooser.useJFileChooser,
+					RecordMaxProjectionMovieDialog.this,
+					tfPathPNGs.getText(),
+					null,
+					"Browse to a folder to save the PNGs to",
+					DialogType.SAVE,
+					SelectionMode.DIRECTORIES_ONLY,
+					MastodonIcons.BDV_ICON_MEDIUM.getImage() );
+			if ( file != null )
+			{
+				tfPathPNGs.setText( file.getAbsolutePath() );
+				prefService.put( RecordMaxProjectionMovieDialog.class, PNG_EXPORT_PATH_KEY, file.getAbsolutePath() );
+			}
+		} );
+
+		btnBrowseMovie.addActionListener( e -> {
+			final File file = FileChooser.chooseFile(
+					FileChooser.useJFileChooser,
+					RecordMaxProjectionMovieDialog.this,
+					tfPathMovie.getText(),
+					null,
+					"Save to movie file (MP4, MOV, AVI, ...)",
+					DialogType.SAVE,
+					SelectionMode.FILES_ONLY,
+					MastodonIcons.BDV_ICON_MEDIUM.getImage() );
+			if ( file != null )
+			{
+				tfPathMovie.setText( file.getAbsolutePath() );
+				prefService.put( RecordMaxProjectionMovieDialog.class, MOVIE_EXPORT_PATH_KEY, file.getAbsolutePath() );
+			}
+		} );
+
+		final ButtonGroup buttonGroup = new ButtonGroup();
+		buttonGroup.add( rdbtnToPNG );
+		buttonGroup.add( rdbtnToMovie );
+
+		final ItemListener enableGroupListener = e -> {
+			if ( e != null && e.getStateChange() == ItemEvent.DESELECTED )
+				return;
+			final boolean pngEnabled = rdbtnToPNG.isSelected();
+			tfPathPNGs.setEnabled( pngEnabled );
+			btnBrowsePNGs.setEnabled( pngEnabled );
+			tfPathMovie.setEnabled( !pngEnabled );
+			btnBrowseMovie.setEnabled( !pngEnabled );
+			spinnerFPS.setEnabled( !pngEnabled );
+
+			prefService.put( RecordMaxProjectionMovieDialog.class, EXPORT_TO_MOVIE_KEY, !pngEnabled );
+		};
+		rdbtnToPNG.addItemListener( enableGroupListener );
+		rdbtnToMovie.addItemListener( enableGroupListener );
+
+		/*
+		 * Persistence.
+		 */
+
+		rdbtnToMovie.setSelected( prefService.getBoolean( RecordMaxProjectionMovieDialog.class, EXPORT_TO_MOVIE_KEY, true ) );
+		tfPathPNGs.setText( prefService.get( RecordMaxProjectionMovieDialog.class, PNG_EXPORT_PATH_KEY, System.getProperty( "user.home" ) ) );
+		tfPathMovie.setText( prefService.get( RecordMaxProjectionMovieDialog.class, MOVIE_EXPORT_PATH_KEY, new File( System.getProperty( "user.home" ), "BDVCapture.mp4" ).getAbsolutePath() ) );
+		int fps = prefService.getInt( RecordMaxProjectionMovieDialog.class, FPS_KEY, 10 );
+		fps = Math.min( 200, Math.max( 1, fps ) );
+		spinnerFPS.setValue( fps );
+		int nSteps = prefService.getInt( RecordMaxProjectionMovieDialog.class, NUM_STEPS_KEY, 10 );
+		nSteps = Math.min( 10000, Math.max( 1, nSteps ) );
+		spinnerNumSteps.setValue( nSteps );
+		double stepSize = prefService.getDouble( RecordMaxProjectionMovieDialog.class, STEP_SIZE_KEY, 1. );
+		stepSize = Math.min( 20., Math.max( 0.01, stepSize ) );
+		spinnerStepSize.setValue( stepSize );
+		chckbxProjectOverlay.setSelected( prefService.getBoolean( RecordMaxProjectionMovieDialog.class, PROJECT_OVERLAY_KEY, false ) );
+
+		spinnerFPS.addChangeListener( e -> prefService.put( RecordMaxProjectionMovieDialog.class, FPS_KEY, ( ( Number ) spinnerFPS.getValue() ).intValue() ) );
+		spinnerNumSteps.addChangeListener( e -> prefService.put( RecordMaxProjectionMovieDialog.class, NUM_STEPS_KEY, ( ( Number ) spinnerNumSteps.getValue() ).intValue() ) );
+		spinnerStepSize.addChangeListener( e -> prefService.put( RecordMaxProjectionMovieDialog.class, STEP_SIZE_KEY, ( ( Number ) spinnerStepSize.getValue() ).doubleValue() ) );
+		chckbxProjectOverlay.addChangeListener( e -> prefService.put( RecordMaxProjectionMovieDialog.class, PROJECT_OVERLAY_KEY, chckbxProjectOverlay.isSelected() ) );
+		
+		setCanvasSize( viewer.getWidth(), viewer.getHeight() );
+
+		/*
+		 * Record action.
+		 */
+
+		recordButton.addActionListener( new ActionListener()
+		{
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{
+				final double stepSize = ( Double ) spinnerStepSize.getValue();
+				final int numSteps = ( Integer ) spinnerNumSteps.getValue();
+				final boolean toPNG = rdbtnToPNG.isSelected();
+
+				final AbstractBDVRecorder recorder;
+				if ( toPNG )
+				{
+					final String dirname = tfPathPNGs.getText();
+					final File dir = new File( dirname );
+					if ( !dir.exists() )
+						dir.mkdirs();
+					if ( !dir.exists() || !dir.isDirectory() )
+					{
+						progressWriter.err().append( "Invalid export directory " + dirname + '\n' );
+						return;
+					}
+					recorder = new PNGFolderBDVRecorder( viewer, tracksOverlay, colorBarOverlay, progressWriter, dir );
+				}
+				else
+				{
+					final String filename = tfPathMovie.getText();
+					final int fps = ( ( Number ) spinnerFPS.getValue() ).intValue();
+					recorder = new MovieFileBDVRecorder( viewer, tracksOverlay, colorBarOverlay, progressWriter, filename, fps );
+				}
+
+				final int minTimepointIndex = ( Integer ) spinnerMinTimepoint.getValue();
+				final int maxTimepointIndex = ( Integer ) spinnerMaxTimepoint.getValue();
+				final int width = ( Integer ) spinnerWidth.getValue();
+				final int height = ( Integer ) spinnerHeight.getValue();
+				final boolean projectOverlay = chckbxProjectOverlay.isSelected();
+				new Thread()
+				{
+					@Override
+					public void run()
+					{
+						try
+						{
+							recordButton.setEnabled( false );
+							recorder.recordMaxProjectionMovie(
+									width, height,
+									minTimepointIndex, maxTimepointIndex,
+									stepSize, numSteps,
+									projectOverlay );
+							recordButton.setEnabled( true );
+						}
+						catch ( final Exception ex )
+						{
+							ex.printStackTrace();
+						}
+					}
+				}.start();
+			}
+		} );
+
+		// Pack.
+		pack();
+	}
+
+	@Override
+	public void drawOverlays( final Graphics g )
+	{}
+
+	@Override
+	public void setCanvasSize( final int width, final int height )
+	{
+		spinnerWidth.setValue( width );
+		spinnerHeight.setValue( height );
+	}
+}

--- a/src/main/java/org/mastodon/views/bdv/export/RecordMaxProjectionMovieDialog.java
+++ b/src/main/java/org/mastodon/views/bdv/export/RecordMaxProjectionMovieDialog.java
@@ -66,7 +66,7 @@ import ij.io.LogStream;
 public class RecordMaxProjectionMovieDialog extends DelayedPackDialog implements OverlayRenderer
 {
 
-	private static final String RECORD_MIP_MOVIE_DIALOG = "record max projection movie dialog";
+	public static final String RECORD_MIP_MOVIE_DIALOG = "record max projection movie dialog";
 
 	private static final String[] RECORD_MIP_MOVIE_DIALOG_KEYS = { "ctrl shift R" };
 

--- a/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
+++ b/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
@@ -1,0 +1,464 @@
+package org.mastodon.views.bdv.export;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.PrintStream;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.JRadioButton;
+import javax.swing.JSeparator;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.ui.keymap.CommandDescriptionProvider;
+import org.mastodon.ui.keymap.CommandDescriptions;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.ui.util.FileChooser;
+import org.mastodon.ui.util.FileChooser.DialogType;
+import org.mastodon.ui.util.FileChooser.SelectionMode;
+import org.mastodon.views.bdv.BigDataViewerMamut;
+import org.mastodon.views.bdv.overlay.OverlayGraphRenderer;
+import org.mastodon.views.trackscheme.display.ColorBarOverlay;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.util.Actions;
+
+import bdv.BigDataViewerActions;
+import bdv.export.ProgressWriter;
+import bdv.util.DelayedPackDialog;
+import bdv.viewer.OverlayRenderer;
+import bdv.viewer.ViewerPanel;
+import ij.io.LogStream;
+
+/**
+ * Adapted from BDV {@code RecordMovieDialog} to also record the MaMuT overlay.
+ *
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class RecordMovieDialog extends DelayedPackDialog implements OverlayRenderer
+{
+
+	private static final String RECORD_MOVIE_DIALOG = "record movie dialog";
+
+	private static final String[] RECORD_MOVIE_DIALOG_KEYS = { "ctrl R" };
+
+	/*
+	 * Command descriptions for all provided commands
+	 */
+	@Plugin( type = CommandDescriptionProvider.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+
+		public Descriptions()
+		{
+			super( KeyConfigContexts.BIGDATAVIEWER );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add( RECORD_MOVIE_DIALOG, RECORD_MOVIE_DIALOG_KEYS, "Show the record movie dialog." );
+		}
+	}
+
+	public static void install(
+			final Actions actions,
+			final BigDataViewerMamut bdv, final OverlayGraphRenderer< ?, ? > tracksOverlay, final ColorBarOverlay colorBarOverlay )
+	{
+		final RecordMovieDialog dialog = new RecordMovieDialog(
+				bdv.getViewerFrame(),
+				bdv.getViewer(),
+				tracksOverlay,
+				colorBarOverlay );
+		dialog.setLocationRelativeTo( bdv.getViewerFrame() );
+		BigDataViewerActions.toggleDialogAction( actions, dialog, RECORD_MOVIE_DIALOG, RECORD_MOVIE_DIALOG_KEYS );
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	private final int maxTimepoint;
+
+	private final JTextField pathTextField;
+
+	private final JSpinner spinnerMinTimepoint;
+
+	private final JSpinner spinnerMaxTimepoint;
+
+	private final JSpinner spinnerWidth;
+
+	private final JSpinner spinnerHeight;
+
+	private JTextField textField;
+
+	public RecordMovieDialog(
+			final Frame owner,
+			final ViewerPanel viewer,
+			final OverlayGraphRenderer< ?, ? > tracksOverlay,
+			final ColorBarOverlay colorBarOverlay )
+	{
+		super( owner, "Record BDV movie", false );
+		maxTimepoint = viewer.state().getNumTimepoints() - 1;
+
+		final JPanel boxes = new JPanel();
+		boxes.setBorder( new EmptyBorder( 5, 5, 5, 5 ) );
+		getContentPane().add( boxes, BorderLayout.CENTER );
+		final GridBagLayout gblBoxes = new GridBagLayout();
+		gblBoxes.columnWidths = new int[] { 309, 0 };
+		gblBoxes.rowHeights = new int[] { 0, 0, 30, 0, 25, 30, 0, 0, 30, 10, 30, 0 };
+		gblBoxes.columnWeights = new double[] { 1.0, Double.MIN_VALUE };
+		gblBoxes.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, Double.MIN_VALUE };
+		boxes.setLayout( gblBoxes );
+
+		final JPanel timepointsPanel = new JPanel();
+		final GridBagConstraints gbcTimepointsPanel = new GridBagConstraints();
+		gbcTimepointsPanel.fill = GridBagConstraints.BOTH;
+		gbcTimepointsPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcTimepointsPanel.gridx = 0;
+		gbcTimepointsPanel.gridy = 0;
+		boxes.add( timepointsPanel, gbcTimepointsPanel );
+		timepointsPanel.setLayout( new BoxLayout( timepointsPanel, BoxLayout.X_AXIS ) );
+
+		timepointsPanel.add( new JLabel( "Record from timepoint" ) );
+
+		final Component horizontalGlue = Box.createHorizontalGlue();
+		timepointsPanel.add( horizontalGlue );
+
+		spinnerMinTimepoint = new JSpinner();
+		spinnerMinTimepoint.setModel( new SpinnerNumberModel( 0, 0, maxTimepoint, 1 ) );
+		timepointsPanel.add( spinnerMinTimepoint );
+
+		timepointsPanel.add( Box.createHorizontalGlue() );
+		timepointsPanel.add( new JLabel( "to" ) );
+
+		timepointsPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerMaxTimepoint = new JSpinner();
+		spinnerMaxTimepoint.setModel( new SpinnerNumberModel( maxTimepoint, 0, maxTimepoint, 1 ) );
+		timepointsPanel.add( spinnerMaxTimepoint );
+
+		spinnerMinTimepoint.addChangeListener( new ChangeListener()
+		{
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final int min = ( Integer ) spinnerMinTimepoint.getValue();
+				final int max = ( Integer ) spinnerMaxTimepoint.getValue();
+				if ( max < min )
+					spinnerMaxTimepoint.setValue( min );
+			}
+		} );
+
+		spinnerMaxTimepoint.addChangeListener( new ChangeListener()
+		{
+			@Override
+			public void stateChanged( final ChangeEvent e )
+			{
+				final int min = ( Integer ) spinnerMinTimepoint.getValue();
+				final int max = ( Integer ) spinnerMaxTimepoint.getValue();
+				if ( min > max )
+					spinnerMinTimepoint.setValue( max );
+			}
+		} );
+
+		final JPanel widthPanel = new JPanel();
+		final GridBagConstraints gbcWidthPanel = new GridBagConstraints();
+		gbcWidthPanel.fill = GridBagConstraints.BOTH;
+		gbcWidthPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcWidthPanel.gridx = 0;
+		gbcWidthPanel.gridy = 1;
+		boxes.add( widthPanel, gbcWidthPanel );
+		widthPanel.setLayout( new BoxLayout( widthPanel, BoxLayout.X_AXIS ) );
+
+		final JLabel lblTargetSize = new JLabel( "Target Size" );
+		widthPanel.add( lblTargetSize );
+
+		widthPanel.add( Box.createHorizontalGlue() );
+		widthPanel.add( new JLabel( "width" ) );
+
+		widthPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerWidth = new JSpinner();
+		spinnerWidth.setModel( new SpinnerNumberModel( 800, 10, 5000, 1 ) );
+		widthPanel.add( spinnerWidth );
+
+		widthPanel.add( Box.createHorizontalGlue() );
+		final JLabel label = new JLabel( "height" );
+		widthPanel.add( label );
+
+		widthPanel.add( Box.createHorizontalStrut( 5 ) );
+		spinnerHeight = new JSpinner();
+		widthPanel.add( spinnerHeight );
+		spinnerHeight.setModel( new SpinnerNumberModel( 600, 10, 5000, 1 ) );
+
+		final GridBagConstraints gbcSeparator = new GridBagConstraints();
+		gbcSeparator.anchor = GridBagConstraints.SOUTH;
+		gbcSeparator.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator.gridx = 0;
+		gbcSeparator.gridy = 2;
+		boxes.add( new JSeparator(), gbcSeparator );
+
+		final JRadioButton rdbtnToPNG = new JRadioButton( "Record as a folder of PNGs " );
+		final GridBagConstraints gbcRdbtnToPNG = new GridBagConstraints();
+		gbcRdbtnToPNG.anchor = GridBagConstraints.WEST;
+		gbcRdbtnToPNG.insets = new Insets( 0, 0, 5, 0 );
+		gbcRdbtnToPNG.gridx = 0;
+		gbcRdbtnToPNG.gridy = 3;
+		boxes.add( rdbtnToPNG, gbcRdbtnToPNG );
+
+		final JPanel saveAsPanel = new JPanel();
+		final GridBagConstraints gbcSaveAsPanel = new GridBagConstraints();
+		gbcSaveAsPanel.fill = GridBagConstraints.BOTH;
+		gbcSaveAsPanel.insets = new Insets( 0, 0, 5, 0 );
+		gbcSaveAsPanel.gridx = 0;
+		gbcSaveAsPanel.gridy = 4;
+		boxes.add( saveAsPanel, gbcSaveAsPanel );
+		saveAsPanel.setLayout( new BoxLayout( saveAsPanel, BoxLayout.X_AXIS ) );
+
+		saveAsPanel.add( new JLabel( "save to" ) );
+
+		saveAsPanel.add( Box.createHorizontalStrut( 5 ) );
+		pathTextField = new JTextField();
+		saveAsPanel.add( pathTextField );
+		pathTextField.setColumns( 20 );
+
+		saveAsPanel.add( Box.createHorizontalStrut( 10 ) );
+
+		final JButton browseButton = new JButton( "Browse" );
+		saveAsPanel.add( browseButton );
+
+		browseButton.addActionListener( new ActionListener()
+		{
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{
+				final File file = FileChooser.chooseFile(
+						FileChooser.useJFileChooser,
+						RecordMovieDialog.this,
+						pathTextField.getText(),
+						null,
+						"Browse to a folder to save the PNGs to",
+						DialogType.SAVE,
+						SelectionMode.DIRECTORIES_ONLY,
+						MastodonIcons.BDV_ICON_MEDIUM.getImage() );
+				if ( file != null )
+					pathTextField.setText( file.getAbsolutePath() );
+			}
+		} );
+
+		final GridBagConstraints gbcSeparator1 = new GridBagConstraints();
+		gbcSeparator1.anchor = GridBagConstraints.SOUTH;
+		gbcSeparator1.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator1.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator1.gridx = 0;
+		gbcSeparator1.gridy = 5;
+		boxes.add( new JSeparator(), gbcSeparator1 );
+
+		final JRadioButton rdbtnToMovie = new JRadioButton( "Record to a movie file" );
+		final GridBagConstraints gbcRdbtnToMovie = new GridBagConstraints();
+		gbcRdbtnToMovie.anchor = GridBagConstraints.WEST;
+		gbcRdbtnToMovie.insets = new Insets( 0, 0, 5, 0 );
+		gbcRdbtnToMovie.gridx = 0;
+		gbcRdbtnToMovie.gridy = 6;
+		boxes.add( rdbtnToMovie, gbcRdbtnToMovie );
+
+		final JPanel panelSaveTo2 = new JPanel();
+		final GridBagConstraints gbcPanelSaveTo2 = new GridBagConstraints();
+		gbcPanelSaveTo2.insets = new Insets( 0, 0, 5, 0 );
+		gbcPanelSaveTo2.fill = GridBagConstraints.BOTH;
+		gbcPanelSaveTo2.gridx = 0;
+		gbcPanelSaveTo2.gridy = 7;
+		boxes.add( panelSaveTo2, gbcPanelSaveTo2 );
+		panelSaveTo2.setLayout( new BoxLayout( panelSaveTo2, BoxLayout.X_AXIS ) );
+
+		final JLabel lblSaveTo2 = new JLabel( "save to" );
+		panelSaveTo2.add( lblSaveTo2 );
+
+		panelSaveTo2.add( Box.createHorizontalStrut( 5 ) );
+
+		textField = new JTextField();
+		panelSaveTo2.add( textField );
+		textField.setColumns( 10 );
+
+		panelSaveTo2.add( Box.createHorizontalStrut( 10 ) );
+
+		final JButton btnBrowseMovie = new JButton( "Browse" );
+		panelSaveTo2.add( btnBrowseMovie );
+
+		final JPanel panelFPS = new JPanel();
+		final FlowLayout flowLayout = ( FlowLayout ) panelFPS.getLayout();
+		flowLayout.setAlignment( FlowLayout.RIGHT );
+		final GridBagConstraints gbcPanelFPS = new GridBagConstraints();
+		gbcPanelFPS.insets = new Insets( 0, 0, 5, 0 );
+		gbcPanelFPS.fill = GridBagConstraints.BOTH;
+		gbcPanelFPS.gridx = 0;
+		gbcPanelFPS.gridy = 8;
+		boxes.add( panelFPS, gbcPanelFPS );
+
+		final JLabel lblNewLabel = new JLabel( "fps" );
+		panelFPS.add( lblNewLabel );
+
+		panelFPS.add( Box.createHorizontalStrut( 10 ) );
+
+		final JSpinner spinnerFPS = new JSpinner();
+		spinnerFPS.setModel( new SpinnerNumberModel( 10, 1, 200, 1 ) );
+		panelFPS.add( spinnerFPS );
+
+		final GridBagConstraints gbcSeparator2 = new GridBagConstraints();
+		gbcSeparator2.anchor = GridBagConstraints.NORTH;
+		gbcSeparator2.fill = GridBagConstraints.HORIZONTAL;
+		gbcSeparator2.insets = new Insets( 0, 0, 5, 0 );
+		gbcSeparator2.gridx = 0;
+		gbcSeparator2.gridy = 9;
+		boxes.add( new JSeparator(), gbcSeparator2 );
+
+		final JPanel panelRecord = new JPanel();
+		final GridBagConstraints gbcPanelRecord = new GridBagConstraints();
+		gbcPanelRecord.anchor = GridBagConstraints.SOUTH;
+		gbcPanelRecord.fill = GridBagConstraints.HORIZONTAL;
+		gbcPanelRecord.gridx = 0;
+		gbcPanelRecord.gridy = 10;
+		boxes.add( panelRecord, gbcPanelRecord );
+		panelRecord.setLayout( new BoxLayout( panelRecord, BoxLayout.X_AXIS ) );
+
+		final JProgressBar progressBar = new JProgressBar();
+		panelRecord.add( progressBar );
+
+		final JButton recordButton = new JButton( "Record" );
+		panelRecord.add( recordButton );
+
+		/*
+		 * Progress bar.
+		 */
+
+		progressBar.getModel().setMinimum( 0 );
+		progressBar.getModel().setMaximum( 100 );
+		progressBar.setStringPainted( true );
+		final ProgressWriter progressWriter = new ProgressWriter()
+		{
+			private final LogStream ls = new LogStream();
+
+			@Override
+			public void setProgress( final double completionRatio )
+			{
+				progressBar.setValue( ( int ) ( 100 * completionRatio ) );
+			}
+
+			@Override
+			public PrintStream out()
+			{
+				return ls;
+			}
+
+			@Override
+			public PrintStream err()
+			{
+				return ls;
+			}
+		};
+
+		/*
+		 * Listeners.
+		 */
+
+		recordButton.addActionListener( new ActionListener()
+		{
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{
+				final String dirname = pathTextField.getText();
+				final int fps = 30;
+				final String filename = "C:/Users/tinevez/Desktop/testexport/testMastodon.mp4";
+				final AbstractBDVRecorder recorder = new MovieFileBDVRecorder( viewer, tracksOverlay, colorBarOverlay, progressWriter, filename, fps );
+
+				final File dir = new File( dirname );
+				if ( !dir.exists() )
+					dir.mkdirs();
+				if ( !dir.exists() || !dir.isDirectory() )
+				{
+					System.err.println( "Invalid export directory " + dirname );
+					return;
+				}
+				final int minTimepointIndex = ( Integer ) spinnerMinTimepoint.getValue();
+				final int maxTimepointIndex = ( Integer ) spinnerMaxTimepoint.getValue();
+				final int width = ( Integer ) spinnerWidth.getValue();
+				final int height = ( Integer ) spinnerHeight.getValue();
+				new Thread()
+				{
+					@Override
+					public void run()
+					{
+						try
+						{
+							recordButton.setEnabled( false );
+							recorder.record( width, height, minTimepointIndex, maxTimepointIndex );
+							recordButton.setEnabled( true );
+						}
+						catch ( final Exception ex )
+						{
+							ex.printStackTrace();
+						}
+					}
+				}.start();
+			}
+		} );
+
+		final JFileChooser fileChooser = new JFileChooser();
+		fileChooser.setMultiSelectionEnabled( false );
+		fileChooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
+
+		final ActionMap am = getRootPane().getActionMap();
+		final InputMap im = getRootPane().getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
+		final Object hideKey = new Object();
+		final Action hideAction = new AbstractAction()
+		{
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{
+				setVisible( false );
+			}
+
+			private static final long serialVersionUID = 1L;
+		};
+		im.put( KeyStroke.getKeyStroke( KeyEvent.VK_ESCAPE, 0 ), hideKey );
+		am.put( hideKey, hideAction );
+
+		pack();
+	}
+
+	@Override
+	public void drawOverlays( final Graphics g )
+	{}
+
+	@Override
+	public void setCanvasSize( final int width, final int height )
+	{
+		spinnerWidth.setValue( width );
+		spinnerHeight.setValue( height );
+	}
+}

--- a/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
+++ b/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
@@ -485,6 +485,7 @@ public class RecordMovieDialog extends DelayedPackDialog implements OverlayRende
 		int fps = prefService.getInt( RecordMovieDialog.class, FPS_KEY, 10 );
 		fps = Math.min( 200, Math.max( 1, fps ) );
 		spinnerFPS.setValue( fps );
+		spinnerFPS.addChangeListener( e -> prefService.put( RecordMovieDialog.class, FPS_KEY, ( ( Number ) spinnerFPS.getValue() ).intValue() ) );
 		setCanvasSize( viewer.getWidth(), viewer.getHeight() );
 
 		/*
@@ -558,7 +559,7 @@ public class RecordMovieDialog extends DelayedPackDialog implements OverlayRende
 		spinnerHeight.setValue( height );
 	}
 
-	private static final class MyToggleDialogAction extends ToggleDialogAction
+	static final class MyToggleDialogAction extends ToggleDialogAction
 	{
 
 		private static final long serialVersionUID = 1L;

--- a/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
+++ b/src/main/java/org/mastodon/views/bdv/export/RecordMovieDialog.java
@@ -66,7 +66,7 @@ import ij.io.LogStream;
 public class RecordMovieDialog extends DelayedPackDialog implements OverlayRenderer
 {
 
-	private static final String RECORD_MOVIE_DIALOG = "record movie dialog";
+	public static final String RECORD_MOVIE_DIALOG = "record movie dialog";
 
 	private static final String[] RECORD_MOVIE_DIALOG_KEYS = { "ctrl R" };
 


### PR DESCRIPTION
This PR adds two commands to the BDV views. They toggle two new dialogs that let the user configure and record movies from a BDV view. Default shortcuts: `ctrl R` & `ctrl shift R`

![Screenshot 2022-06-01 at 14 31 22](https://user-images.githubusercontent.com/3583203/171404961-181bbbc5-47af-4a91-bc8c-3489f7501801.png)

The first one is used to record movies from the display, as it is currently shown in the BDV. 
The second one does the same, but can build a MIP image over a sandwich of images above and below the displayed plane. 

The two dialogs look like this:

![Screenshot 2022-06-01 at 14 39 35](https://user-images.githubusercontent.com/3583203/171406459-4e5e744b-9620-4e21-9295-8dd0db814dbe.png)

![Screenshot 2022-06-01 at 14 39 24](https://user-images.githubusercontent.com/3583203/171406411-43f3b30e-b351-4630-b942-c1d691933d7f.png)

The code is of course derived from the classes with the same name in the BDV core by Tobias. 
I adapted it so that:
- The track overlay is also recorded. And possibly projected in the second case.
- The colorbar overlay is also recorded.
- When building the MIP, take planes above and below, not just below.
- It can export the results as a collection of PNG files, like in the original BDV version.
- If required, generate a MP4, MOV or AVI movie on the fly, using the io.humble library (https://github.com/artclarke/humble-video). This adds 100MB to the mastodon libs.

Regarding the last point, it would make sense to ship these two commands in a separate, optional repo as a plugin, but we first need a plugin infrastructure that has specific plugin for each view, and attach to a view instance. For instance, we want to launch a plugin that knows of THE BDV window it has been launched on.


