### PR TITLE
Support for creating a new Mastodon project directly from an image opened in Fiji.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 			<artifactId>spim_data</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>cisd</groupId>
+			<artifactId>jhdf5</artifactId>
+		<version>19.04.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>ui-behaviour</artifactId>
 		</dependency>
@@ -123,7 +128,7 @@
 			<artifactId>humble-video-all</artifactId>
 			<version>0.3.0</version>
 		</dependency>
-	
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/mastodon/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/mamut/MainWindow.java
@@ -66,6 +66,7 @@ import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
 import javax.swing.WindowConstants;
 
+import org.mastodon.app.MastodonIcons;
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.ui.keymap.Keymap;
@@ -245,13 +246,27 @@ public class MainWindow extends JFrame
 		setResizable( false );
 	}
 
-	private void close( final WindowManager windowManager, final Action saveAction, final WindowEvent trigger )
+	/**
+	 * Closes all the windows opened in Mastodon, this main window. If the model
+	 * has been modified and not saved, prompts the user for confirmation.
+	 * Returns <code>true</code> if Mastodon has been closed, or
+	 * <code>false</code> if the user canceled closing.
+	 * 
+	 * @param windowManager
+	 *            the Mastodon window manager controlled in this windown.
+	 * @param saveAction
+	 *            the action that saves the Mastodon file.
+	 * @param trigger
+	 *            the event that triggered this action.
+	 * @return <code>true</code> if the Mastodon instance has been closed.
+	 */
+	public boolean close( final WindowManager windowManager, final Action saveAction, final WindowEvent trigger )
 	{
 		if ( windowManager != null && windowManager.getAppModel() == null || windowManager.getAppModel().getModel().isSavePoint() )
 		{
 			windowManager.closeAllWindows();
 			dispose();
-			return;
+			return true;
 		}
 
 		// Custom button text
@@ -260,17 +275,21 @@ public class MainWindow extends JFrame
 				"Don't save",
 				"Cancel" };
 		final int choice = JOptionPane.showOptionDialog( this,
-				"Data changed since last save. Do you want to save the project before closing mastodon?",
+				"Data changed since last save. \n"
+						+ "Do you want to save the project before closing mastodon?",
 				"Save before close?",
 				JOptionPane.YES_NO_CANCEL_OPTION,
-				JOptionPane.QUESTION_MESSAGE, null, options, JOptionPane.CANCEL_OPTION );
+				JOptionPane.QUESTION_MESSAGE,
+				MastodonIcons.MASTODON_ICON_MEDIUM,
+				options,
+				JOptionPane.CANCEL_OPTION );
 
 		switch ( choice )
 		{
 		case JOptionPane.CLOSED_OPTION:
 		case JOptionPane.CANCEL_OPTION:
 		default:
-			return;
+			return false;
 
 		case JOptionPane.YES_OPTION:
 			saveAction.actionPerformed( new ActionEvent( trigger.getSource(), trigger.getID(), trigger.paramString() ) );
@@ -281,6 +300,7 @@ public class MainWindow extends JFrame
 				windowManager.closeAllWindows();
 			dispose();
 		}
+		return true;
 	}
 
 	private static void prepareButton( final JButton button, final String txt, final ImageIcon icon )

--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -606,18 +606,29 @@ public class ProjectManager
 		final String canonicalPath = new File( imagePath ).getCanonicalPath();
 		if ( !canonicalPath.endsWith( ".xml" ) )
 		{
-			// Assume it is a plain image file.
-			final ImagePlus imp = IJ.openImage( canonicalPath );
+			final ImagePlus imp;
 
-			// If it does not work file.
-			if ( imp == null )
-				throw new IOException( "Cannot open image " + canonicalPath );
+			// Do we have the ImagePlus already in memory?
+			if ( project instanceof MamutImagePlusProject )
+			{
+				imp = ( ( MamutImagePlusProject ) project ).getImagePlus();
+				// No need to morph.
+				localProject = project;
+			}
+			else
+			{
+				// Assume the path points to a plain image file.
+				imp = IJ.openImage( canonicalPath );
+				// If it does not work tell the user.
+				if ( imp == null )
+					throw new IOException( "Cannot open image " + canonicalPath );
 
-			// Morph the project.
-			localProject = new MamutImagePlusProject( imp );
-			localProject.setProjectRoot( project.getProjectRoot() );
-			localProject.setSpaceUnits( project.getSpaceUnits() );
-			localProject.setTimeUnits( project.getTimeUnits() );
+				// Morph the project.
+				localProject = new MamutImagePlusProject( imp );
+				localProject.setProjectRoot( project.getProjectRoot() );
+				localProject.setSpaceUnits( project.getSpaceUnits() );
+				localProject.setTimeUnits( project.getTimeUnits() );
+			}
 		}
 		else
 		{

--- a/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
+++ b/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
@@ -42,13 +42,11 @@ import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Desktop;
-import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.MouseAdapter;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -58,12 +56,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
-import javax.swing.JTextArea;
 import javax.swing.border.EmptyBorder;
-
-import bdv.spimdata.SpimDataMinimal;
-import bdv.spimdata.XmlIoSpimDataMinimal;
-import mpicbg.spim.data.SpimDataException;
 
 class LauncherGUI extends JPanel
 {
@@ -102,7 +95,7 @@ class LauncherGUI extends JPanel
 
 	final JPanel sidePanel;
 
-	final OpenBDVPanel newMastodonProjectPanel;
+	final NewMastodonProjectPanel newMastodonProjectPanel;
 
 	final OpenRemoteURLPanel openRemoteURLPanel;
 
@@ -211,7 +204,7 @@ class LauncherGUI extends JPanel
 		final WelcomePanel welcomePanel = new WelcomePanel();
 		centralPanel.add( welcomePanel, WELCOME_PANEL_KEY );
 
-		newMastodonProjectPanel = new OpenBDVPanel( "New Mastodon project", "create" );
+		newMastodonProjectPanel = new NewMastodonProjectPanel( "New Mastodon project", "create" );
 		centralPanel.add( newMastodonProjectPanel, NEW_MASTODON_PROJECT_KEY );
 
 		recentProjectsPanel = new RecentProjectsPanel( projectOpener );
@@ -355,103 +348,5 @@ class LauncherGUI extends JPanel
 			g.drawImage( MAINWINDOW_BG, 0, 0, this );
 		}
 
-	}
-
-	class OpenBDVPanel extends JPanel
-	{
-
-		private static final long serialVersionUID = 1L;
-
-		final JButton btnCreate;
-
-		final JLabel labelInfo;
-
-		final JTextArea textAreaFile;
-
-		public OpenBDVPanel( final String panelTitle, final String buttonTitle )
-		{
-			final GridBagLayout gbl_newMastodonProjectPanel = new GridBagLayout();
-			gbl_newMastodonProjectPanel.columnWidths = new int[] { 0, 0 };
-			gbl_newMastodonProjectPanel.rowHeights = new int[] { 35, 70, 65, 0, 0, 0, 0 };
-			gbl_newMastodonProjectPanel.columnWeights = new double[] { 1.0, Double.MIN_VALUE };
-			gbl_newMastodonProjectPanel.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, Double.MIN_VALUE };
-			setLayout( gbl_newMastodonProjectPanel );
-
-			final JLabel lblNewMastodonProject_1 = new JLabel( panelTitle );
-			lblNewMastodonProject_1.setFont( lblNewMastodonProject_1.getFont().deriveFont( lblNewMastodonProject_1.getFont().getStyle() | Font.BOLD ) );
-			final GridBagConstraints gbc_lblNewMastodonProject_1 = new GridBagConstraints();
-			gbc_lblNewMastodonProject_1.insets = new Insets( 5, 5, 5, 5 );
-			gbc_lblNewMastodonProject_1.gridx = 0;
-			gbc_lblNewMastodonProject_1.gridy = 0;
-			add( lblNewMastodonProject_1, gbc_lblNewMastodonProject_1 );
-
-			final JLabel lblBrowseToA = new JLabel( "Browse to a BDV file (xml/h5 pair):" );
-			final GridBagConstraints gbc_lblBrowseToA = new GridBagConstraints();
-			gbc_lblBrowseToA.anchor = GridBagConstraints.SOUTHWEST;
-			gbc_lblBrowseToA.insets = new Insets( 5, 5, 5, 5 );
-			gbc_lblBrowseToA.gridx = 0;
-			gbc_lblBrowseToA.gridy = 1;
-			add( lblBrowseToA, gbc_lblBrowseToA );
-
-			textAreaFile = new JTextArea();
-			textAreaFile.setLineWrap( true );
-			final GridBagConstraints gbc_textAreaFile = new GridBagConstraints();
-			gbc_textAreaFile.insets = new Insets( 5, 5, 5, 5 );
-			gbc_textAreaFile.fill = GridBagConstraints.BOTH;
-			gbc_textAreaFile.gridx = 0;
-			gbc_textAreaFile.gridy = 2;
-			add( textAreaFile, gbc_textAreaFile );
-
-			final JButton btnBrowse = new JButton( "browse" );
-			final GridBagConstraints gbc_btnBrowse = new GridBagConstraints();
-			gbc_btnBrowse.insets = new Insets( 5, 5, 5, 5 );
-			gbc_btnBrowse.anchor = GridBagConstraints.EAST;
-			gbc_btnBrowse.gridx = 0;
-			gbc_btnBrowse.gridy = 3;
-			add( btnBrowse, gbc_btnBrowse );
-
-			labelInfo = new JLabel( "" );
-			final GridBagConstraints gbc_labelInfo = new GridBagConstraints();
-			gbc_labelInfo.insets = new Insets( 5, 5, 5, 5 );
-			gbc_labelInfo.fill = GridBagConstraints.BOTH;
-			gbc_labelInfo.gridx = 0;
-			gbc_labelInfo.gridy = 4;
-			add( labelInfo, gbc_labelInfo );
-
-			btnCreate = new JButton( buttonTitle );
-			final GridBagConstraints gbc_btnCreate = new GridBagConstraints();
-			gbc_btnCreate.anchor = GridBagConstraints.EAST;
-			gbc_btnCreate.gridx = 0;
-			gbc_btnCreate.gridy = 5;
-			add( btnCreate, gbc_btnCreate );
-
-			/*
-			 * Wire listeners.
-			 */
-
-			btnBrowse.addActionListener( l -> LauncherUtil.browseToBDVFile(
-					null,
-					textAreaFile,
-					() -> checkBDVFile(),
-					this ) );
-			LauncherUtil.decorateJComponent( textAreaFile, () -> checkBDVFile() );
-		}
-
-		boolean checkBDVFile()
-		{
-			final File file = new File( textAreaFile.getText() );
-			try
-			{
-				final SpimDataMinimal spimData = new XmlIoSpimDataMinimal().load( file.getAbsolutePath() );
-				final String str = LauncherUtil.buildInfoString( spimData );
-				labelInfo.setText( str );
-				return true;
-			}
-			catch ( final SpimDataException | RuntimeException e )
-			{
-				labelInfo.setText( "<html>Invalid BDV xml/h5 file.<p>" + e.getMessage() + "</html>" );
-				return false;
-			}
-		}
 	}
 }

--- a/src/main/java/org/mastodon/mamut/launcher/LauncherUtil.java
+++ b/src/main/java/org/mastodon/mamut/launcher/LauncherUtil.java
@@ -202,10 +202,8 @@ class LauncherUtil
 		return str.toString();
 	}
 
-	static final String toHtml( final Exception e )
+	static final String toMessage( final Exception e )
 	{
-		return e.getMessage()
-				.replace( "<", "&lt;" )
-				.replace( ">", "&gt;" );
+		return e.getMessage();
 	}
 }

--- a/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
+++ b/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
@@ -408,6 +408,27 @@ public class MastodonLauncher extends JFrame
 							}
 						} );
 					}
+					
+					// Check whether the imp can be found on disk.
+					if ( imp.getOriginalFileInfo() == null ||
+							imp.getOriginalFileInfo().directory == null ||
+							imp.getOriginalFileInfo().fileName == null ||
+							!new File( imp.getOriginalFileInfo().directory, imp.getOriginalFileInfo().fileName ).exists() )
+					{
+						JOptionPane.showMessageDialog( gui,
+								"Warning.\n"
+										+ "\n"
+										+ "The image being used for this new \n"
+										+ "Mastodon project cannot be found \n"
+										+ "on disk.  \n"
+										+ "\n"
+										+ "Mastodon will not be able to reopen it \n"
+										+ "unless you resave the image as a BDV \n"
+										+ "file when saving the Mastodon project. ",
+								"Source image not saved",
+								JOptionPane.WARNING_MESSAGE,
+								MastodonIcons.MASTODON_ICON_MEDIUM );
+					}
 
 					windowManager.getProjectManager().open( new MamutImagePlusProject( imp ) );
 					mainWindow.setVisible( true );

--- a/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
+++ b/src/main/java/org/mastodon/mamut/launcher/MastodonLauncher.java
@@ -195,18 +195,18 @@ public class MastodonLauncher extends JFrame
 			{
 				gui.importSimiBioCellPanel.labelInfo.setText(
 						"<html>Problem reading the SimiBioCell file.<p>" +
-								LauncherUtil.toHtml( e ) + "</html>" );
+								LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			catch ( final ParseException e )
 			{
 				gui.importSimiBioCellPanel.labelInfo.setText(
 						"<html>Problem parsing the SimiBioCell file.<p>" +
-								LauncherUtil.toHtml( e ) + "</html>" );
+								LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			catch ( final SpimDataException e )
 			{
 				gui.importSimiBioCellPanel.labelInfo.setText( "<html>Invalid BDV xml/h5 file.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+						LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			finally
 			{
@@ -267,17 +267,17 @@ public class MastodonLauncher extends JFrame
 			catch ( final ParseException e )
 			{
 				gui.importTGMMPanel.labelInfo.setText( "<html>Could not parse timepoint pattern.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+						LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			catch ( JDOMException | IOException e )
 			{
 				gui.importTGMMPanel.labelInfo.setText( "<html>Malformed TGMM dataset.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+						LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			catch ( final SpimDataException e )
 			{
 				gui.importTGMMPanel.labelInfo.setText( "<html>Invalid BDV xml/h5 file.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+						LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			disabler.reenable();
 		} ).start();
@@ -342,7 +342,7 @@ public class MastodonLauncher extends JFrame
 				catch ( IOException | SpimDataException e )
 				{
 					gui.newMastodonProjectPanel.labelInfo.setText( "<html>Invalid BDV xml/h5 file.<p>" +
-							LauncherUtil.toHtml( e ) + "</html>" );
+							LauncherUtil.toMessage( e ) + "</html>" );
 				}
 				finally
 				{
@@ -416,7 +416,7 @@ public class MastodonLauncher extends JFrame
 				catch ( IOException | SpimDataException e )
 				{
 					gui.newMastodonProjectPanel.labelInfo.setText( "<html>Invalid image.<p>" +
-							LauncherUtil.toHtml( e ) + "</html>" );
+							LauncherUtil.toMessage( e ) + "</html>" );
 				}
 				finally
 				{
@@ -502,7 +502,7 @@ public class MastodonLauncher extends JFrame
 				{
 					gui.openRemoteURLPanel.log.setForeground( Color.RED );
 					gui.openRemoteURLPanel.log.setText( "<html>Problem save to BDV file.<p>" +
-							LauncherUtil.toHtml( e ) + "</html>" );
+							LauncherUtil.toMessage( e ) + "</html>" );
 				}
 
 				/*
@@ -523,7 +523,7 @@ public class MastodonLauncher extends JFrame
 			{
 				gui.openRemoteURLPanel.log.setForeground( Color.RED );
 				gui.openRemoteURLPanel.log.setText( "<html>Problem creating project.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+						LauncherUtil.toMessage( e ) + "</html>" );
 			}
 			finally
 			{
@@ -548,7 +548,7 @@ public class MastodonLauncher extends JFrame
 			return;
 		}
 
-		gui.showPanel( LauncherGUI.IMPORT_MAMUT_KEY );
+		gui.showPanel( LauncherGUI.LOGGER_KEY );
 		new Thread( () -> {
 			try
 			{
@@ -562,8 +562,7 @@ public class MastodonLauncher extends JFrame
 			}
 			catch ( final IOException | SpimDataException e )
 			{
-				gui.importMamutPanel.lblInfo.setText( "<html>Invalid MaMuT file.<p>" +
-						LauncherUtil.toHtml( e ) + "</html>" );
+				gui.error( "Invalid MaMuT file.\n\n" + LauncherUtil.toMessage( e ) );
 			}
 			finally
 			{
@@ -576,11 +575,11 @@ public class MastodonLauncher extends JFrame
 	{
 		final EverythingDisablerAndReenabler disabler = new EverythingDisablerAndReenabler( gui, new Class[] { JLabel.class } );
 		disabler.disable();
-		gui.showPanel( LauncherGUI.LOAD_MASTODON_PROJECT_KEY );
+		gui.showPanel( LauncherGUI.LOGGER_KEY );
 		new Thread( () -> {
 			try
 			{
-				gui.loadMastodonPanel.lblInfo.setText( "" );
+				gui.clearLog();
 				final WindowManager windowManager = createWindowManager();
 				SwingUtilities.invokeLater( () -> {
 
@@ -619,8 +618,7 @@ public class MastodonLauncher extends JFrame
 					}
 					catch ( final IOException | SpimDataException e )
 					{
-						gui.loadMastodonPanel.lblInfo.setText( "<html>Invalid Mastodon file.<p>" +
-								LauncherUtil.toHtml( e ) + "</html>" );
+						gui.error( "Invalid Mastodon file.\n\n" + LauncherUtil.toMessage( e ) );
 					}
 				} );
 			}

--- a/src/main/java/org/mastodon/mamut/launcher/NewMastodonProjectPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/NewMastodonProjectPanel.java
@@ -1,0 +1,184 @@
+package org.mastodon.mamut.launcher;
+
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JSeparator;
+import javax.swing.JTextArea;
+
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import mpicbg.spim.data.SpimDataException;
+
+class NewMastodonProjectPanel extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	final JButton btnCreate;
+
+	final JLabel labelInfo;
+
+	final JTextArea textAreaFile;
+
+	final JComboBox< String > comboBox;
+
+	final JRadioButton rdbtBrowseToBDV;
+
+	public NewMastodonProjectPanel( final String panelTitle, final String buttonTitle )
+	{
+		final GridBagLayout gblNewMastodonProjectPanel = new GridBagLayout();
+		gblNewMastodonProjectPanel.columnWidths = new int[] { 0, 0 };
+		gblNewMastodonProjectPanel.rowHeights = new int[] { 35, 70, 65, 0, 25, 45, 0, 0, 25, 0, 0, 0 };
+		gblNewMastodonProjectPanel.columnWeights = new double[] { 1.0, Double.MIN_VALUE };
+		gblNewMastodonProjectPanel.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, Double.MIN_VALUE };
+		setLayout( gblNewMastodonProjectPanel );
+
+		final JLabel lblNewMastodonProject = new JLabel( panelTitle );
+		lblNewMastodonProject.setFont( lblNewMastodonProject.getFont().deriveFont( lblNewMastodonProject.getFont().getStyle() | Font.BOLD ) );
+		final GridBagConstraints gbcLblNewMastodonProject = new GridBagConstraints();
+		gbcLblNewMastodonProject.insets = new Insets( 5, 5, 5, 5 );
+		gbcLblNewMastodonProject.gridx = 0;
+		gbcLblNewMastodonProject.gridy = 0;
+		add( lblNewMastodonProject, gbcLblNewMastodonProject );
+
+		rdbtBrowseToBDV = new JRadioButton( "Browse to a BDV file (xml/h5 pair):" );
+		final GridBagConstraints gbc_rdbtBrowseToBDV = new GridBagConstraints();
+		gbc_rdbtBrowseToBDV.anchor = GridBagConstraints.SOUTHWEST;
+		gbc_rdbtBrowseToBDV.insets = new Insets( 5, 5, 5, 5 );
+		gbc_rdbtBrowseToBDV.gridx = 0;
+		gbc_rdbtBrowseToBDV.gridy = 1;
+		add( rdbtBrowseToBDV, gbc_rdbtBrowseToBDV );
+
+		textAreaFile = new JTextArea();
+		textAreaFile.setLineWrap( true );
+		final GridBagConstraints gbcTextAreaFile = new GridBagConstraints();
+		gbcTextAreaFile.insets = new Insets( 5, 5, 5, 5 );
+		gbcTextAreaFile.fill = GridBagConstraints.BOTH;
+		gbcTextAreaFile.gridx = 0;
+		gbcTextAreaFile.gridy = 2;
+		add( textAreaFile, gbcTextAreaFile );
+
+		final JButton btnBrowse = new JButton( "browse" );
+		final GridBagConstraints gbcBtnBrowse = new GridBagConstraints();
+		gbcBtnBrowse.insets = new Insets( 5, 5, 5, 5 );
+		gbcBtnBrowse.anchor = GridBagConstraints.EAST;
+		gbcBtnBrowse.gridx = 0;
+		gbcBtnBrowse.gridy = 3;
+		add( btnBrowse, gbcBtnBrowse );
+
+		final GridBagConstraints gbcSeparator1 = new GridBagConstraints();
+		gbcSeparator1.fill = GridBagConstraints.BOTH;
+		gbcSeparator1.insets = new Insets( 5, 5, 5, 5 );
+		gbcSeparator1.gridx = 0;
+		gbcSeparator1.gridy = 4;
+		add( new JSeparator(), gbcSeparator1 );
+
+		final JRadioButton rdbtnOpenedImage = new JRadioButton( "Use an image opened in ImageJ: " );
+		final GridBagConstraints gbc_rdbtnOpenedImage = new GridBagConstraints();
+		gbc_rdbtnOpenedImage.anchor = GridBagConstraints.SOUTHWEST;
+		gbc_rdbtnOpenedImage.insets = new Insets( 5, 5, 5, 5 );
+		gbc_rdbtnOpenedImage.gridx = 0;
+		gbc_rdbtnOpenedImage.gridy = 5;
+		add( rdbtnOpenedImage, gbc_rdbtnOpenedImage );
+
+		comboBox = new JComboBox<>();
+		final GridBagConstraints gbcComboBox = new GridBagConstraints();
+		gbcComboBox.insets = new Insets( 5, 5, 5, 5 );
+		gbcComboBox.fill = GridBagConstraints.HORIZONTAL;
+		gbcComboBox.gridx = 0;
+		gbcComboBox.gridy = 6;
+		add( comboBox, gbcComboBox );
+
+		final JButton btnRefresh = new JButton( "refresh" );
+		final GridBagConstraints gbcBtnRefresh = new GridBagConstraints();
+		gbcBtnRefresh.anchor = GridBagConstraints.EAST;
+		gbcBtnRefresh.insets = new Insets( 5, 5, 5, 5 );
+		gbcBtnRefresh.gridx = 0;
+		gbcBtnRefresh.gridy = 7;
+		add( btnRefresh, gbcBtnRefresh );
+
+		final GridBagConstraints gbcSeparator2 = new GridBagConstraints();
+		gbcSeparator2.fill = GridBagConstraints.BOTH;
+		gbcSeparator2.insets = new Insets( 5, 5, 5, 5 );
+		gbcSeparator2.gridx = 0;
+		gbcSeparator2.gridy = 8;
+		add( new JSeparator(), gbcSeparator2 );
+
+		labelInfo = new JLabel( "" );
+		final GridBagConstraints gbcLabelInfo = new GridBagConstraints();
+		gbcLabelInfo.insets = new Insets( 5, 5, 5, 5 );
+		gbcLabelInfo.fill = GridBagConstraints.BOTH;
+		gbcLabelInfo.gridx = 0;
+		gbcLabelInfo.gridy = 9;
+		add( labelInfo, gbcLabelInfo );
+
+		btnCreate = new JButton( buttonTitle );
+		final GridBagConstraints gbcBtnCreate = new GridBagConstraints();
+		gbcBtnCreate.anchor = GridBagConstraints.EAST;
+		gbcBtnCreate.gridx = 0;
+		gbcBtnCreate.gridy = 10;
+		add( btnCreate, gbcBtnCreate );
+
+		final ButtonGroup buttonGroup = new ButtonGroup();
+		buttonGroup.add( rdbtBrowseToBDV );
+		buttonGroup.add( rdbtnOpenedImage );
+
+		/*
+		 * Wire listeners.
+		 */
+
+		btnBrowse.addActionListener( l -> LauncherUtil.browseToBDVFile(
+				null,
+				textAreaFile,
+				() -> checkBDVFile(),
+				this ) );
+		LauncherUtil.decorateJComponent( textAreaFile, () -> checkBDVFile() );
+
+		rdbtBrowseToBDV.addItemListener( e -> {
+			final boolean selected = rdbtBrowseToBDV.isSelected();
+			btnBrowse.setEnabled( selected );
+			textAreaFile.setEnabled( selected );
+			comboBox.setEnabled( !selected );
+			btnRefresh.setEnabled( !selected );
+		} );
+
+		btnRefresh.addActionListener( e -> refreshImpList() );
+		refreshImpList();
+		rdbtBrowseToBDV.setSelected( true );
+	}
+
+	private void refreshImpList()
+	{
+		final String[] imageNames = ij.WindowManager.getImageTitles();
+		final DefaultComboBoxModel< String > model = new DefaultComboBoxModel<>( imageNames );
+		comboBox.setModel( model );
+	}
+
+	boolean checkBDVFile()
+	{
+		final File file = new File( textAreaFile.getText() );
+		try
+		{
+			final SpimDataMinimal spimData = new XmlIoSpimDataMinimal().load( file.getAbsolutePath() );
+			final String str = LauncherUtil.buildInfoString( spimData );
+			labelInfo.setText( str );
+			return true;
+		}
+		catch ( final SpimDataException | RuntimeException e )
+		{
+			labelInfo.setText( "<html>Invalid BDV xml/h5 file.<p>" + e.getMessage() + "</html>" );
+			return false;
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/launcher/OpenRemoteURLPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/OpenRemoteURLPanel.java
@@ -165,7 +165,7 @@ public class OpenRemoteURLPanel extends JPanel
 		catch ( final MalformedURLException e2 )
 		{
 			log.setForeground( Color.RED.darker() );
-			log.setText( "Malformed URL." + LauncherUtil.toHtml( e2 ) );
+			log.setText( "Malformed URL." + LauncherUtil.toMessage( e2 ) );
 			return;
 		}
 

--- a/src/main/java/org/mastodon/mamut/project/MamutImagePlusProject.java
+++ b/src/main/java/org/mastodon/mamut/project/MamutImagePlusProject.java
@@ -1,0 +1,47 @@
+package org.mastodon.mamut.project;
+
+import java.io.File;
+
+import ij.ImagePlus;
+import ij.io.FileInfo;
+
+/**
+ * For Mamut projects that are based on an ImagePlus instead of a BDV file.
+ * Ultimately, the imp will have to be converted, but this subclass offers the
+ * means for Mastodon to play with an ImagePlus opened in Fiji in the meantime.
+ */
+public class MamutImagePlusProject extends MamutProject
+{
+
+	private final ImagePlus imp;
+
+	public MamutImagePlusProject( final ImagePlus imp )
+	{
+		super( null, getImagePath( imp ) );
+		this.imp = imp;
+	}
+
+	public ImagePlus getImagePlus()
+	{
+		return imp;
+	}
+
+	private static File getImagePath( final ImagePlus imp )
+	{
+		final FileInfo fileInfo = imp.getOriginalFileInfo();
+		String imageFileName;
+		String imageFolder;
+		if ( null != fileInfo )
+		{
+			imageFileName = fileInfo.fileName;
+			imageFolder = fileInfo.directory;
+		}
+		else
+		{
+			imageFileName = imp.getShortTitle();
+			imageFolder = "";
+		}
+		return new File( imageFolder, imageFileName );
+	}
+
+}

--- a/src/main/java/org/mastodon/util/BDVImagePlusExporter.java
+++ b/src/main/java/org/mastodon/util/BDVImagePlusExporter.java
@@ -1,0 +1,499 @@
+/*-
+ * #%L
+ * Fiji plugins for starting BigDataViewer and exporting data.
+ * %%
+ * Copyright (C) 2014 - 2021 BigDataViewer developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package org.mastodon.util;
+
+import java.awt.AWTEvent;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.TextField;
+import java.awt.event.ItemEvent;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import bdv.export.ExportMipmapInfo;
+import bdv.export.ExportScalePyramid.AfterEachPlane;
+import bdv.export.ExportScalePyramid.LoopbackHeuristic;
+import bdv.export.ProgressWriter;
+import bdv.export.ProposeMipmaps;
+import bdv.export.SubTaskProgressWriter;
+import bdv.export.WriteSequenceToHdf5;
+import bdv.ij.export.imgloader.ImagePlusImgLoader;
+import bdv.ij.export.imgloader.ImagePlusImgLoader.MinMaxOption;
+import bdv.ij.util.PluginHelper;
+import bdv.ij.util.ProgressWriterIJ;
+import bdv.img.hdf5.Hdf5ImageLoader;
+import bdv.img.hdf5.Partition;
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.XmlIoSpimDataMinimal;
+import fiji.util.gui.GenericDialogPlus;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.gui.DialogListener;
+import ij.gui.GenericDialog;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
+import mpicbg.spim.data.sequence.Channel;
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.TimePoints;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.util.Intervals;
+
+/**
+ * Function to export the current image to xml/hdf5. Taken and adapted from
+ * BDV-core fiji.
+ * 
+ * @see https://github.com/bigdataviewer/bigdataviewer_fiji/blob/master/src/main/java/bdv/ij/ExportImagePlusPlugIn.java
+ *
+ * @author Tobias Pietzsch &lt;tobias.pietzsch@gmail.com&gt;
+ */
+public class BDVImagePlusExporter
+{
+
+	public static final File export( final ImagePlus imp, final String targetPath )
+	{
+
+		// make sure there is one
+		if ( imp == null )
+			return null;
+
+		// check the image type
+		switch ( imp.getType() )
+		{
+		case ImagePlus.GRAY8:
+		case ImagePlus.GRAY16:
+		case ImagePlus.GRAY32:
+			break;
+		default:
+			IJ.showMessage( "Only 8, 16, 32-bit images are supported currently!" );
+			return null;
+		}
+
+		// get calibration and image size
+		final double pw = imp.getCalibration().pixelWidth;
+		final double ph = imp.getCalibration().pixelHeight;
+		final double pd = imp.getCalibration().pixelDepth;
+		String punit = imp.getCalibration().getUnit();
+		if ( punit == null || punit.isEmpty() )
+			punit = "pixel";
+		final FinalVoxelDimensions voxelSize = new FinalVoxelDimensions( punit, pw, ph, pd );
+		final int w = imp.getWidth();
+		final int h = imp.getHeight();
+		final int d = imp.getNSlices();
+		final FinalDimensions size = new FinalDimensions( w, h, d );
+
+		// propose reasonable mipmap settings
+		final ExportMipmapInfo autoMipmapSettings = ProposeMipmaps.proposeMipmaps( new BasicViewSetup( 0, "", size, voxelSize ) );
+
+		// show dialog to get output paths, resolutions, subdivisions, min-max option
+		final Parameters params = getParameters(
+				imp.getDisplayRangeMin(),
+				imp.getDisplayRangeMax(),
+				autoMipmapSettings,
+				targetPath );
+		if ( params == null )
+			return null;
+
+		final ProgressWriter progressWriter = new ProgressWriterIJ();
+		progressWriter.out().println( "starting export..." );
+
+		// create ImgLoader wrapping the image
+		final ImagePlusImgLoader< ? > imgLoader;
+		switch ( imp.getType() )
+		{
+		case ImagePlus.GRAY8:
+			imgLoader = ImagePlusImgLoader.createGray8( imp, params.minMaxOption, params.rangeMin, params.rangeMax );
+			break;
+		case ImagePlus.GRAY16:
+			imgLoader = ImagePlusImgLoader.createGray16( imp, params.minMaxOption, params.rangeMin, params.rangeMax );
+			break;
+		case ImagePlus.GRAY32:
+		default:
+			imgLoader = ImagePlusImgLoader.createGray32( imp, params.minMaxOption, params.rangeMin, params.rangeMax );
+			break;
+		}
+
+		final int numTimepoints = imp.getNFrames();
+		final int numSetups = imp.getNChannels();
+
+		// create SourceTransform from the images calibration
+		final AffineTransform3D sourceTransform = new AffineTransform3D();
+		sourceTransform.set( pw, 0, 0, 0, 0, ph, 0, 0, 0, 0, pd, 0 );
+
+		// write hdf5
+		final HashMap< Integer, BasicViewSetup > setups = new HashMap<>( numSetups );
+		for ( int s = 0; s < numSetups; ++s )
+		{
+			final BasicViewSetup setup = new BasicViewSetup( s, String.format( "channel %d", s + 1 ), size, voxelSize );
+			setup.setAttribute( new Channel( s + 1 ) );
+			setups.put( s, setup );
+		}
+		final ArrayList< TimePoint > timepoints = new ArrayList<>( numTimepoints );
+		for ( int t = 0; t < numTimepoints; ++t )
+			timepoints.add( new TimePoint( t ) );
+		final SequenceDescriptionMinimal seq = new SequenceDescriptionMinimal( new TimePoints( timepoints ), setups, imgLoader, null );
+
+		Map< Integer, ExportMipmapInfo > perSetupExportMipmapInfo;
+		perSetupExportMipmapInfo = new HashMap<>();
+		final ExportMipmapInfo mipmapInfo = new ExportMipmapInfo( params.resolutions, params.subdivisions );
+		for ( final BasicViewSetup setup : seq.getViewSetupsOrdered() )
+			perSetupExportMipmapInfo.put( setup.getId(), mipmapInfo );
+
+		// LoopBackHeuristic:
+		// - If saving more than 8x on pixel reads use the loopback image over
+		//   original image
+		// - For virtual stacks also consider the cache size that would be
+		//   required for all original planes contributing to a "plane of
+		//   blocks" at the current level. If this is more than 1/4 of
+		//   available memory, use the loopback image.
+		final boolean isVirtual = imp.getStack().isVirtual();
+		final long planeSizeInBytes = imp.getWidth() * imp.getHeight() * imp.getBytesPerPixel();
+		final long ijMaxMemory = IJ.maxMemory();
+		final int numCellCreatorThreads = Math.max( 1, PluginHelper.numThreads() - 1 );
+		final LoopbackHeuristic loopbackHeuristic = new LoopbackHeuristic()
+		{
+			@Override
+			public boolean decide( final RandomAccessibleInterval< ? > originalImg, final int[] factorsToOriginalImg, final int previousLevel, final int[] factorsToPreviousLevel, final int[] chunkSize )
+			{
+				if ( previousLevel < 0 )
+					return false;
+
+				if ( Intervals.numElements( factorsToOriginalImg ) / Intervals.numElements( factorsToPreviousLevel ) >= 8 )
+					return true;
+
+				if ( isVirtual )
+				{
+					final long requiredCacheSize = planeSizeInBytes * factorsToOriginalImg[ 2 ] * chunkSize[ 2 ];
+					if ( requiredCacheSize > ijMaxMemory / 4 )
+						return true;
+				}
+
+				return false;
+			}
+		};
+
+		final AfterEachPlane afterEachPlane = new AfterEachPlane()
+		{
+			@Override
+			public void afterEachPlane( final boolean usedLoopBack )
+			{
+				if ( !usedLoopBack && isVirtual )
+				{
+					final long free = Runtime.getRuntime().freeMemory();
+					final long total = Runtime.getRuntime().totalMemory();
+					final long max = Runtime.getRuntime().maxMemory();
+					final long actuallyFree = max - total + free;
+
+					if ( actuallyFree < max / 2 )
+						imgLoader.clearCache();
+				}
+			}
+
+		};
+
+		final ArrayList< Partition > partitions;
+		if ( params.split )
+		{
+			final String xmlFilename = params.seqFile.getAbsolutePath();
+			final String basename = xmlFilename.endsWith( ".xml" ) ? xmlFilename.substring( 0, xmlFilename.length() - 4 ) : xmlFilename;
+			partitions = Partition.split( timepoints, seq.getViewSetupsOrdered(), params.timepointsPerPartition, params.setupsPerPartition, basename );
+
+			for ( int i = 0; i < partitions.size(); ++i )
+			{
+				final Partition partition = partitions.get( i );
+				final ProgressWriter p = new SubTaskProgressWriter( progressWriter, 0, 0.95 * i / partitions.size() );
+				WriteSequenceToHdf5.writeHdf5PartitionFile( seq, perSetupExportMipmapInfo, params.deflate, partition, loopbackHeuristic, afterEachPlane, numCellCreatorThreads, p );
+			}
+			WriteSequenceToHdf5.writeHdf5PartitionLinkFile( seq, perSetupExportMipmapInfo, partitions, params.hdf5File );
+		}
+		else
+		{
+			partitions = null;
+			WriteSequenceToHdf5.writeHdf5File( seq, perSetupExportMipmapInfo, params.deflate, params.hdf5File, loopbackHeuristic, afterEachPlane, numCellCreatorThreads, new SubTaskProgressWriter( progressWriter, 0, 0.95 ) );
+		}
+
+		// write xml sequence description
+		final Hdf5ImageLoader hdf5Loader = new Hdf5ImageLoader( params.hdf5File, partitions, null, false );
+		final SequenceDescriptionMinimal seqh5 = new SequenceDescriptionMinimal( seq, hdf5Loader );
+
+		final ArrayList< ViewRegistration > registrations = new ArrayList<>();
+		for ( int t = 0; t < numTimepoints; ++t )
+			for ( int s = 0; s < numSetups; ++s )
+				registrations.add( new ViewRegistration( t, s, sourceTransform ) );
+
+		final File basePath = params.seqFile.getParentFile();
+		final SpimDataMinimal spimData = new SpimDataMinimal( basePath, seqh5, new ViewRegistrations( registrations ) );
+
+		try
+		{
+			new XmlIoSpimDataMinimal().save( spimData, params.seqFile.getAbsolutePath() );
+			progressWriter.setProgress( 1.0 );
+		}
+		catch ( final Exception e )
+		{
+			throw new RuntimeException( e );
+		}
+		progressWriter.out().println( "done" );
+		return params.seqFile;
+	}
+
+	protected static class Parameters
+	{
+		final boolean setMipmapManual;
+
+		final int[][] resolutions;
+
+		final int[][] subdivisions;
+
+		final File seqFile;
+
+		final File hdf5File;
+
+		final MinMaxOption minMaxOption;
+
+		final double rangeMin;
+
+		final double rangeMax;
+
+		final boolean deflate;
+
+		final boolean split;
+
+		final int timepointsPerPartition;
+
+		final int setupsPerPartition;
+
+		public Parameters(
+				final boolean setMipmapManual, final int[][] resolutions, final int[][] subdivisions,
+				final File seqFile, final File hdf5File,
+				final MinMaxOption minMaxOption, final double rangeMin, final double rangeMax, final boolean deflate,
+				final boolean split, final int timepointsPerPartition, final int setupsPerPartition )
+		{
+			this.setMipmapManual = setMipmapManual;
+			this.resolutions = resolutions;
+			this.subdivisions = subdivisions;
+			this.seqFile = seqFile;
+			this.hdf5File = hdf5File;
+			this.minMaxOption = minMaxOption;
+			this.rangeMin = rangeMin;
+			this.rangeMax = rangeMax;
+			this.deflate = deflate;
+			this.split = split;
+			this.timepointsPerPartition = timepointsPerPartition;
+			this.setupsPerPartition = setupsPerPartition;
+		}
+	}
+
+	static boolean lastSetMipmapManual = false;
+
+	static String lastSubsampling = "{1,1,1}, {2,2,1}, {4,4,2}";
+
+	static String lastChunkSizes = "{32,32,4}, {16,16,8}, {8,8,8}";
+
+	static int lastMinMaxChoice = 2;
+
+	static double lastMin = 0;
+
+	static double lastMax = 65535;
+
+	static boolean lastSplit = false;
+
+	static int lastTimepointsPerPartition = 0;
+
+	static int lastSetupsPerPartition = 0;
+
+	static boolean lastDeflate = true;
+
+	private static Parameters getParameters(
+			final double impMin,
+			final double impMax,
+			final ExportMipmapInfo autoMipmapSettings,
+			final String defaultPath )
+	{
+		if ( lastMinMaxChoice == 0 ) // use ImageJs...
+		{
+			lastMin = impMin;
+			lastMax = impMax;
+		}
+
+		while ( true )
+		{
+			final GenericDialogPlus gd = new GenericDialogPlus( "Export to BDV file format" );
+
+			gd.addCheckbox( "manual_mipmap_setup", lastSetMipmapManual );
+			final Checkbox cManualMipmap = ( Checkbox ) gd.getCheckboxes().lastElement();
+			gd.addStringField( "Subsampling_factors", lastSubsampling, 25 );
+			final TextField tfSubsampling = ( TextField ) gd.getStringFields().lastElement();
+			gd.addStringField( "Hdf5_chunk_sizes", lastChunkSizes, 25 );
+			final TextField tfChunkSizes = ( TextField ) gd.getStringFields().lastElement();
+
+			gd.addMessage( "" );
+			final String[] minMaxChoices = new String[] {
+					"Use ImageJ's current min/max setting",
+					"Compute min/max of the (hyper-)stack",
+					"Use values specified below" };
+			gd.addChoice( "Value_range", minMaxChoices, minMaxChoices[ lastMinMaxChoice ] );
+			final Choice cMinMaxChoices = (Choice) gd.getChoices().lastElement();
+			gd.addNumericField( "Min", lastMin, 0 );
+			final TextField tfMin = (TextField) gd.getNumericFields().lastElement();
+			gd.addNumericField( "Max", lastMax, 0 );
+			final TextField tfMax = (TextField) gd.getNumericFields().lastElement();
+
+			gd.addMessage( "" );
+			gd.addCheckbox( "split_hdf5", lastSplit );
+			final Checkbox cSplit = ( Checkbox ) gd.getCheckboxes().lastElement();
+			gd.addNumericField( "timepoints_per_partition", lastTimepointsPerPartition, 0, 25, "" );
+			final TextField tfSplitTimepoints = ( TextField ) gd.getNumericFields().lastElement();
+			gd.addNumericField( "setups_per_partition", lastSetupsPerPartition, 0, 25, "" );
+			final TextField tfSplitSetups = ( TextField ) gd.getNumericFields().lastElement();
+
+			gd.addMessage( "" );
+			gd.addCheckbox( "use_deflate_compression", lastDeflate );
+
+			gd.addMessage( "" );
+			PluginHelper.addSaveAsFileField( gd, "Export_path", defaultPath, 25 );
+
+			final String autoSubsampling = ProposeMipmaps.getArrayString( autoMipmapSettings.getExportResolutions() );
+			final String autoChunkSizes = ProposeMipmaps.getArrayString( autoMipmapSettings.getSubdivisions() );
+			gd.addDialogListener( new DialogListener()
+			{
+				@Override
+				public boolean dialogItemChanged( final GenericDialog dialog, final AWTEvent e )
+				{
+					gd.getNextBoolean();
+					gd.getNextString();
+					gd.getNextString();
+					gd.getNextChoiceIndex();
+					gd.getNextNumber();
+					gd.getNextNumber();
+					gd.getNextBoolean();
+					gd.getNextNumber();
+					gd.getNextNumber();
+					gd.getNextBoolean();
+					gd.getNextString();
+					if ( e instanceof ItemEvent && e.getID() == ItemEvent.ITEM_STATE_CHANGED && e.getSource() == cMinMaxChoices )
+					{
+						final boolean enable = cMinMaxChoices.getSelectedIndex() == 2;
+						tfMin.setEnabled( enable );
+						tfMax.setEnabled( enable );
+					}
+					else if ( e instanceof ItemEvent && e.getID() == ItemEvent.ITEM_STATE_CHANGED && e.getSource() == cManualMipmap )
+					{
+						final boolean useManual = cManualMipmap.getState();
+						tfSubsampling.setEnabled( useManual );
+						tfChunkSizes.setEnabled( useManual );
+						if ( !useManual )
+						{
+							tfSubsampling.setText( autoSubsampling );
+							tfChunkSizes.setText( autoChunkSizes );
+						}
+					}
+					else if ( e instanceof ItemEvent && e.getID() == ItemEvent.ITEM_STATE_CHANGED && e.getSource() == cSplit )
+					{
+						final boolean split = cSplit.getState();
+						tfSplitTimepoints.setEnabled( split );
+						tfSplitSetups.setEnabled( split );
+					}
+					return true;
+				}
+			} );
+
+			final boolean enable = lastMinMaxChoice == 2;
+			tfMin.setEnabled( enable );
+			tfMax.setEnabled( enable );
+
+			tfSubsampling.setEnabled( lastSetMipmapManual );
+			tfChunkSizes.setEnabled( lastSetMipmapManual );
+			if ( !lastSetMipmapManual )
+			{
+				tfSubsampling.setText( autoSubsampling );
+				tfChunkSizes.setText( autoChunkSizes );
+			}
+
+			tfSplitTimepoints.setEnabled( lastSplit );
+			tfSplitSetups.setEnabled( lastSplit );
+
+			gd.showDialog();
+			if ( gd.wasCanceled() )
+				return null;
+
+			lastSetMipmapManual = gd.getNextBoolean();
+			lastSubsampling = gd.getNextString();
+			lastChunkSizes = gd.getNextString();
+			lastMinMaxChoice = gd.getNextChoiceIndex();
+			lastMin = gd.getNextNumber();
+			lastMax = gd.getNextNumber();
+			lastSplit = gd.getNextBoolean();
+			lastTimepointsPerPartition = ( int ) gd.getNextNumber();
+			lastSetupsPerPartition = ( int ) gd.getNextNumber();
+			lastDeflate = gd.getNextBoolean();
+			final String selectedPath = gd.getNextString();
+
+			// parse mipmap resolutions and cell sizes
+			final int[][] resolutions = PluginHelper.parseResolutionsString( lastSubsampling );
+			final int[][] subdivisions = PluginHelper.parseResolutionsString( lastChunkSizes );
+			if ( resolutions.length == 0 )
+			{
+				IJ.showMessage( "Cannot parse subsampling factors " + lastSubsampling );
+				continue;
+			}
+			if ( subdivisions.length == 0 )
+			{
+				IJ.showMessage( "Cannot parse hdf5 chunk sizes " + lastChunkSizes );
+				continue;
+			}
+			else if ( resolutions.length != subdivisions.length )
+			{
+				IJ.showMessage( "subsampling factors and hdf5 chunk sizes must have the same number of elements" );
+				continue;
+			}
+
+			final MinMaxOption minMaxOption;
+			if ( lastMinMaxChoice == 0 )
+				minMaxOption = MinMaxOption.TAKE_FROM_IMAGEPROCESSOR;
+			else if ( lastMinMaxChoice == 1 )
+				minMaxOption = MinMaxOption.COMPUTE;
+			else
+				minMaxOption = MinMaxOption.SET;
+
+			String seqFilename = selectedPath;
+			if ( !seqFilename.endsWith( ".xml" ) )
+				seqFilename += ".xml";
+			final File seqFile = new File( seqFilename );
+			final File parent = seqFile.getParentFile();
+			if ( parent == null || !parent.exists() || !parent.isDirectory() )
+			{
+				IJ.showMessage( "Invalid export filename " + seqFilename );
+				continue;
+			}
+			final String hdf5Filename = seqFilename.substring( 0, seqFilename.length() - 4 ) + ".h5";
+			final File hdf5File = new File( hdf5Filename );
+
+			return new Parameters( lastSetMipmapManual, resolutions, subdivisions, seqFile, hdf5File, minMaxOption, lastMin, lastMax, lastDeflate, lastSplit, lastTimepointsPerPartition, lastSetupsPerPartition );		}
+	}
+}

--- a/src/test/java/org/mastodon/mamut/MastodonInFiji.java
+++ b/src/test/java/org/mastodon/mamut/MastodonInFiji.java
@@ -1,12 +1,73 @@
 package org.mastodon.mamut;
 
+import java.io.IOException;
+import java.util.Locale;
+
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import org.mastodon.mamut.launcher.MastodonLauncherCommand;
+import org.mastodon.mamut.project.MamutImagePlusProject;
+import org.scijava.Context;
+
+import ij.IJ;
 import ij.ImageJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.SpimDataException;
 
 public class MastodonInFiji
 {
 
-	public static void main( final String[] args )
+	public static void main( final String[] args ) throws Exception
 	{
+		setSystemLookAndFeelAndLocale();
 		ImageJ.main( args );
+
+		final String path = "/Users/tinevez/Desktop/mitosis.tif";
+
+		final ImagePlus imp = IJ.openImage( path );
+//		final ImagePlus imp = IJ.openVirtual( path );
+
+		imp.show();
+
+		final MastodonLauncherCommand launcher = new MastodonLauncherCommand();
+		try (Context context = new Context())
+		{
+			context.inject( launcher );
+			launcher.run();
+		}
+	}
+
+	public static void main2( final String[] args ) throws IOException, SpimDataException
+	{
+		setSystemLookAndFeelAndLocale();
+		ImageJ.main( args );
+		
+		final String path = "/Users/tinevez/Desktop/mitosis.tif";
+		
+		final ImagePlus imp = IJ.openImage( path );
+//		final ImagePlus imp = IJ.openVirtual( path );
+		
+		imp.show();
+
+		final MamutImagePlusProject project = new MamutImagePlusProject( imp );
+
+		final WindowManager wm = new WindowManager( new Context() );
+		wm.getProjectManager().open( project );
+		
+		new MainWindow( wm ).setVisible( true );
+	}
+
+	private static final void setSystemLookAndFeelAndLocale()
+	{
+		Locale.setDefault( Locale.ROOT );
+		try
+		{
+			UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		}
+		catch ( ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e )
+		{
+			e.printStackTrace();
+		}
 	}
 }

--- a/src/test/java/org/mastodon/mamut/importer/trackmate/MaMuTExporterTest.java
+++ b/src/test/java/org/mastodon/mamut/importer/trackmate/MaMuTExporterTest.java
@@ -331,7 +331,7 @@ public class MaMuTExporterTest
 
 		final String spimDataXmlFilename = project.getDatasetXmlFile().getAbsolutePath();
 		final SpimDataMinimal spimData = new XmlIoSpimDataMinimal().load( spimDataXmlFilename );
-		final SharedBigDataViewerData sharedBdvData = new SharedBigDataViewerData( spimDataXmlFilename, spimData, new ViewerOptions(), () -> {} );
+		final SharedBigDataViewerData sharedBdvData = SharedBigDataViewerData.fromSpimDataXmlFile( spimDataXmlFilename, new ViewerOptions(), () -> {} );
 
 		final Model model = new Model( project.getSpaceUnits(), project.getTimeUnits() );
 		loadProject( context, project, model );


### PR DESCRIPTION
Solves #124 

This PR makes it possible to create a new Mastodon project directly from an image opened in Fiji. The core code to wrap a `SpimData` around an `ImagePlus` is based on existing code by Tobias in the BDV Fiji plugins. The proper handling of this feature in Mastodon mainly requires  dealing with warning the user and ultimately offering exporting the image to a BDV file.

It works like this:

The launcher "New Mastodon project" as a new option, listing the images opened in Fiji as possible source.

![Screenshot 2022-07-06 at 14 02 22](https://user-images.githubusercontent.com/3583203/177545586-ea296a32-0637-4935-b2e0-a812720f9445.png)


Project created this way looks like classic Mastodon project, as if the image source had only 1 resolution level. 
The LUT and display scale are imported from the ImagePlus as well.
![Screenshot 2022-07-06 at 14 05 36](https://user-images.githubusercontent.com/3583203/177546136-3456647c-8224-4dc2-b05a-2d194857a943.png)


The image data in Mastodon **wraps** the ImagePlus data. If the user modify the image in the ImagePlus window, the modifications will be shown, and used, in Mastodon:
![Screenshot 2022-07-06 at 14 06 57](https://user-images.githubusercontent.com/3583203/177546359-7a8b1b99-dba0-412d-a5a7-460e4d9807c9.png)


Because of this we have to be extra careful when the user closes the ImagePlus. So the ImagePlus window is modified to listen to the user closing the image, and shows this message:
![Screenshot 2022-07-06 at 14 11 45](https://user-images.githubusercontent.com/3583203/177547163-703ab93c-f134-4183-9c5b-b9ec95657c6f.png)
If the user clicks 'Yes', both the image and all Mastodon windows are closed. 


When the user wants to save such a Mastodon project, they are offered to export the image to a BDV file:
![Screenshot 2022-07-06 at 14 17 40](https://user-images.githubusercontent.com/3583203/177548285-bb59da39-757b-4b2f-b4c1-1e594f206b91.png)

It then shows the familiar dialog of the BDV export (the code is copied from the BDV Fiji plugin):
![Screenshot 2022-07-06 at 14 25 26](https://user-images.githubusercontent.com/3583203/177549621-1498c63e-2e26-49f9-b940-6ce62c03e7ec.png)

After the export, the user is prompted to save the Mastodon project in a standard way. The Mastodon session will now run using the new BDV file as source for the image data, not on the ImagePlus anymore. The warning that appeared when trying to close the image is removed.

If the user chooses **not** to export to a BDV file, a standard project file will be created, but with a dataset field pointing to where the image file is saved (as inferred from the `FileInfo` of the ImagePlus). Such a project can now be reloaded by Mastodon normally, without warning. 

TODOs:
- [x] Warn the user if they reload a Mastodon project based on an image file, and propose to export to BDV by clickong on "save as".
- [x] When saving such a project based on an image file, check that the image file actually exists. If not warn the user that the Mastodon project will fail to reload and tell them to save the image file themselves or export to BDV.
- [x] If the user clicks 'Yes' and the project was modified, we need to propose saving the Mastodon project *after offering to export the image to a BDV file*.

