### PR TITLE
FIX: catches (warns and continues operation!) when restoring of BDV windows from gui.xml

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewStateSerialization.java
@@ -619,10 +619,16 @@ class MamutViewStateSerialization
 			{
 			case "MamutViewBdv":
 			{
-				final MamutViewBdv bdv = windowManager.createBigDataViewer( guiState );
+				try {
+					final MamutViewBdv bdv = windowManager.createBigDataViewer( guiState );
 
-				// Store context provider.
-				contextProviders.put( bdv.getContextProvider().getName(), bdv.getContextProvider() );
+					// Store context provider.
+					contextProviders.put( bdv.getContextProvider().getName(), bdv.getContextProvider() );
+				}
+				catch (IllegalArgumentException iae) {
+					System.err.println( "Info: Failed restoring state of a BigDataViewer window, thus not showing it.\n"
+							+ "      You may want to resave your project to replace the previous (failing) state with the current (okay) state." );
+				}
 				break;
 			}
 


### PR DESCRIPTION
This happens typically when dummy data is loaded instead of the original images AND the original images have more than one source. The [exception is thrown](https://github.com/bigdataviewer/bigdataviewer-core/blob/9255efe8eb63a4b861ea7c6be283b556d31c0e7a/src/main/java/bdv/viewer/state/XmlIoViewerState.java#L129) when the number of stored sources is not matching the number of sources present in the loaded data.

I decided not to create special-case for dummy data, rather I catch this discrepancy and informs an user about it...


**and especially** the swallowed exception allows to loading operation to continue.