### PR TITLE
Fix LineageTreeLayout to work for graphs containing merging spots

### DIFF
--- a/src/main/java/org/mastodon/views/trackscheme/display/ShowSelectedTracksActions.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/ShowSelectedTracksActions.java
@@ -30,15 +30,12 @@ package org.mastodon.views.trackscheme.display;
 
 import javax.swing.SwingUtilities;
 
-import org.mastodon.adapter.SelectionModelAdapter;
 import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefSet;
 import org.mastodon.collection.ref.RefArrayList;
 import org.mastodon.collection.ref.RefSetImp;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Vertex;
-import org.mastodon.mamut.model.branch.BranchLink;
-import org.mastodon.mamut.model.branch.BranchSpot;
 import org.mastodon.model.RootsModel;
 import org.mastodon.model.SelectionModel;
 import org.mastodon.ui.keymap.CommandDescriptionProvider;
@@ -193,15 +190,14 @@ public class ShowSelectedTracksActions<V extends Vertex<E>, E extends Edge<V>>
 	private RefList<TrackSchemeVertex> filterRootNodes( RefSet<TrackSchemeVertex> selectedVertices )
 	{
 		RefList<TrackSchemeVertex> roots = new RefArrayList<>( viewGraph.getVertexPool() );
-		DepthFirstIteration<TrackSchemeVertex> df = new DepthFirstIteration<>( viewGraph );
-		df.setExcludeNodeAction( node -> {
-			boolean isSelected = selectedVertices.contains( node );
-			if(isSelected)
-				roots.add(node);
-			return isSelected;
-		} );
 		for( TrackSchemeVertex realRoot : LexicographicalVertexOrder.sort( viewGraph, viewGraph.getRoots() ) )
-			df.runForRoot( realRoot );
+			for( DepthFirstIteration.Step<TrackSchemeVertex> step : DepthFirstIteration.forRoot(viewGraph, realRoot) ) {
+				TrackSchemeVertex node = step.node();
+				if(selectedVertices.contains( node )) {
+					roots.add( node );
+					step.truncate();
+				}
+			}
 		return roots;
 	}
 

--- a/src/test/java/org/mastodon/views/trackscheme/LineageTreeLayoutImpTest.java
+++ b/src/test/java/org/mastodon/views/trackscheme/LineageTreeLayoutImpTest.java
@@ -1,0 +1,114 @@
+package org.mastodon.views.trackscheme;
+
+import org.junit.Test;
+import org.mastodon.adapter.SelectionModelAdapter;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.ModelGraphTrackSchemeProperties;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.DefaultRootsModel;
+import org.mastodon.model.DefaultSelectionModel;
+import org.mastodon.model.RootsModel;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.ui.coloring.GraphColorGeneratorAdapter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link LineageTreeLayoutImp}
+ */
+public class LineageTreeLayoutImpTest
+{
+	/**
+	 * Tests if the {@link LineageTreeLayout} properly layouts a graph that is
+	 * shaped like this:
+	 * <pre>
+	 *   O
+	 *  / \
+	 * O   O
+	 *  \ /
+	 *   O
+	 * </pre>
+	 */
+	@Test
+	public void testDiamondGraph()
+	{
+		// setup
+		ModelGraph graph = initDiamondModelGraph();
+		TrackSchemeGraph<Spot, Link> tsGraph = new TrackSchemeGraph<>( graph, graph.getGraphIdBimap(), new ModelGraphTrackSchemeProperties( graph ) );
+		ScreenEntities screenEntities = new ScreenEntities( tsGraph );
+		ScreenTransform transform = initScreenTransform();
+		LineageTreeLayout layout = initLineageTreeLayout( graph, tsGraph );
+		// run
+		layout.layout();
+		layout.cropAndScale( transform, screenEntities, 0, 0, new GraphColorGeneratorAdapter<>( tsGraph.getVertexMap(), tsGraph.getEdgeMap() ) );
+		// test
+		assertEquals( Arrays.asList( "a", "b", "c", "d" ), getVertexLabels( screenEntities ) );
+		assertEquals( Arrays.asList( "a->b", "a->c", "b->d", "c->d"), getEdges( screenEntities ) );
+	}
+
+
+	private ModelGraph initDiamondModelGraph()
+	{
+		ModelGraph graph = new ModelGraph();
+		Spot a = addSpot( graph, 0, "a", 0, 0, 0 );
+		Spot b = addSpot( graph, 1, "b", -1, 0, 0 );
+		Spot c = addSpot( graph, 1, "c", 1, 0, 0 );
+		Spot d = addSpot( graph, 2, "d", 0, 0, 0 );
+		graph.addEdge( a, b );
+		graph.addEdge( a, c );
+		graph.addEdge( c, d );
+		graph.addEdge( b, d );
+		return graph;
+	}
+
+	private LineageTreeLayout initLineageTreeLayout( ModelGraph graph, TrackSchemeGraph<Spot, Link> tsGraph )
+	{
+		SelectionModel<Spot, Link> selectionModel = new DefaultSelectionModel<>( graph, graph.getGraphIdBimap() );
+		SelectionModel<TrackSchemeVertex, TrackSchemeEdge> tsSelectionModel = new SelectionModelAdapter<>( selectionModel, tsGraph.getVertexMap(), tsGraph.getEdgeMap() );
+		RootsModel<TrackSchemeVertex> tsRootsModel = new DefaultRootsModel<>( graph, tsGraph );
+		LineageTreeLayout layout = new LineageTreeLayoutImp( tsRootsModel, tsGraph, tsSelectionModel );
+		return layout;
+	}
+
+	private ScreenTransform initScreenTransform()
+	{
+		ScreenTransform transform = new ScreenTransform();
+		transform.set( -1, 5, -1, 5, 601, 601 );
+		return transform;
+	}
+
+	private Spot addSpot( ModelGraph graph, int timepointId, String label, double... pos )
+	{
+		Spot spot = graph.addVertex().init( timepointId, pos, 1 );
+		spot.setLabel( label );
+		return spot;
+	}
+
+	private List<String> getVertexLabels( ScreenEntities screenEntities )
+	{
+		List<String> labels = new ArrayList<>();
+		for ( ScreenVertex v : screenEntities.getVertices() )
+			labels.add( v.getLabel() );
+		labels.sort( String::compareTo );
+		return labels;
+	}
+
+	private List<String> getEdges( ScreenEntities screenEntities )
+	{
+		List<String> labels = new ArrayList<>();
+		for ( ScreenVertex v : screenEntities.getVertices() )
+			labels.add( v.getLabel() );
+		List<String> edges = new ArrayList<>();
+		for ( ScreenEdge e : screenEntities.getEdges() )
+			edges.add( labels.get( e.getSourceScreenVertexIndex() ) + "->" +
+					labels.get( e.getTargetScreenVertexIndex() ) );
+		edges.sort( String::compareTo );
+		return edges;
+	}
+
+}


### PR DESCRIPTION
This PR fixes issue #187.

What changed:
* LineageTreeLayoutImp.layoutX(TrackSchemeVertex root) is fixed. It now correctly detects loop in a tree just as before the bug was introduced.
* LineageTreeLayoutImpTest, tests if a diamond shaped graph is laid out correctly.
* DepthFirstIteration is changed to use an iterator instead of callback functions.
* DepthFirstIterationTest was updated.