### PR TITLE
Change to FeatureComputerTestUtils improving tests

### DIFF
--- a/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
@@ -1,5 +1,6 @@
 package org.mastodon.mamut.feature.branch;
 
+import net.imglib2.util.Cast;
 import org.mastodon.feature.Feature;
 import org.mastodon.feature.FeatureProjection;
 import org.mastodon.feature.FeatureProjectionKey;
@@ -9,7 +10,6 @@ import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchSpot;
-import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.scijava.Context;
 
 import javax.annotation.Nonnull;
@@ -17,24 +17,43 @@ import javax.annotation.Nonnull;
 public class FeatureComputerTestUtils
 {
 	@Nonnull
-	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
+	public static Feature< BranchSpot > getBranchSpotFeature( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec,
+			@Nonnull FeatureProjectionSpec featureProjectionSpec )
 	{
 		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
-		Feature< BranchSpot > feature = ( Feature< BranchSpot > ) featureComputerService.compute( spec ).get( spec );
+		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
+	}
 
+	@Nonnull
+	public static Feature< Spot > getSpotFeature( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph,
+			@Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
+	{
+		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
+		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
+	}
+
+	@Nonnull
+	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec,
+			@Nonnull FeatureProjectionSpec featureProjectionSpec )
+	{
+		Feature< BranchSpot > feature = getBranchSpotFeature( context, exampleGraph, spec, featureProjectionSpec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 
 	@Nonnull
-	public static FeatureProjection< Spot > getSpotFeatureProjection( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
+	public static FeatureProjection< Spot > getSpotFeatureProjection( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph,
+			@Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
 	{
-		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
-		Feature< Spot > feature = ( Feature< Spot > ) featureComputerService.compute( spec ).get( spec );
+
+		Feature< Spot > feature = getSpotFeature( context, exampleGraph, spec, featureProjectionSpec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 
 	@Nonnull
-	private static MamutFeatureComputerService getMamutFeatureComputerService( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph )
+	private static MamutFeatureComputerService getMamutFeatureComputerService( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph )
 	{
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
 		featureComputerService.setModel( exampleGraph.getModel() );


### PR DESCRIPTION
* call featureComputerService with forceRecomputeAll flag to increase potential test coverage
* Reduce cast warnings by using Cast.unchecked
* Add new methods getBranchFeature and getSpotFeature so that feature can be retrieved without projection