### PR TITLE
Serialize branch features and features computed on the fly.

### DIFF
--- a/src/main/java/org/mastodon/feature/io/FeatureSerializer.java
+++ b/src/main/java/org/mastodon/feature/io/FeatureSerializer.java
@@ -76,7 +76,9 @@ public interface FeatureSerializer< F extends Feature< O >, O > extends SciJavaP
 	public void serialize( F feature, ObjectToFileIdMap< O > idmap, ObjectOutputStream oos ) throws IOException;
 
 	/**
-	 * Deserializes a feature from the specified input stream.
+	 * Deserializes a feature from the specified input stream. Returns
+	 * <code>null</code> if the feature values are computed on the fly and do
+	 * not need deseralization.
 	 *
 	 * @param idmap
 	 *            the {@link FileIdToObjectMap}.
@@ -85,13 +87,17 @@ public interface FeatureSerializer< F extends Feature< O >, O > extends SciJavaP
 	 *            the feature.
 	 * @param ois
 	 *            the input stream.
-	 * @return a new feature instance.
+	 * @return a new feature instance or <code>null</code> if the feature values
+	 *         are computed on the fly and do not need deseralization.
 	 * @throws IOException
 	 *             if an I/O error occurs while reading the feature file.
 	 * @throws ClassNotFoundException
 	 *             if the class of the feature or the class of its target cannot
 	 *             be found.
 	 */
-	public F deserialize( final FileIdToObjectMap< O > idmap, final RefCollection< O > pool, ObjectInputStream ois ) throws IOException, ClassNotFoundException;
+	public default F deserialize( final FileIdToObjectMap< O > idmap, final RefCollection< O > pool, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
+	{
+		return null;
+	}
 
 }

--- a/src/main/java/org/mastodon/feature/io/LazyFeatureSerializer.java
+++ b/src/main/java/org/mastodon/feature/io/LazyFeatureSerializer.java
@@ -1,0 +1,109 @@
+package org.mastodon.feature.io;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Set;
+
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjection;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.io.ObjectToFileIdMap;
+
+/**
+ * Used to serialize features that are computed on the fly and therefore do not
+ * have a property map that can be serialized.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class LazyFeatureSerializer
+{
+
+	/**
+	 * Serialize a feature via its collection of projections, over a specified
+	 * collection of objects.
+	 * <p>
+	 * Serialization is the result of the concatenation of:
+	 * <ul>
+	 * <li><i>No</i> the number of objects serialized (<code>int</code>).
+	 * <li><i>Np</i> the number of projections serialized (<code>int</code>).
+	 * There will be <i>No x Np</i> values to read.
+	 * <li>a list of <i>Np</i> blocks, one per projection, made of:
+	 * <ul>
+	 * <li>the projection name (<code>UTF string</code>).
+	 * <li>the projection dimension (<code>UTF string</code>).
+	 * <li>the projection units (<code>UTF string</code>).
+	 * <li>a block of object id x projection value, alternating <i>No</i> times:
+	 * <ul>
+	 * <li>the object file id (<code>int</code>).
+	 * <li>the projection value for this object (<code>double</code>).
+	 * </ul>
+	 * </ul>
+	 * </ul>
+	 * 
+	 * 
+	 * @param <O>
+	 *            the type of objects to serialize.
+	 * @param feature
+	 *            the feature to serialize.
+	 * @param objs
+	 *            the collection of objects to serialize.
+	 * @param idmap
+	 *            the map linking object to their file if.
+	 * @param oos
+	 *            an object output stream to write to.
+	 * @throws IOException
+	 *             if problems arise while writing the file.
+	 */
+	public static < O > void serialize(
+			final Feature< O > feature,
+			final Collection< O > objs,
+			final ObjectToFileIdMap< O > idmap,
+			final ObjectOutputStream oos ) throws IOException
+	{
+		// NUMBER OF ENTRIES
+		oos.writeInt( objs.size() );
+
+		final Set< FeatureProjection< O > > projs = feature.projections();
+
+		// NUMBER OF PROJECTIONS.
+		oos.writeInt( projs.size() );
+
+		// PER PROJ
+		for ( final FeatureProjection< O > proj : projs )
+		{
+			final FeatureProjectionKey key = proj.getKey();
+
+			// PROJECTION NAME.
+			oos.writeUTF( key.toString() );
+
+			// PROJECTION DIMENSION.
+			oos.writeUTF( key.getSpec().projectionDimension.name() );
+
+			// UNITS.
+			oos.writeUTF( proj.units() );
+
+			// ENTRIES.
+			try
+			{
+				objs.forEach( o -> {
+					try
+					{
+						oos.writeInt( idmap.getId( o ) );
+						oos.writeDouble( proj.value( o ) );
+					}
+					catch ( final IOException e )
+					{
+						throw new UncheckedIOException( e );
+					}
+				} );
+			}
+			catch ( final UncheckedIOException e )
+			{
+				throw e.getCause();
+			}
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -552,7 +552,7 @@ public class ProjectManager
 			final Model model = windowManager.getAppModel().getModel();
 			final GraphToFileIdMap< Spot, Link > idmap = model.saveRaw( writer );
 			// Serialize feature model.
-			MamutRawFeatureModelIO.serialize( windowManager.getContext(), model.getFeatureModel(), idmap, writer );
+			MamutRawFeatureModelIO.serialize( windowManager.getContext(), model, idmap, writer );
 			// Serialize GUI state.
 			saveGUI( writer );
 			// Set save point.

--- a/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeature.java
@@ -57,7 +57,7 @@ public class LinkDisplacementFeature implements Feature< Link >
 
 	public static final Spec SPEC = new Spec();
 
-	private final ModelGraph graph;
+	final ModelGraph graph;
 
 	private final String units;
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkDisplacementFeatureSerializer.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.feature;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.feature.io.LazyFeatureSerializer;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.mamut.feature.LinkDisplacementFeature.Spec;
+import org.mastodon.mamut.model.Link;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = FeatureSerializer.class )
+public class LinkDisplacementFeatureSerializer implements FeatureSerializer< LinkDisplacementFeature, Link >
+{
+
+	@Override
+	public Spec getFeatureSpec()
+	{
+		return LinkDisplacementFeature.SPEC;
+	}
+
+	@Override
+	public void serialize( final LinkDisplacementFeature feature, final ObjectToFileIdMap< Link > idmap, final ObjectOutputStream oos ) throws IOException
+	{
+		LazyFeatureSerializer.serialize( feature, feature.graph.edges(), idmap, oos );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeature.java
@@ -57,7 +57,7 @@ public class LinkVelocityFeature implements Feature< Link >
 
 	public static final Spec SPEC = new Spec();
 
-	private final ModelGraph graph;
+	final ModelGraph graph;
 
 	private final String units;
 

--- a/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkVelocityFeatureSerializer.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.feature;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.feature.io.LazyFeatureSerializer;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.mamut.feature.LinkVelocityFeature.Spec;
+import org.mastodon.mamut.model.Link;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = FeatureSerializer.class )
+public class LinkVelocityFeatureSerializer implements FeatureSerializer< LinkVelocityFeature, Link >
+{
+
+	@Override
+	public Spec getFeatureSpec()
+	{
+		return LinkVelocityFeature.SPEC;
+	}
+
+	@Override
+	public void serialize( final LinkVelocityFeature feature, final ObjectToFileIdMap< Link > idmap, final ObjectOutputStream oos ) throws IOException
+	{
+		LazyFeatureSerializer.serialize( feature, feature.graph.edges(), idmap, oos );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/feature/MamutRawFeatureModelIO.java
+++ b/src/main/java/org/mastodon/mamut/feature/MamutRawFeatureModelIO.java
@@ -130,7 +130,14 @@ public class MamutRawFeatureModelIO
 				System.err.println( "Do not know how to deserialize a feature that targets " + targetClass );
 				continue;
 			}
-			featureModel.declareFeature( feature );
+
+			/*
+			 * Only declare the feature if it was properly deserialized. A null
+			 * value indicates that the feature we are trying to deserialize is
+			 * anyway computed on the fly and does not require deserialization.
+			 */
+			if ( feature != null )
+				featureModel.declareFeature( feature );
 		}
 		featureModel.resumeListeners();
 	}

--- a/src/main/java/org/mastodon/mamut/feature/SpotCenterIntensityFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/SpotCenterIntensityFeatureComputer.java
@@ -129,6 +129,7 @@ public class SpotCenterIntensityFeatureComputer implements MamutFeatureComputer,
 
 		final ArrayList< SourceAndConverter< ? > > sources = bdvData.getSources();
 		int done = 0;
+		final ExecutorService executor = Executors.newFixedThreadPool( numThreads );
 		for ( int iSource = 0; iSource < sources.size(); iSource++ )
 		{
 			@SuppressWarnings( "unchecked" )
@@ -148,7 +149,6 @@ public class SpotCenterIntensityFeatureComputer implements MamutFeatureComputer,
 						recomputeAll ) );
 				try
 				{
-					final ExecutorService executor = Executors.newFixedThreadPool( numThreads );
 					final List< Future< Void > > futures = executor.invokeAll( tasks );
 					for ( final Future< Void > future : futures )
 						future.get();
@@ -163,6 +163,7 @@ public class SpotCenterIntensityFeatureComputer implements MamutFeatureComputer,
 				}
 			}
 		}
+		executor.shutdown();
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeature.java
@@ -53,10 +53,13 @@ public class BranchDisplacementDurationFeature implements Feature< BranchLink >
 
 	final DoublePropertyMap< BranchLink > durMap;
 
+	final String lengthUnits;
+
 	BranchDisplacementDurationFeature( final DoublePropertyMap< BranchLink > dispMap, final DoublePropertyMap< BranchLink > durMap, final String lengthUnits )
 	{
 		this.dispMap = dispMap;
 		this.durMap = durMap;
+		this.lengthUnits = lengthUnits;
 		this.projectionMap = new LinkedHashMap<>( 2 );
 		projectionMap.put( key( DISPLACEMENT_PROJECTION_SPEC ), FeatureProjections.project( key( DISPLACEMENT_PROJECTION_SPEC ), dispMap, lengthUnits ) );
 		projectionMap.put( key( DURATION_PROJECTION_SPEC ), FeatureProjections.project( key( DURATION_PROJECTION_SPEC ), durMap, Dimension.NONE_UNITS ) );

--- a/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureSerializer.java
@@ -1,0 +1,96 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.feature.branch;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.io.properties.DoublePropertyMapSerializer;
+import org.mastodon.mamut.feature.branch.BranchDisplacementDurationFeature.Spec;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.ModelBranchGraph;
+import org.mastodon.properties.DoublePropertyMap;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = FeatureSerializer.class )
+public class BranchDisplacementDurationFeatureSerializer implements BranchFeatureSerializer< BranchDisplacementDurationFeature, BranchLink, Link >
+{
+
+	@Override
+	public Spec getFeatureSpec()
+	{
+		return BranchDisplacementDurationFeature.SPEC;
+	}
+
+	@Override
+	public BranchDisplacementDurationFeature deserialize(
+			final FileIdToObjectMap< Link > idmap,
+			final ObjectInputStream ois,
+			final ModelBranchGraph branchGraph,
+			final ModelGraph graph ) throws ClassNotFoundException, IOException
+	{
+		// Read the map link -> val.
+		final DoublePropertyMap< Link > dispLMap = new DoublePropertyMap<>( graph.edges(), Double.NaN );
+		final DoublePropertyMap< Link > durLMap = new DoublePropertyMap<>( graph.edges(), Double.NaN );
+		final DoublePropertyMapSerializer< Link > dispPms = new DoublePropertyMapSerializer<>( dispLMap );
+		final DoublePropertyMapSerializer< Link > durPms = new DoublePropertyMapSerializer<>( durLMap );
+		final String lengthUnits = ois.readUTF();
+		dispPms.readPropertyMap( idmap, ois );
+		durPms.readPropertyMap( idmap, ois );
+
+		// Map to branch-link -> val.
+		return new BranchDisplacementDurationFeature(
+				BranchFeatureSerializer.mapToBranchLinkMap( dispLMap, branchGraph ),
+				BranchFeatureSerializer.mapToBranchLinkMap( durLMap, branchGraph ),
+				lengthUnits );
+	}
+
+	@Override
+	public void serialize(
+			final BranchDisplacementDurationFeature feature,
+			final ObjectToFileIdMap< Link > idmap,
+			final ObjectOutputStream oos,
+			final ModelBranchGraph branchGraph,
+			final ModelGraph graph ) throws IOException
+	{
+		final DoublePropertyMap< Link > dispLMap = BranchFeatureSerializer.branchLinkMapToMap( feature.dispMap, branchGraph, graph );
+		final DoublePropertyMap< Link > durLMap = BranchFeatureSerializer.branchLinkMapToMap( feature.durMap, branchGraph, graph );
+		final DoublePropertyMapSerializer< Link > dispPms = new DoublePropertyMapSerializer<>( dispLMap );
+		final DoublePropertyMapSerializer< Link > durPms = new DoublePropertyMapSerializer<>( durLMap );
+		oos.writeUTF( feature.lengthUnits );
+		dispPms.writePropertyMap( idmap, oos );
+		durPms.writePropertyMap( idmap, oos );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/feature/branch/BranchFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/BranchFeatureSerializer.java
@@ -1,0 +1,235 @@
+package org.mastodon.mamut.feature.branch;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.mastodon.collection.RefCollection;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.mamut.model.branch.ModelBranchGraph;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+
+/**
+ * Specialized {@link FeatureSerializer} for the branch features we have in the
+ * Mamut app.
+ * <p>
+ * The de/serialization process is a bit complex in the case of branch features.
+ * We serialize only the core model, not the branch graph. So we get access to a
+ * map the maps the core graph object (spots ot links) to file ID. But the
+ * features are defined over a branch spot or a branch link. We we need this
+ * interface that invalidates the mother interface (calling the non-specialized
+ * methods will trigger a {@link IllegalArgumentException}) and can deal with
+ * the issue.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ * @param <F>
+ *            the type of feature de/serialized by this serializer.
+ * @param <O>
+ *            the type of object the feature is defined for.
+ * @param <Q>
+ *            the type of object the map object -> file ID is defined for.
+ */
+public interface BranchFeatureSerializer< F extends Feature< O >, O, Q > extends FeatureSerializer< F, O >
+{
+
+	public F deserialize(
+			FileIdToObjectMap< Q > idmap,
+			ObjectInputStream ois,
+			ModelBranchGraph branchGraph,
+			ModelGraph graph ) throws ClassNotFoundException, IOException;
+
+	public void serialize( 
+			final F feature, 
+			final ObjectToFileIdMap< Q > idmap, 
+			final ObjectOutputStream oos,
+			ModelBranchGraph branchGraph,
+			final ModelGraph graph ) throws IOException;
+
+	/*
+	 * Deserialization utils.
+	 */
+
+	public static IntPropertyMap< BranchLink > mapToBranchLinkMap( final IntPropertyMap< Link > map, final ModelBranchGraph branchGraph )
+	{
+		final IntPropertyMap< BranchLink > bmap = new IntPropertyMap<>( branchGraph.edges(), -1 );
+		final BranchLink beref = branchGraph.edgeRef();
+		try
+		{
+			for ( final Link l : map.getMap().keySet() )
+			{
+				final BranchLink bl = branchGraph.getBranchEdge( l, beref );
+				bmap.set( bl, map.get( l ) );
+			}
+		}
+		finally
+		{
+			branchGraph.releaseRef( beref );
+		}
+		return bmap;
+	}
+
+	public static DoublePropertyMap< BranchLink > mapToBranchLinkMap( final DoublePropertyMap< Link > map, final ModelBranchGraph branchGraph )
+	{
+		final DoublePropertyMap< BranchLink > bmap = new DoublePropertyMap<>( branchGraph.edges(), Double.NaN );
+		final BranchLink beref = branchGraph.edgeRef();
+		try
+		{
+			for ( final Link l : map.getMap().keySet() )
+			{
+				final BranchLink bl = branchGraph.getBranchEdge( l, beref );
+				bmap.set( bl, map.get( l ) );
+			}
+		}
+		finally
+		{
+			branchGraph.releaseRef( beref );
+		}
+		return bmap;
+	}
+
+	public static IntPropertyMap< BranchSpot > mapToBranchSpotMap( final IntPropertyMap< Spot > map, final ModelBranchGraph branchGraph )
+	{
+		final IntPropertyMap< BranchSpot > bmap = new IntPropertyMap<>( branchGraph.vertices(), -1 );
+		final BranchSpot beref = branchGraph.vertexRef();
+		try
+		{
+			for ( final Spot l : map.getMap().keySet() )
+			{
+				final BranchSpot bl = branchGraph.getBranchVertex( l, beref );
+				bmap.set( bl, map.get( l ) );
+			}
+		}
+		finally
+		{
+			branchGraph.releaseRef( beref );
+		}
+		return bmap;
+	}
+
+	public static DoublePropertyMap< BranchSpot > mapToBranchSpotMap( final DoublePropertyMap< Spot > map, final ModelBranchGraph branchGraph )
+	{
+		final DoublePropertyMap< BranchSpot > bmap = new DoublePropertyMap<>( branchGraph.vertices(), Double.NaN );
+		final BranchSpot beref = branchGraph.vertexRef();
+		try
+		{
+			for ( final Spot l : map.getMap().keySet() )
+			{
+				final BranchSpot bl = branchGraph.getBranchVertex( l, beref );
+				bmap.set( bl, map.get( l ) );
+			}
+		}
+		finally
+		{
+			branchGraph.releaseRef( beref );
+		}
+		return bmap;
+	}
+
+	/*
+	 * Serialization utils.
+	 */
+
+	public static IntPropertyMap< Link > branchLinkMapToMap( final IntPropertyMap< BranchLink > map, final ModelBranchGraph branchGraph, final ModelGraph graph )
+	{
+		final IntPropertyMap< Link > lmap = new IntPropertyMap<>( graph.edges(), -1 );
+		final Link eref = graph.edgeRef();
+		try
+		{
+			for ( final BranchLink bl : map.getMap().keySet() )
+			{
+				final Link l = branchGraph.getLinkedEdge( bl, eref );
+				lmap.set( l, map.get( bl ) );
+			}
+		}
+		finally
+		{
+			graph.releaseRef( eref );
+		}
+		return lmap;
+	}
+
+	public static DoublePropertyMap< Link > branchLinkMapToMap( final DoublePropertyMap< BranchLink > map, final ModelBranchGraph branchGraph, final ModelGraph graph )
+	{
+		final DoublePropertyMap< Link > lmap = new DoublePropertyMap<>( graph.edges(), Double.NaN );
+		final Link eref = graph.edgeRef();
+		try
+		{
+			for ( final BranchLink bl : map.getMap().keySet() )
+			{
+				final Link l = branchGraph.getLinkedEdge( bl, eref );
+				lmap.set( l, map.get( bl ) );
+			}
+		}
+		finally
+		{
+			graph.releaseRef( eref );
+		}
+		return lmap;
+	}
+
+	public static IntPropertyMap< Spot > branchSpotMapToMap( final IntPropertyMap< BranchSpot > map, final ModelBranchGraph branchGraph, final ModelGraph graph )
+	{
+		final IntPropertyMap< Spot > lmap = new IntPropertyMap<>( graph.vertices(), -1 );
+		final Spot eref = graph.vertexRef();
+		try
+		{
+			for ( final BranchSpot bl : map.getMap().keySet() )
+			{
+				final Spot l = branchGraph.getLinkedVertex( bl, eref );
+				lmap.set( l, map.get( bl ) );
+			}
+		}
+		finally
+		{
+			graph.releaseRef( eref );
+		}
+		return lmap;
+	}
+
+	public static DoublePropertyMap< Spot > branchSpotMapToMap( final DoublePropertyMap< BranchSpot > map, final ModelBranchGraph branchGraph, final ModelGraph graph )
+	{
+		final DoublePropertyMap< Spot > lmap = new DoublePropertyMap<>( graph.vertices(), Double.NaN );
+		final Spot eref = graph.vertexRef();
+		try
+		{
+			for ( final BranchSpot bl : map.getMap().keySet() )
+			{
+				final Spot l = branchGraph.getLinkedVertex( bl, eref );
+				lmap.set( l, map.get( bl ) );
+			}
+		}
+		finally
+		{
+			graph.releaseRef( eref );
+		}
+		return lmap;
+	}
+
+	/*
+	 * Invalidated overriden methods.
+	 */
+
+	// FIXME Imperfect. Use another interface?
+	@Override
+	default void serialize( final F feature, final ObjectToFileIdMap< O > idmap, final ObjectOutputStream oos ) throws IOException
+	{
+		throw new IllegalArgumentException( "Branch features cannot be serialized by this method call." );
+	}
+
+	@Override
+	default F deserialize( final FileIdToObjectMap< O > idmap, final RefCollection< O > pool, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
+	{
+		throw new IllegalArgumentException( "Branch features cannot be deserialized by this method call." );
+	}
+
+}


### PR DESCRIPTION
1.
Some features, such as the link displacement, are computed on the fly, and are not serialized. But they might be interesting for other softwares that can read the mastodon file format and do not want to recompute them.

This PR introduces facilities to serialize them, and use them on the link displacement and velocity features. 

2.
The de/serialization process is a bit complex in the case of branch features. We serialize only the core model, not
the branch graph. So we get access to a map the maps the core graph object (spots ot links) to file ID. But the
features are defined over a branch spot or a branch link. 

There is now a hierarchy to can de/serialize the branch features.
