### PR TITLE
Enable opening of dummy data

### DIFF
--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -85,6 +85,7 @@ import org.mastodon.ui.util.FileChooser;
 import org.mastodon.ui.util.FileChooser.SelectionMode;
 import org.mastodon.ui.util.XmlFileFilter;
 import org.mastodon.util.BDVImagePlusExporter;
+import org.mastodon.util.DummySpimData;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.behaviour.KeyPressedManager;
@@ -604,7 +605,7 @@ public class ProjectManager
 		// Check whether the project points to a BDV file.
 		final String imagePath = project.getDatasetXmlFile().getAbsolutePath().replaceAll( "\\\\", "/" );
 		final String canonicalPath = new File( imagePath ).getCanonicalPath();
-		if ( !canonicalPath.endsWith( ".xml" ) )
+		if ( !canonicalPath.endsWith( ".xml" )  && !canonicalPath.endsWith( DummySpimData.DUMMY ) )
 		{
 			final ImagePlus imp;
 

--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -633,6 +633,7 @@ public class ProjectManager
 		}
 		else
 		{
+			// Opening a project with standard BDV (or DUMMY) image data
 			localProject = project;
 		}
 

--- a/src/main/java/org/mastodon/util/DummySpimData.java
+++ b/src/main/java/org/mastodon/util/DummySpimData.java
@@ -70,7 +70,7 @@ import net.imglib2.view.Views;
  */
 public class DummySpimData
 {
-	static final String DUMMY = ".dummy";
+	static public final String DUMMY = ".dummy";
 
 	/**
 	 * Create a dummy {@link SpimDataMinimal} with a {@code BasicImgLoader} that

--- a/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
+++ b/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
@@ -97,6 +97,9 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
 
+import javax.swing.JComponent;
+import javax.swing.JOptionPane;
+
 public class SharedBigDataViewerData
 {
 	private final ArrayList< SourceAndConverter< ? > > sources;
@@ -382,8 +385,22 @@ public class SharedBigDataViewerData
 					System.err.println( "Could not open image data file: " + e.getMessage() );
 				}
 				System.err.println( "Despite that, still going to try to load the project but over a dummy\n"
-						+ "image dataset. Please fix the dataset path in the mastodon project file afterwards\n"
+						+ "image dataset. Please fix the dataset path in the Mastodon project file afterwards\n"
 						+ "by using menu entry: Mastodon -> File -> Fix Image Path.");
+
+				final int val = JOptionPane.showConfirmDialog(
+						null,
+						"Failed opening the original image data.\n"
+								+ "\n"
+								+ "Despite that, still going to try to load\n"
+								+ "the project but over a dummy image dataset.\n"
+								+ "\n"
+								+ "Please fix the dataset path in the Mastodon\n"
+								+ "project file afterwards by using menu entry:\n"
+								+ "Mastodon -> File -> Fix Image Path.",
+						"Image data not accessible",
+						JOptionPane.CLOSED_OPTION,
+						JOptionPane.WARNING_MESSAGE );
 
 				// Try to resurrect/figure-out as many parameters as possible from the .xml file,
 				// and build dummy data after it fails (it must fail, otherwise we wouldn't get here)

--- a/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
+++ b/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
@@ -366,6 +366,7 @@ public class SharedBigDataViewerData
 		{
 			try
 			{
+				//trying to load the actual (not-dummy) data
 				spimData = new XmlIoSpimDataMinimal().load( spimDataXmlFilename );
 			}
 			catch ( final SpimDataIOException | RuntimeException e )
@@ -378,12 +379,15 @@ public class SharedBigDataViewerData
 				}
 				else
 				{
-					System.err.println( "Could not open image data file. " );
-					e.printStackTrace();
+					System.err.println( "Could not open image data file: " + e.getMessage() );
 				}
-				final DatasetInfoParser info = DatasetInfoParser.inspect( spimDataXmlFilename );
-				System.err.println( "Opening with dummy dataset. Please fix dataset path in the mastodon project file." );
-				spimData = info.toDummySpimData();
+				System.err.println( "Despite that, still going to try to load the project but over a dummy\n"
+						+ "image dataset. Please fix the dataset path in the mastodon project file afterwards\n"
+						+ "by using menu entry: Mastodon -> File -> Fix Image Path.");
+
+				// Try to resurrect/figure-out as many parameters as possible from the .xml file,
+				// and build dummy data after it fails (it must fail, otherwise we wouldn't get here)
+				spimData = DatasetInfoParser.inspect( spimDataXmlFilename ).toDummySpimData();
 			}
 		}
 


### PR DESCRIPTION
Previously there was BasicImgLoader utlized in `DummySpimData` object.
But [some code around](https://github.com/mastodon-sc/mastodon/blob/adc7bddb4850510007b1a93004f33d04b7bb2340/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java#L392) (even [outside Mastodon](https://github.com/bigdataviewer/bigdataviewer-core/blob/9255efe8eb63a4b861ea7c6be283b556d31c0e7a/src/main/java/bdv/BigDataViewer.java#L277)) is casting to `ViewerImgLoader`.

To enable these pieces of code to function with our dummy data, we had to upgrade the dummy....

The implementation features single resolution level pyramid (I hope).