### PR TITLE
Menu and title fixes

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
+++ b/src/main/java/org/mastodon/mamut/MamutMenuBuilder.java
@@ -66,12 +66,12 @@ public class MamutMenuBuilder extends ViewMenuBuilder
 
 		menuTexts.put( WindowManager.NEW_BDV_VIEW, "New Bdv" );
 		menuTexts.put( WindowManager.NEW_TRACKSCHEME_VIEW, "New TrackScheme" );
-		menuTexts.put( WindowManager.NEW_TABLE_VIEW, "New data table" );
-		menuTexts.put( WindowManager.NEW_SELECTION_TABLE_VIEW, "New selection table" );
-		menuTexts.put( WindowManager.NEW_GRAPHER_VIEW, "New grapher" );
-		menuTexts.put( WindowManager.NEW_BRANCH_BDV_VIEW, "New branch Bdv" );
-		menuTexts.put( WindowManager.NEW_BRANCH_TRACKSCHEME_VIEW, "New branch TrackScheme" );
-		menuTexts.put( WindowManager.NEW_HIERARCHY_TRACKSCHEME_VIEW, "New hierarchy TrackScheme" );
+		menuTexts.put( WindowManager.NEW_TABLE_VIEW, "New Data table" );
+		menuTexts.put( WindowManager.NEW_SELECTION_TABLE_VIEW, "New Selection table" );
+		menuTexts.put( WindowManager.NEW_GRAPHER_VIEW, "New Grapher" );
+		menuTexts.put( WindowManager.NEW_BRANCH_BDV_VIEW, "New Bdv Branch" );
+		menuTexts.put( WindowManager.NEW_BRANCH_TRACKSCHEME_VIEW, "New TrackScheme Branch" );
+		menuTexts.put( WindowManager.NEW_HIERARCHY_TRACKSCHEME_VIEW, "New TrackScheme Hierarchy" );
 		menuTexts.put( WindowManager.PREFERENCES_DIALOG, "Preferences..." );
 
 		menuTexts.put( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL, "Settings Toolbar" );

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -332,8 +332,10 @@ public class WindowManager
 		newTrackSchemeViewAction.setEnabled( appModel != null );
 		newTableViewAction.setEnabled( appModel != null );
 		newSelectionTableViewAction.setEnabled( appModel != null );
+		newGrapherViewAction.setEnabled( appModel != null );
 		newBranchBdvViewAction.setEnabled( appModel != null );
 		newBranchTrackSchemeViewAction.setEnabled( appModel != null );
+		newHierarchyTrackSchemeViewAction.setEnabled( appModel != null );
 		editTagSetsAction.setEnabled( appModel != null );
 		featureComputationAction.setEnabled( appModel != null );
 	}

--- a/src/main/java/org/mastodon/views/grapher/display/DataDisplayFrame.java
+++ b/src/main/java/org/mastodon/views/grapher/display/DataDisplayFrame.java
@@ -82,7 +82,7 @@ public class DataDisplayFrame< V extends Vertex< E > & HasTimepoint & HasLabel, 
 			final ContextChooser< V > contextChooser,
 			final DataDisplayOptions optional )
 	{
-		super( "Data" );
+		super( "Grapher" );
 
 		/*
 		 * Plot panel.


### PR DESCRIPTION
I have accidentally discovered:
![Screenshot_20220727_151026](https://user-images.githubusercontent.com/10509335/181273281-e86b23e3-8ba1-40c4-af34-b659b8af919d.png)

and while fixing it, I synced item names and camelCaseiness with the actual window Names

[ this one replaces the wrong #184 ]