### PR TITLE
Make recent project JTextArea in the Mastodon launcher editable (Issue 181)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.mastodon</groupId>
 	<artifactId>mastodon</artifactId>
-	<version>1.0.0-beta-26-SNAPSHOT</version>
+	<version>1.0.0-beta-27-SNAPSHOT</version>
 
 	<name>Mastodon</name>
 	<description>Mastodon – a large-scale tracking and track-editing framework for large, multi-view images.</description>

--- a/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
@@ -128,15 +128,15 @@ public class RecentProjectsPanel extends JPanel
 				gbc.gridy++;
 				gbc.gridx = 0;
 				final JTextArea ta = new JTextArea( projectPath );
-				ta.setEditable( false );
+				ta.setEditable( true );
 				ta.setLineWrap( true );
-				ta.addMouseListener( new MouseDblClickOpenPath( projectPath ) );
+				ta.addMouseListener( new MouseDblClickOpenPath( ta.getText() ) );
 				add( ta, gbc );
 
 				gbc.gridx = 1;
 				final JButton btnOpen = new JButton( MastodonIcons.LOAD_ICON_SMALL );
 				btnOpen.addActionListener( l -> {
-					projectOpener.accept( projectPath );
+					projectOpener.accept( ta.getText() );
 					// Recent projects will be updated in the launcher method.
 				} );
 				add( btnOpen, gbc );


### PR DESCRIPTION
resolves #181 