### PR TITLE
Notify MastodonPlugins about a Mastodon project being closed

### DIFF
--- a/src/main/java/org/mastodon/mamut/CloseListener.java
+++ b/src/main/java/org/mastodon/mamut/CloseListener.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut;
+
+public interface CloseListener
+{
+	void close();
+}

--- a/src/main/java/org/mastodon/mamut/MamutAppModel.java
+++ b/src/main/java/org/mastodon/mamut/MamutAppModel.java
@@ -42,6 +42,7 @@ import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.mastodon.views.bdv.overlay.ui.RenderSettingsManager;
 import org.mastodon.views.grapher.display.style.DataDisplayStyleManager;
 import org.mastodon.views.trackscheme.display.style.TrackSchemeStyleManager;
+import org.scijava.listeners.Listeners;
 import org.scijava.ui.behaviour.KeyPressedManager;
 import org.scijava.ui.behaviour.util.Actions;
 
@@ -72,6 +73,8 @@ public class MamutAppModel extends MastodonAppModel< Model, Spot, Link >
 	private final int maxTimepoint;
 
 	private final BranchGraphSynchronizer branchGraphSync;
+
+	private final Listeners.List< CloseListener > closeListeners = new Listeners.List<>();
 
 	public MamutAppModel(
 			final Model model,
@@ -156,5 +159,17 @@ public class MamutAppModel extends MastodonAppModel< Model, Spot, Link >
 	public BranchGraphSynchronizer getBranchGraphSync()
 	{
 		return branchGraphSync;
+	}
+
+	public void close() {
+		closeListeners.list.forEach( CloseListener::close );
+	}
+
+	/**
+	 * Listeners that are notified when the Mastodon project is closed,
+	 * by for example closing the main window.
+	 */
+	public Listeners< CloseListener > closeListeners() {
+		return closeListeners;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/MamutAppModel.java
+++ b/src/main/java/org/mastodon/mamut/MamutAppModel.java
@@ -161,7 +161,8 @@ public class MamutAppModel extends MastodonAppModel< Model, Spot, Link >
 		return branchGraphSync;
 	}
 
-	public void close() {
+	public void close()
+	{
 		closeListeners.list.forEach( CloseListener::close );
 	}
 

--- a/src/main/java/org/mastodon/mamut/MamutAppModel.java
+++ b/src/main/java/org/mastodon/mamut/MamutAppModel.java
@@ -166,10 +166,10 @@ public class MamutAppModel extends MastodonAppModel< Model, Spot, Link >
 	}
 
 	/**
-	 * Listeners that are notified when the Mastodon project is closed,
-	 * by for example closing the main window.
+	 * Listeners that are notified when the Mastodon project is closed.
 	 */
-	public Listeners< CloseListener > closeListeners() {
+	public Listeners< CloseListener > projectClosedListeners()
+	{
 		return closeListeners;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/mamut/ProjectManager.java
@@ -702,10 +702,11 @@ public class ProjectManager
 		// Prepare image data.
 		final SharedBigDataViewerData sharedBdvData = openImageData( localProject, windowManager, loadDummyData );
 
+		this.project = localProject;
+
 		// Load model.
 		loadModel( windowManager, sharedBdvData, localProject, restoreGUIState );
 
-		this.project = localProject;
 		updateEnabledActions();
 	}
 

--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -399,6 +399,8 @@ public class WindowManager
 	void setAppModel( final MamutAppModel appModel )
 	{
 		closeAllWindows();
+		if ( this.appModel != null )
+			this.appModel.close();
 
 		this.appModel = appModel;
 		if ( appModel == null )

--- a/src/test/java/org/mastodon/mamut/CloseListenerTest.java
+++ b/src/test/java/org/mastodon/mamut/CloseListenerTest.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.mastodon.mamut.project.MamutProject;
+import org.mastodon.mamut.project.MamutProjectIO;
+import org.scijava.Context;
+
+import mpicbg.spim.data.SpimDataException;
+
+public class CloseListenerTest
+{
+
+	/**
+	 * Test if {@link CloseListener} is called, when a Mastodon project
+	 * is closed.
+	 */
+	@Test
+	public void testCloseListeners() throws IOException, SpimDataException
+	{
+		try ( Context context = new Context() ) {
+			// setup
+			WindowManager windowManager = openTinyProject( context );
+			MamutAppModel appModel = windowManager.getAppModel();
+			final int[] counter = new int[] { 0 };
+			appModel.closeListeners().add( () -> counter[ 0 ]++ );
+			// process
+			windowManager.setAppModel( null ); // NB: This is the current way to close a Mastodon project. It could maybe use some refactoring.
+			// test
+			assertEquals( 1, counter[ 0 ] );
+		}
+	}
+
+	private static WindowManager openTinyProject( Context context ) throws IOException, SpimDataException
+	{
+		String tinyProjectFile = CloseListenerTest.class.getResource( "/org/mastodon/mamut/examples/tiny/tiny-project.mastodon" ).getFile();
+		WindowManager windowManager = new WindowManager( context );
+		MamutProject project = new MamutProjectIO().load( tinyProjectFile );
+		windowManager.getProjectManager().open( project, false, true );
+		return windowManager;
+	}
+}

--- a/src/test/java/org/mastodon/mamut/CloseListenerTest.java
+++ b/src/test/java/org/mastodon/mamut/CloseListenerTest.java
@@ -29,7 +29,9 @@
 package org.mastodon.mamut;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 
 import org.junit.Test;
@@ -49,6 +51,7 @@ public class CloseListenerTest
 	@Test
 	public void testCloseListeners() throws IOException, SpimDataException
 	{
+		assumeFalse( "This test requires a display.", GraphicsEnvironment.isHeadless() );
 		try ( Context context = new Context() ) {
 			// setup
 			WindowManager windowManager = openTinyProject( context );

--- a/src/test/java/org/mastodon/mamut/CloseListenerTest.java
+++ b/src/test/java/org/mastodon/mamut/CloseListenerTest.java
@@ -52,12 +52,13 @@ public class CloseListenerTest
 	public void testCloseListeners() throws IOException, SpimDataException
 	{
 		assumeFalse( "This test requires a display.", GraphicsEnvironment.isHeadless() );
-		try ( Context context = new Context() ) {
+		try (Context context = new Context())
+		{
 			// setup
 			WindowManager windowManager = openTinyProject( context );
 			MamutAppModel appModel = windowManager.getAppModel();
 			final int[] counter = new int[] { 0 };
-			appModel.closeListeners().add( () -> counter[ 0 ]++ );
+			appModel.projectClosedListeners().add( () -> counter[ 0 ]++ );
 			// process
 			windowManager.setAppModel( null ); // NB: This is the current way to close a Mastodon project. It could maybe use some refactoring.
 			// test


### PR DESCRIPTION
Fixes #237

This PR does two things:
* Adds a CloseListener to the MamutAppModel, this allows a MamutPlugin to get notified when the Mastodon project is closed.
* Allows a MamutPlugin to retrieve the project folder when initializing the plugin.

Here is an example:
```java
@Plugin( type = MamutPlugin.class )
public class ExampleMastodonPlugin implements MamutPlugin
{
	@Override
	public void setAppPluginModel( MamutPluginAppModel appPluginModel )
	{
		// register a close listener
		appPluginModel.getAppModel().closeListeners().add( this::onClosed );
		
		// get the project folder
		File projectFolder = appPluginModel
				.getWindowManager()
				.getProjectManager()
				.getProject()
				.getProjectRoot();
	}

	private void onClosed()
	{
		// TODO: free resources
	}
}
```