### PR TITLE
bugfix: the DnD handler does not EXIT_ON_CLOSE

### DIFF
--- a/src/main/java/org/mastodon/mamut/launcher/MastodonDndLauncher.java
+++ b/src/main/java/org/mastodon/mamut/launcher/MastodonDndLauncher.java
@@ -68,12 +68,16 @@ public class MastodonDndLauncher extends AbstractIOPlugin<Object> {
 
 		final String projectPath = fsource.getFile().getAbsolutePath();
 
+		//make sure that the menus appear on top of the screen
+		//to look natively in the Apple world
 		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+
+		//start up "the main object behind the scenes" -- the WindowManager,
 		final WindowManager windowManager = new WindowManager( getContext() );
 
+		//start up the main/central Mastodon window
 		final MainWindow mainWindow = new MainWindow( windowManager );
 		mainWindow.setVisible( true );
-		mainWindow.setDefaultCloseOperation( WindowConstants.EXIT_ON_CLOSE );
 
 		try {
 			final MamutProject project = new MamutProjectIO().load( projectPath );


### PR DESCRIPTION
which was closing the parent process, closing also the main Fiji window in the "production" settings

this was a leftover from the `src/test/...` times when @xulman was starting Mastodon directly from IDE and closing the Mastodon window wasn't closing the process making IDE believe that the program is still running