### PR TITLE
Add tools to be used in Feature tests

### DIFF
--- a/src/main/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializer.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializer.java
@@ -1,0 +1,50 @@
+package org.mastodon.mamut.feature.branch;
+
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.io.properties.IntPropertyMapSerializer;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.mamut.model.branch.ModelBranchGraph;
+import org.mastodon.properties.IntPropertyMap;
+import org.scijava.plugin.Plugin;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+@Plugin( type = FeatureSerializer.class )
+public class BranchDepthFeatureSerializer implements BranchFeatureSerializer< BranchDepthFeature, BranchSpot, Spot >
+{
+
+	@Override
+	public BranchDepthFeature.Spec getFeatureSpec()
+	{
+		return BranchDepthFeature.SPEC;
+	}
+
+	@Override
+	public BranchDepthFeature deserialize( final FileIdToObjectMap< Spot > idmap, final ObjectInputStream ois,
+			final ModelBranchGraph branchGraph, final ModelGraph graph ) throws ClassNotFoundException, IOException
+	{
+		// Read the map link -> val.
+		final IntPropertyMap< Spot > linkMap = new IntPropertyMap<>( graph.vertices(), -1 );
+		final IntPropertyMapSerializer< Spot > propertyMapSerializer = new IntPropertyMapSerializer<>( linkMap );
+		propertyMapSerializer.readPropertyMap( idmap, ois );
+
+		// Map to branch-link -> val.
+		return new BranchDepthFeature( BranchFeatureSerializer.mapToBranchSpotMap( linkMap, branchGraph ) );
+	}
+
+	@Override
+	public void serialize( final BranchDepthFeature feature, final ObjectToFileIdMap< Spot > idmap, final ObjectOutputStream oos,
+			final ModelBranchGraph branchGraph, final ModelGraph graph ) throws IOException
+	{
+		final IntPropertyMap< Spot > linkMap = BranchFeatureSerializer.branchSpotMapToMap( feature.map, branchGraph, graph );
+		final IntPropertyMapSerializer< Spot > propertyMapSerializer = new IntPropertyMapSerializer<>( linkMap );
+		propertyMapSerializer.writePropertyMap( idmap, oos );
+	}
+
+}

--- a/src/test/java/org/mastodon/mamut/feature/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureComputerTestUtils.java
@@ -6,7 +6,6 @@ import org.mastodon.feature.FeatureProjection;
 import org.mastodon.feature.FeatureProjectionKey;
 import org.mastodon.feature.FeatureProjectionSpec;
 import org.mastodon.feature.FeatureSpec;
-import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
 import org.mastodon.mamut.model.Model;
 import org.scijava.Context;
 
@@ -19,10 +18,10 @@ public class FeatureComputerTestUtils
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
-	public static < T > FeatureProjection< T > getFeatureProjection( Context context, AbstractExampleGraph exampleGraph,
+	public static < T > FeatureProjection< T > getFeatureProjection( Context context, Model model,
 			FeatureSpec< ? extends Feature< T >, T > spec, FeatureProjectionSpec featureProjectionSpec )
 	{
-		Feature< T > feature = getFeature( context, exampleGraph.getModel(), spec );
+		Feature< T > feature = getFeature( context, model, spec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 

--- a/src/test/java/org/mastodon/mamut/feature/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureComputerTestUtils.java
@@ -1,4 +1,4 @@
-package org.mastodon.mamut.feature.branch;
+package org.mastodon.mamut.feature;
 
 import net.imglib2.util.Cast;
 import org.mastodon.feature.Feature;
@@ -6,7 +6,6 @@ import org.mastodon.feature.FeatureProjection;
 import org.mastodon.feature.FeatureProjectionKey;
 import org.mastodon.feature.FeatureProjectionSpec;
 import org.mastodon.feature.FeatureSpec;
-import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
 import org.mastodon.mamut.model.Model;
 import org.scijava.Context;

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -1,6 +1,7 @@
 package org.mastodon.mamut.feature;
 
 import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjection;
 import org.mastodon.graph.io.RawGraphIO;
 import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
@@ -11,6 +12,7 @@ import org.scijava.Context;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Set;
 
 public class FeatureSerializerTestUtils
 {
@@ -36,9 +38,6 @@ public class FeatureSerializerTestUtils
 		reloadProject = new MamutProject( projectRoot, datasetXmlFile );
 		Model modelReloaded = new Model();
 
-		// Add all vertices of the given model to the reloaded model.
-		model.getGraph().vertices().forEach( spot -> modelReloaded.getGraph().addVertex( spot ) );
-
 		// reload the model from temporary files
 		try (MamutProject.ProjectReader reader = reloadProject.openForReading())
 		{
@@ -56,5 +55,43 @@ public class FeatureSerializerTestUtils
 			}
 		}
 		return modelReloaded.getFeatureModel().getFeature( feature.getSpec() );
+	}
+
+	/**
+	 * Checks, if the two features have the same spec and the same projection values for a given object.
+	 * <p>
+	 * The latter is done by comparing the values of the projections
+	 * of the two given features having the same key for the given object.
+	 *
+	 * @param feature1 first feature to compare
+	 * @param feature2 second feature to compare
+	 * @param object object to compare the projections on
+	 * @return {@code true} if the two features have the same spec and the same projection values for the given object,
+	 * 		   {@code false} otherwise.
+	 * @param <T> the type of the object
+	 */
+	public static < T > boolean checkFeatureProjectionEquality( Feature< T > feature1, Feature< T > feature2, T object )
+	{
+		if ( feature1 == null || feature2 == null )
+			return false;
+		if ( !feature1.getSpec().equals( feature2.getSpec() ) )
+			return false;
+
+		Set< FeatureProjection< T > > featureProjections1 = feature1.projections();
+		Set< FeatureProjection< T > > featureProjections2 = feature2.projections();
+		for ( FeatureProjection< T > featureProjection1 : featureProjections1 )
+		{
+			for ( FeatureProjection< T > featureProjection2 : featureProjections2 )
+			{
+				if ( featureProjection1.getKey().equals( featureProjection2.getKey() ) )
+				{
+					double value1 = featureProjection1.value( object );
+					double value2 = featureProjection2.value( object );
+					if ( value1 != value2 )
+						return false;
+				}
+			}
+		}
+		return true;
 	}
 }

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -40,18 +40,12 @@ public class FeatureSerializerTestUtils
 		// reload the model from temporary files
 		try (MamutProject.ProjectReader reader = reloadProject.openForReading())
 		{
-			RawGraphIO.FileIdToGraphMap< Spot, Link > fileIdToGraphMap;
-			fileIdToGraphMap = modelReloaded.loadRaw( reader );
-			if ( fileIdToGraphMap == null )
-				throw new RuntimeException( "FileId to Graph map was not generated during loading model" );
-			try
-			{
-				MamutRawFeatureModelIO.deserialize( context, modelReloaded, fileIdToGraphMap, reader );
-			}
-			catch ( ClassNotFoundException e )
-			{
-				throw new RuntimeException( "Could not find feature class. Message: " + e.getMessage() );
-			}
+			RawGraphIO.FileIdToGraphMap< Spot, Link > fileIdToGraphMap = modelReloaded.loadRaw( reader );
+			MamutRawFeatureModelIO.deserialize( context, modelReloaded, fileIdToGraphMap, reader );
+		}
+		catch ( ClassNotFoundException e )
+		{
+			throw new RuntimeException( "Could not find feature class.", e );
 		}
 		return modelReloaded.getFeatureModel().getFeature( feature.getSpec() );
 	}

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -34,8 +34,7 @@ public class FeatureSerializerTestUtils
 			MamutRawFeatureModelIO.serialize( context, model, graphToFileIdMap, writer );
 		}
 
-		MamutProject reloadProject;
-		reloadProject = new MamutProject( projectRoot, datasetXmlFile );
+		MamutProject reloadProject = new MamutProject( projectRoot, datasetXmlFile );
 		Model modelReloaded = new Model();
 
 		// reload the model from temporary files

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -29,8 +29,6 @@ public class FeatureSerializerTestUtils
 			model.getFeatureModel().declareFeature( feature );
 			RawGraphIO.GraphToFileIdMap< Spot, Link > graphToFileIdMap;
 			graphToFileIdMap = model.saveRaw( writer );
-			if ( graphToFileIdMap == null )
-				throw new RuntimeException( "Graph to FileId map was not generated during saving model" );
 			MamutRawFeatureModelIO.serialize( context, model, graphToFileIdMap, writer );
 		}
 

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -1,0 +1,60 @@
+package org.mastodon.mamut.feature;
+
+import org.mastodon.feature.Feature;
+import org.mastodon.graph.io.RawGraphIO;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.project.MamutProject;
+import org.scijava.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class FeatureSerializerTestUtils
+{
+
+	public static Feature< ? > saveAndReload( Context context, Model model, Feature< ? > feature ) throws IOException
+	{
+		File projectRoot = Files.createTempDirectory( "mamut" ).toFile();
+		File datasetXmlFile = Files.createTempFile( "project", ".xml" ).toFile();
+		MamutProject saveProject = new MamutProject( projectRoot, datasetXmlFile );
+
+		// save the model to temporary files
+		try (MamutProject.ProjectWriter writer = saveProject.openForWriting())
+		{
+			model.getFeatureModel().declareFeature( feature );
+			RawGraphIO.GraphToFileIdMap< Spot, Link > graphToFileIdMap;
+			graphToFileIdMap = model.saveRaw( writer );
+			if ( graphToFileIdMap == null )
+				throw new RuntimeException( "Graph to FileId map was not generated during saving model" );
+			MamutRawFeatureModelIO.serialize( context, model, graphToFileIdMap, writer );
+		}
+
+		MamutProject reloadProject;
+		reloadProject = new MamutProject( projectRoot, datasetXmlFile );
+		Model modelReloaded = new Model();
+
+		// Add all vertices of the given model to the reloaded model.
+		model.getGraph().vertices().forEach( spot -> modelReloaded.getGraph().addVertex( spot ) );
+
+		// reload the model from temporary files
+		try (MamutProject.ProjectReader reader = reloadProject.openForReading())
+		{
+			RawGraphIO.FileIdToGraphMap< Spot, Link > fileIdToGraphMap;
+			fileIdToGraphMap = modelReloaded.loadRaw( reader );
+			if ( fileIdToGraphMap == null )
+				throw new RuntimeException( "FileId to Graph map was not generated during loading model" );
+			try
+			{
+				MamutRawFeatureModelIO.deserialize( context, modelReloaded, fileIdToGraphMap, reader );
+			}
+			catch ( ClassNotFoundException e )
+			{
+				throw new RuntimeException( "Could not find feature class. Message: " + e.getMessage() );
+			}
+		}
+		return modelReloaded.getFeatureModel().getFeature( feature.getSpec() );
+	}
+}

--- a/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/FeatureSerializerTestUtils.java
@@ -67,9 +67,24 @@ public class FeatureSerializerTestUtils
 			return false;
 		if ( !feature1.getSpec().equals( feature2.getSpec() ) )
 			return false;
-
 		Set< FeatureProjection< T > > featureProjections1 = feature1.projections();
 		Set< FeatureProjection< T > > featureProjections2 = feature2.projections();
+		// check if the two features have the same projections
+		for ( FeatureProjection< T > featureProjection1 : featureProjections1 )
+		{
+			boolean found = false;
+			for ( FeatureProjection< T > featureProjection2 : featureProjections2 )
+			{
+				if ( featureProjection1.getKey().equals( featureProjection2.getKey() ) )
+				{
+					found = true;
+					break;
+				}
+			}
+			if ( !found )
+				return false;
+		}
+		// check if the two features have the same projection values for the given object
 		for ( FeatureProjection< T > featureProjection1 : featureProjections1 )
 		{
 			for ( FeatureProjection< T > featureProjection2 : featureProjections2 )

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
@@ -2,6 +2,7 @@ package org.mastodon.mamut.feature.branch;
 
 import org.junit.Test;
 import org.mastodon.feature.FeatureProjection;
+import org.mastodon.mamut.feature.FeatureComputerTestUtils;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph1;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
 import org.mastodon.mamut.model.branch.BranchSpot;

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
@@ -19,8 +19,10 @@ public class BranchDepthFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
-					BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph1.getModel(),
+					BranchDepthFeature.SPEC,
+					BranchDepthFeature.PROJECTION_SPEC );
 
 			assertEquals( 0, featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -32,8 +34,10 @@ public class BranchDepthFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
-					BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph2.getModel(),
+					BranchDepthFeature.SPEC,
+					BranchDepthFeature.PROJECTION_SPEC );
 
 			assertEquals( 0, featureProjection.value( exampleGraph2.branchSpotA ), 0 );
 			assertEquals( 1, featureProjection.value( exampleGraph2.branchSpotB ), 0 );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureComputerTest.java
@@ -18,7 +18,8 @@ public class BranchDepthFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph1, BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
+					BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
 
 			assertEquals( 0, featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -30,7 +31,8 @@ public class BranchDepthFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph2, BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
+					BranchDepthFeature.SPEC, BranchDepthFeature.PROJECTION_SPEC );
 
 			assertEquals( 0, featureProjection.value( exampleGraph2.branchSpotA ), 0 );
 			assertEquals( 1, featureProjection.value( exampleGraph2.branchSpotB ), 0 );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
@@ -9,6 +9,7 @@ import org.mastodon.mamut.model.branch.BranchSpot;
 import org.scijava.Context;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import static org.junit.Assert.assertTrue;
 
@@ -21,23 +22,12 @@ public class BranchDepthFeatureSerializerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			Feature< BranchSpot > branchDepthFeature =
-					FeatureComputerTestUtils.getFeature( context, exampleGraph2.getModel(), BranchDepthFeature.SPEC );
 
-			BranchDepthFeature branchDepthFeatureReloaded = ( BranchDepthFeature ) FeatureSerializerTestUtils.saveAndReload( context,
-					exampleGraph2.getModel(), branchDepthFeature );
+			Feature< BranchSpot > feature = FeatureComputerTestUtils.getFeature( context, exampleGraph2.getModel(), BranchDepthFeature.SPEC );
+			Feature< BranchSpot > featureReloaded = FeatureSerializerTestUtils.saveAndReload( context, exampleGraph2.getModel(), feature );
 
-			// check that the feature has correct values after saving and reloading
-			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
-					exampleGraph2.branchSpotA ) );
-			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
-					exampleGraph2.branchSpotB ) );
-			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
-					exampleGraph2.branchSpotC ) );
-			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
-					exampleGraph2.branchSpotD ) );
-			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
-					exampleGraph2.branchSpotE ) );
+			Collection< BranchSpot > branchSpots = exampleGraph2.getModel().getBranchGraph().vertices();
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( feature, featureReloaded, branchSpots ) );
 		}
 	}
 }

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
@@ -11,13 +11,12 @@ import org.scijava.Context;
 import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class BranchDepthFeatureSerializerTest
 {
 
 	@Test
-	public void testFeatureSerialization()
+	public void testFeatureSerialization() throws IOException
 	{
 		try (Context context = new Context())
 		{
@@ -25,16 +24,9 @@ public class BranchDepthFeatureSerializerTest
 			Feature< BranchSpot > branchDepthFeature =
 					FeatureComputerTestUtils.getFeature( context, exampleGraph2.getModel(), BranchDepthFeature.SPEC );
 
-			BranchDepthFeature branchDepthFeatureReloaded = null;
-			try
-			{
-				branchDepthFeatureReloaded = ( BranchDepthFeature ) FeatureSerializerTestUtils.saveAndReload( context,
-						exampleGraph2.getModel(), branchDepthFeature );
-			}
-			catch ( IOException e )
-			{
-				fail( "Could not save and reload feature: " + e.getMessage() );
-			}
+			BranchDepthFeature branchDepthFeatureReloaded = ( BranchDepthFeature ) FeatureSerializerTestUtils.saveAndReload( context,
+					exampleGraph2.getModel(), branchDepthFeature );
+
 			// check that the feature has correct values after saving and reloading
 			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
 					exampleGraph2.branchSpotA ) );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
@@ -22,7 +22,7 @@ public class BranchDepthFeatureSerializerTest
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
 			Feature< BranchSpot > branchDepthFeature =
-					FeatureComputerTestUtils.getBranchSpotFeature( context, exampleGraph2, BranchDepthFeature.SPEC );
+					FeatureComputerTestUtils.getFeature( context, exampleGraph2.getModel(), BranchDepthFeature.SPEC );
 
 			BranchDepthFeature branchDepthFeatureReloaded = null;
 			try

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
@@ -1,0 +1,50 @@
+package org.mastodon.mamut.feature.branch;
+
+import org.junit.Test;
+import org.mastodon.feature.Feature;
+import org.mastodon.mamut.feature.FeatureSerializerTestUtils;
+import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.scijava.Context;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BranchDepthFeatureSerializerTest
+{
+
+	@Test
+	public void testFeatureSerialization()
+	{
+		try (Context context = new Context())
+		{
+			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
+			Feature< BranchSpot > branchDepthFeature =
+					FeatureComputerTestUtils.getBranchSpotFeature( context, exampleGraph2, BranchDepthFeature.SPEC );
+
+			BranchDepthFeature branchDepthFeatureReloaded = null;
+			try
+			{
+				branchDepthFeatureReloaded = ( BranchDepthFeature ) FeatureSerializerTestUtils.saveAndReload( context,
+						exampleGraph2.getModel(), branchDepthFeature );
+			}
+			catch ( IOException e )
+			{
+				fail( "Could not save and reload feature: " + e.getMessage() );
+			}
+			// check that the feature has correct values after saving and reloading
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
+					exampleGraph2.branchSpotA ) );
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
+					exampleGraph2.branchSpotB ) );
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
+					exampleGraph2.branchSpotC ) );
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
+					exampleGraph2.branchSpotD ) );
+			assertTrue( FeatureSerializerTestUtils.checkFeatureProjectionEquality( branchDepthFeature, branchDepthFeatureReloaded,
+					exampleGraph2.branchSpotE ) );
+		}
+	}
+}

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDepthFeatureSerializerTest.java
@@ -2,6 +2,7 @@ package org.mastodon.mamut.feature.branch;
 
 import org.junit.Test;
 import org.mastodon.feature.Feature;
+import org.mastodon.mamut.feature.FeatureComputerTestUtils;
 import org.mastodon.mamut.feature.FeatureSerializerTestUtils;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
 import org.mastodon.mamut.model.branch.BranchSpot;

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
@@ -2,6 +2,7 @@ package org.mastodon.mamut.feature.branch;
 
 import org.junit.Test;
 import org.mastodon.feature.FeatureProjection;
+import org.mastodon.mamut.feature.FeatureComputerTestUtils;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph1;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
 import org.mastodon.mamut.model.branch.BranchSpot;

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
@@ -19,8 +19,11 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
-					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
+
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph1.getModel(),
+					BranchDisplacementDurationFeature.SPEC,
+					BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
 
 			assertEquals( 3, featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -32,8 +35,11 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
-					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
+
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph2.getModel(),
+					BranchDisplacementDurationFeature.SPEC,
+					BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
 
 			assertNotNull( featureProjection );
 			assertEquals( 2, featureProjection.value( exampleGraph2.branchSpotA ), 0 );
@@ -50,8 +56,11 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
-					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
+
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph1.getModel(),
+					BranchDisplacementDurationFeature.SPEC,
+					BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
 
 			assertEquals( Math.sqrt( 16 + 64 + 144 ), featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -63,8 +72,11 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
-					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
+
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph2.getModel(),
+					BranchDisplacementDurationFeature.SPEC,
+					BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
 
 			assertEquals( Math.sqrt( 4 + 16 + 36 ), featureProjection.value( exampleGraph2.branchSpotA ), 0d );
 			assertEquals( Math.sqrt( 4 + 16 + 36 ), featureProjection.value( exampleGraph2.branchSpotB ), 0d );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputerTest.java
@@ -18,7 +18,8 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph1, BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
+					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
 
 			assertEquals( 3, featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -30,7 +31,8 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph2, BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
+					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DURATION_PROJECTION_SPEC );
 
 			assertNotNull( featureProjection );
 			assertEquals( 2, featureProjection.value( exampleGraph2.branchSpotA ), 0 );
@@ -47,7 +49,8 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph1, BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
+					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
 
 			assertEquals( Math.sqrt( 16 + 64 + 144 ), featureProjection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -59,7 +62,8 @@ public class BranchDisplacementDurationFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph2, BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
+			FeatureProjection< BranchSpot > featureProjection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
+					BranchDisplacementDurationFeature.SPEC, BranchDisplacementDurationFeature.DISPLACEMENT_PROJECTION_SPEC );
 
 			assertEquals( Math.sqrt( 4 + 16 + 36 ), featureProjection.value( exampleGraph2.branchSpotA ), 0d );
 			assertEquals( Math.sqrt( 4 + 16 + 36 ), featureProjection.value( exampleGraph2.branchSpotB ), 0d );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
@@ -18,7 +18,8 @@ public class BranchNSpotsFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph1, BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
+			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
+					BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
 
 			assertEquals( 5, projection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -30,7 +31,8 @@ public class BranchNSpotsFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getBranchSpotFeatureProjection( context, exampleGraph2, BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
+			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
+					BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
 
 			assertEquals( 3, projection.value( exampleGraph2.branchSpotA ), 0 );
 			assertEquals( 2, projection.value( exampleGraph2.branchSpotB ), 0 );

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
@@ -2,6 +2,7 @@ package org.mastodon.mamut.feature.branch;
 
 import org.junit.Test;
 import org.mastodon.feature.FeatureProjection;
+import org.mastodon.mamut.feature.FeatureComputerTestUtils;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph1;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
 import org.mastodon.mamut.model.branch.BranchSpot;

--- a/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/BranchNSpotsFeatureComputerTest.java
@@ -19,8 +19,10 @@ public class BranchNSpotsFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph1 exampleGraph1 = new ExampleGraph1();
-			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph1,
-					BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
+			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph1.getModel(),
+					BranchNSpotsFeature.SPEC,
+					BranchNSpotsFeature.PROJECTION_SPEC );
 
 			assertEquals( 5, projection.value( exampleGraph1.branchSpotA ), 0 );
 		}
@@ -32,8 +34,10 @@ public class BranchNSpotsFeatureComputerTest
 		try (Context context = new Context())
 		{
 			ExampleGraph2 exampleGraph2 = new ExampleGraph2();
-			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context, exampleGraph2,
-					BranchNSpotsFeature.SPEC, BranchNSpotsFeature.PROJECTION_SPEC );
+			final FeatureProjection< BranchSpot > projection = FeatureComputerTestUtils.getFeatureProjection( context,
+					exampleGraph2.getModel(),
+					BranchNSpotsFeature.SPEC,
+					BranchNSpotsFeature.PROJECTION_SPEC );
 
 			assertEquals( 3, projection.value( exampleGraph2.branchSpotA ), 0 );
 			assertEquals( 2, projection.value( exampleGraph2.branchSpotB ), 0 );

--- a/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
@@ -9,30 +9,21 @@ import org.mastodon.feature.FeatureSpec;
 import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
 import org.mastodon.mamut.model.Model;
-import org.mastodon.mamut.model.Spot;
-import org.mastodon.mamut.model.branch.BranchSpot;
 import org.scijava.Context;
 
 public class FeatureComputerTestUtils
 {
 
-	public static Feature< BranchSpot > getBranchSpotFeature( Context context, AbstractExampleGraph exampleGraph,
-			FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec )
-	{
-		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph.getModel() );
-		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
-	}
-
-	public static Feature< Spot > getSpotFeature( Context context, Model model, FeatureSpec< ? extends Feature< Spot >, Spot > spec )
+	public static < T > Feature< T > getFeature( Context context, Model model, FeatureSpec< ? extends Feature< T >, T > spec )
 	{
 		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, model );
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
-	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( Context context, AbstractExampleGraph exampleGraph,
-			FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec, FeatureProjectionSpec featureProjectionSpec )
+	public static < T > FeatureProjection< T > getFeatureProjection( Context context, AbstractExampleGraph exampleGraph,
+			FeatureSpec< ? extends Feature< T >, T > spec, FeatureProjectionSpec featureProjectionSpec )
 	{
-		Feature< BranchSpot > feature = getBranchSpotFeature( context, exampleGraph, spec );
+		Feature< T > feature = getFeature( context, exampleGraph.getModel(), spec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 

--- a/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
@@ -12,39 +12,31 @@ import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchSpot;
 import org.scijava.Context;
 
-import javax.annotation.Nonnull;
-
 public class FeatureComputerTestUtils
 {
 
-	@Nonnull
-	public static Feature< BranchSpot > getBranchSpotFeature( @Nonnull Context context,
-			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec )
+	public static Feature< BranchSpot > getBranchSpotFeature( Context context, AbstractExampleGraph exampleGraph,
+			FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec )
 	{
 		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
-	@Nonnull
-	public static Feature< Spot > getSpotFeature( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph,
-			@Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec )
+	public static Feature< Spot > getSpotFeature( Context context, AbstractExampleGraph exampleGraph,
+			FeatureSpec< ? extends Feature< Spot >, Spot > spec )
 	{
 		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
-	@Nonnull
-	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( @Nonnull Context context,
-			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec,
-			@Nonnull FeatureProjectionSpec featureProjectionSpec )
+	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( Context context, AbstractExampleGraph exampleGraph,
+			FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec, FeatureProjectionSpec featureProjectionSpec )
 	{
 		Feature< BranchSpot > feature = getBranchSpotFeature( context, exampleGraph, spec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 
-	@Nonnull
-	private static MamutFeatureComputerService getMamutFeatureComputerService( @Nonnull Context context,
-			@Nonnull AbstractExampleGraph exampleGraph )
+	private static MamutFeatureComputerService getMamutFeatureComputerService( Context context, AbstractExampleGraph exampleGraph )
 	{
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
 		featureComputerService.setModel( exampleGraph.getModel() );

--- a/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
@@ -8,6 +8,7 @@ import org.mastodon.feature.FeatureProjectionSpec;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
+import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchSpot;
 import org.scijava.Context;
@@ -18,14 +19,13 @@ public class FeatureComputerTestUtils
 	public static Feature< BranchSpot > getBranchSpotFeature( Context context, AbstractExampleGraph exampleGraph,
 			FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec )
 	{
-		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
+		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph.getModel() );
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
-	public static Feature< Spot > getSpotFeature( Context context, AbstractExampleGraph exampleGraph,
-			FeatureSpec< ? extends Feature< Spot >, Spot > spec )
+	public static Feature< Spot > getSpotFeature( Context context, Model model, FeatureSpec< ? extends Feature< Spot >, Spot > spec )
 	{
-		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
+		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, model );
 		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
 	}
 
@@ -36,10 +36,10 @@ public class FeatureComputerTestUtils
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 
-	private static MamutFeatureComputerService getMamutFeatureComputerService( Context context, AbstractExampleGraph exampleGraph )
+	private static MamutFeatureComputerService getMamutFeatureComputerService( Context context, Model model )
 	{
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
-		featureComputerService.setModel( exampleGraph.getModel() );
+		featureComputerService.setModel( model );
 		return featureComputerService;
 	}
 }

--- a/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
+++ b/src/test/java/org/mastodon/mamut/feature/branch/FeatureComputerTestUtils.java
@@ -1,5 +1,6 @@
 package org.mastodon.mamut.feature.branch;
 
+import net.imglib2.util.Cast;
 import org.mastodon.feature.Feature;
 import org.mastodon.feature.FeatureProjection;
 import org.mastodon.feature.FeatureProjectionKey;
@@ -9,32 +10,41 @@ import org.mastodon.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.mamut.feature.branch.exampleGraph.AbstractExampleGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchSpot;
-import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.scijava.Context;
 
 import javax.annotation.Nonnull;
 
 public class FeatureComputerTestUtils
 {
+
 	@Nonnull
-	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
+	public static Feature< BranchSpot > getBranchSpotFeature( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec )
 	{
 		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
-		Feature< BranchSpot > feature = ( Feature< BranchSpot > ) featureComputerService.compute( spec ).get( spec );
+		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
+	}
 
+	@Nonnull
+	public static Feature< Spot > getSpotFeature( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph,
+			@Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec )
+	{
+		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
+		return Cast.unchecked( featureComputerService.compute( true, spec ).get( spec ) );
+	}
+
+	@Nonnull
+	public static FeatureProjection< BranchSpot > getBranchSpotFeatureProjection( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< BranchSpot >, BranchSpot > spec,
+			@Nonnull FeatureProjectionSpec featureProjectionSpec )
+	{
+		Feature< BranchSpot > feature = getBranchSpotFeature( context, exampleGraph, spec );
 		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
 	}
 
 	@Nonnull
-	public static FeatureProjection< Spot > getSpotFeatureProjection( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph, @Nonnull FeatureSpec< ? extends Feature< Spot >, Spot > spec, @Nonnull FeatureProjectionSpec featureProjectionSpec )
-	{
-		final MamutFeatureComputerService featureComputerService = getMamutFeatureComputerService( context, exampleGraph );
-		Feature< Spot > feature = ( Feature< Spot > ) featureComputerService.compute( spec ).get( spec );
-		return feature.project( FeatureProjectionKey.key( featureProjectionSpec ) );
-	}
-
-	@Nonnull
-	private static MamutFeatureComputerService getMamutFeatureComputerService( @Nonnull Context context, @Nonnull AbstractExampleGraph exampleGraph )
+	private static MamutFeatureComputerService getMamutFeatureComputerService( @Nonnull Context context,
+			@Nonnull AbstractExampleGraph exampleGraph )
 	{
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
 		featureComputerService.setModel( exampleGraph.getModel() );


### PR DESCRIPTION
* Add a class + method to test feature serialization/deserialization (`FeatureSerializerTestUtils`)
  * Contains a method that saves and reloads a feature to/from disk
  * Contains a method that checks, if the feature projection values are the same for two given projection and one given object.

* Add the yet missing `BranchDepthFeatureSerializer`
* Add a unit test `BranchDepthFeatureSerializerTest` that makes use of the new test methods


* Updates + Extensions of `FeatureComputerTestUtils`
  * Call `featureComputerService` with `forceRecomputeAll` flag to increase potential test coverage
  * Reduce cast warnings by using `Cast.unchecked()`
  * Add new method `getFeature()` so that features can be retrieved without projection
  * Generify `getSpotFeatureProjection()` and `getBranchSpotFeatureProjection()` to `getFeatureProjection()`
