### PR TITLE
Fix ConcurrentModificationException when showing the TrackScheme Hierarchy

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutBranchViewTrackSchemeHierarchy.java
+++ b/src/main/java/org/mastodon/mamut/MamutBranchViewTrackSchemeHierarchy.java
@@ -112,7 +112,7 @@ public class MamutBranchViewTrackSchemeHierarchy extends MamutBranchViewTrackSch
 			final GraphIdBimap< BranchSpot, BranchLink > idmap = graph.getGraphIdBimap();
 			final ModelGraphProperties< BranchSpot, BranchLink > properties = new MyModelGraphProperties( graph );
 			final TrackSchemeGraph< BranchSpot, BranchLink > trackSchemeGraph =
-					new TrackSchemeGraph<>( graph, idmap, properties );
+					new TrackSchemeGraph<>( graph, idmap, properties, graph.getLock() );
 			return trackSchemeGraph;
 		}
 


### PR DESCRIPTION
This PR fixes a ConcurrentModificationException, that occurs on some datasets, when the _TrackScheme Hierarchy_ window is opened the first time. Here is the stack trace of this exception:
```
Exception in thread "PainterThread" java.util.ConcurrentModificationException
	at gnu.trove.impl.hash.THashPrimitiveIterator.nextIndex(THashPrimitiveIterator.java:83)
	at gnu.trove.impl.hash.THashPrimitiveIterator.moveToNextIndex(THashPrimitiveIterator.java:137)
	at gnu.trove.set.hash.TIntHashSet$TIntHashIterator.next(TIntHashSet.java:484)
	at org.mastodon.collection.ref.RefSetImp$Iter.next(RefSetImp.java:180)
	at org.mastodon.views.trackscheme.LexicographicalVertexOrder.sort(LexicographicalVertexOrder.java:62)
	at org.mastodon.views.trackscheme.LineageTreeLayoutImp.layout(LineageTreeLayoutImp.java:181)
	at org.mastodon.views.trackscheme.display.TrackSchemePanel.paint(TrackSchemePanel.java:374)
	at bdv.viewer.render.PainterThread.run(PainterThread.java:82)
```
The _TrackScheme Hierarchy_ window is not rendered properly since the exception cancels the `PainterThread`:
![image](https://user-images.githubusercontent.com/24407711/197779996-ec535f98-614a-443c-b404-fb7cdd93bfab.png)

The window can be closed and reopened to workaround this problem.

### Root cause

The problem is caused by multi threading. The branch graph is rebuild by the `BranchGraphSynchronizer` when the _TrackScheme Heirarchy_ window is show. The branch graph rebuild also triggers a rebuild to the `TrackSchemeGraph` that is associated with the branch graph. The `ConcurrentModificationException` happens when the `PainterThread` renders the `TrackSchemeGraph` while it is modified. 

### Solution

The problem can be fixed by introducing a read-write-lock that prevents a simultaneous modification and rendering of the `BranchGraph` and it's associated `TrackSchemeGraph`.

1. Add a `ReentrantReadWriteLock` to the `ModelBranchGraph`.
2. Acquire the write-lock in the `graphRebuilt` method of the `ModelBranchGraph`.
3. Also use this lock in the associated `TrackSchemeGraph`. 
4. ~Acquire the read-lock when rendering the TrackSchemeGraph.~ Update: The code for acquiring the read-lock during rendering is already in the [TrackSchemePanel](https://github.com/mastodon-sc/mastodon/blob/7086a0f9e8273f42df42bd9be3883b6da2cde7fc/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemePanel.java#L366).