### PR TITLE
Update build-pr.yml

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - dev
 
 jobs:
   build:


### PR DESCRIPTION
Add dev branch to build PR workflow.

With this Pull Request, I would like to propose that the "build PR" workflow is processed also in case a PR on the dev branch is drafted. Reason: Since in this repo, the usual workflow for new features / bugfixes is that PRs to the dev branch are created. Enabling this workflow for Pull Requests on the dev branch would ensure that every time a PR is on the dev branch is created, all unit tests are processed on the project is being build. This would add some "automated safety check" that a Pull Request does not destroy existing Unit Test and also will still allow the project to be built.