### PR TITLE
Don't let the "TrackScheme Branch" Window Mess up the TimepointModel

### DIFF
--- a/src/main/java/org/mastodon/mamut/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/MamutViewTrackScheme.java
@@ -148,7 +148,7 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 		// Restore group handle.
 		restoreGroupHandle( groupHandle, guiState );
 
-		final AutoNavigateFocusModel< TrackSchemeVertex, TrackSchemeEdge > navigateFocusModel = new AutoNavigateFocusModel<>( focusModel, navigationHandler );
+		final AutoNavigateFocusModel< TrackSchemeVertex, TrackSchemeEdge > navigateFocusModel = new AutoNavigateFocusModel<>( focusModel, navigationHandler, timepointModel );
 
 		final RootsModel<TrackSchemeVertex> rootsModel = new DefaultRootsModel<>( model.getGraph(), viewGraph );
 

--- a/src/main/java/org/mastodon/model/AutoNavigateFocusModel.java
+++ b/src/main/java/org/mastodon/model/AutoNavigateFocusModel.java
@@ -30,6 +30,7 @@ package org.mastodon.model;
 
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Vertex;
+import org.mastodon.spatial.HasTimepoint;
 import org.scijava.listeners.Listeners;
 
 /**
@@ -44,23 +45,35 @@ import org.scijava.listeners.Listeners;
  * @param <E>
  *            the type of edges in the graph.
  */
-public class AutoNavigateFocusModel< V extends Vertex< E >, E extends Edge< V > > implements FocusModel< V, E >
+public class AutoNavigateFocusModel< V extends Vertex< E > & HasTimepoint, E extends Edge< V > > implements FocusModel< V, E >
 {
 	private final FocusModel< V, E > focus;
 
 	private final NavigationHandler< V, E > navigation;
 
+	private final TimepointModel timepointModel;
+
 	public AutoNavigateFocusModel(
 			final FocusModel< V, E > focus,
 			final NavigationHandler< V, E > navigation )
 	{
+		this( focus, navigation, null );
+	}
+	public AutoNavigateFocusModel(
+			final FocusModel< V, E > focus,
+			final NavigationHandler< V, E > navigation,
+			final TimepointModel timepointModel )
+	{
 		this.focus = focus;
 		this.navigation = navigation;
+		this.timepointModel = timepointModel;
 	}
 
 	@Override
 	public void focusVertex( final V vertex )
 	{
+		if( timepointModel != null )
+			timepointModel.setTimepoint( vertex.getTimepoint() );
 		focus.focusVertex( vertex );
 		navigation.notifyNavigateToVertex( vertex );
 	}

--- a/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemePanel.java
+++ b/src/main/java/org/mastodon/views/trackscheme/display/TrackSchemePanel.java
@@ -537,10 +537,7 @@ public class TrackSchemePanel extends JPanel implements
 	public void navigateToVertex( final TrackSchemeVertex v )
 	{
 		if ( v.getLayoutTimestamp() == layout.getCurrentLayoutTimestamp() )
-		{
-			timepoint.setTimepoint( v.getTimepoint() );
 			navigationBehaviour.navigateToVertex( v, screenTransform.get() );
-		}
 	}
 
 	@Override
@@ -552,10 +549,7 @@ public class TrackSchemePanel extends JPanel implements
 		final TrackSchemeVertex target = edge.getTarget( graph.vertexRef() );
 		final int clts = layout.getCurrentLayoutTimestamp();
 		if ( target.getLayoutTimestamp() == clts && source.getLayoutTimestamp() == clts )
-		{
-			timepoint.setTimepoint( target.getTimepoint() );
 			navigationBehaviour.navigateToEdge( edge, source, target, screenTransform.get() );
-		}
 		graph.releaseRef( source );
 		graph.releaseRef( target );
 	}


### PR DESCRIPTION
Pairing a TrackScheme Branch" window with a BDV window led to wrong behaviour.

Double-clicking a spot in the BDV window should cause the paired "TrackScheme Branch" window to navigate to this spot. This first part worked fine. But the "TrackScheme Branch" window triggered a change of the `TimepointModel`, which causes the BDV window to jump to a different timepoint. This jump to a different timepoint is not intentional and annoying.

This PR fixes the problem, by improving how the TrackSchemePanel sets the timepoint.
Please have a look at the commit: a7af1762569103d8bcdbaa4c84ee14f354d3af7c