### PR TITLE
Add classes for starting Mastodon from the IDE for easy debugging

### DIFF
--- a/src/test/java/org/mastodon/StartImageJ.java
+++ b/src/test/java/org/mastodon/StartImageJ.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon;
+
+import org.scijava.Context;
+import org.scijava.ui.UIService;
+
+/**
+ * Shows the ImageJ main window, with Mastodon installed.
+ *
+ * @author Matthias Arzt
+ */
+public class StartImageJ
+{
+	public static void main( String... args )
+	{
+		Context context = new Context();
+		UIService uiService = context.service( UIService.class );
+		uiService.showUI();
+	}
+}

--- a/src/test/java/org/mastodon/StartMastodonLauncher.java
+++ b/src/test/java/org/mastodon/StartMastodonLauncher.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon;
+
+import org.mastodon.mamut.launcher.MastodonLauncherCommand;
+import org.scijava.Context;
+import org.scijava.command.CommandService;
+import org.scijava.ui.UIService;
+
+/**
+ * Shows the ImageJ main window and Mastodon launcher.
+ *
+ * @author Matthias Arzt
+ */
+public class StartMastodonLauncher
+{
+	public static void main( String... args )
+	{
+		Context context = new Context();
+		UIService uiService = context.service( UIService.class );
+		uiService.showUI();
+		CommandService commandService = context.service( CommandService.class );
+		commandService.run( MastodonLauncherCommand.class, true );
+	}
+}

--- a/src/test/java/org/mastodon/StartMastodonOnProject.java
+++ b/src/test/java/org/mastodon/StartMastodonOnProject.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon;
+
+import javax.swing.JFileChooser;
+import javax.swing.WindowConstants;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import mpicbg.spim.data.SpimDataException;
+import org.mastodon.mamut.MainWindow;
+import org.mastodon.mamut.WindowManager;
+import org.mastodon.mamut.project.MamutProjectIO;
+import org.scijava.Context;
+
+import java.io.IOException;
+
+/**
+ * Starts Mastodon on a given project file.
+ */
+public class StartMastodonOnProject
+{
+
+	public static void main( String... args )
+	{
+		try
+		{
+			String projectPath = fileOpenDialog();
+			System.setProperty( "apple.laf.useScreenMenuBar", "true" );
+			final WindowManager windowManager = new WindowManager( new Context() );
+			windowManager.getProjectManager().open( new MamutProjectIO().load( projectPath ) );
+			final MainWindow win = new MainWindow( windowManager );
+			win.setVisible( true );
+			win.setDefaultCloseOperation( WindowConstants.EXIT_ON_CLOSE );
+
+		}
+		catch ( IOException | SpimDataException e )
+		{
+			e.printStackTrace();
+		}
+	}
+
+	private static String fileOpenDialog()
+	{
+		JFileChooser fileChooser = new JFileChooser( "Open Mastodon Project" );
+		fileChooser.setFileFilter( new FileNameExtensionFilter( "Mastodon Project (*.mastodon)", "mastodon" ) );
+		fileChooser.showOpenDialog( null );
+		return fileChooser.getSelectedFile().getAbsolutePath();
+	}
+}


### PR DESCRIPTION
This PR adds three classes. These classes are in the test folder. They are therefor not part of the production code. They are instead meant for debugging Mastodon within the IDE (Eclipse, IntelliJ etc.)

These classes are:
1. **StartImageJ** Shows the ImageJ main window with Mastodon installed.
2. **StartMastodonLauncher** Shows ImageJ main window and the Mastodon launcher.
3. **StartMastodonOnProject** Shows a file open dialog that allows to select a mastodon project. Mastodon is started on the given project.