### PR TITLE
GraphML file importer

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedLinkFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedLinkFeatures.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.graphml;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.Multiplicity;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeatures;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+import org.scijava.plugin.Plugin;
+
+public class GraphMLImportedLinkFeatures extends TrackMateImportedFeatures< Link >
+{
+
+	public static final String KEY = "GraphML Link features";
+
+	private static final String HELP_STRING =
+			"Stores the link feature values imported from a GraphML file.";
+
+	private final Spec spec = new Spec();
+
+	@Plugin( type = FeatureSpec.class )
+	public static class Spec extends FeatureSpec< GraphMLImportedLinkFeatures, Link >
+	{
+		public Spec()
+		{
+			super(
+					KEY,
+					HELP_STRING,
+					GraphMLImportedLinkFeatures.class,
+					Link.class,
+					Multiplicity.SINGLE );
+		}
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Link > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Link > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureSpec< ? extends Feature< Link >, Link > getSpec()
+	{
+		return spec;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedLinkFeaturesSerializer.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedLinkFeaturesSerializer.java
@@ -1,0 +1,33 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+import org.mastodon.collection.RefCollection;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeaturesSerializer;
+import org.mastodon.mamut.model.Link;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = FeatureSerializer.class )
+public class GraphMLImportedLinkFeaturesSerializer
+		extends TrackMateImportedFeaturesSerializer< GraphMLImportedLinkFeatures, Link >
+{
+
+	@Override
+	public FeatureSpec< GraphMLImportedLinkFeatures, Link > getFeatureSpec()
+	{
+		return new GraphMLImportedLinkFeatures.Spec();
+	}
+
+	@Override
+	public GraphMLImportedLinkFeatures deserialize( final FileIdToObjectMap< Link > idmap,
+			final RefCollection< Link > pool, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
+	{
+		final GraphMLImportedLinkFeatures feature = new GraphMLImportedLinkFeatures();
+		deserializeInto( feature, idmap, pool, ois );
+		return feature;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedSpotFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedSpotFeatures.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.graphml;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.Multiplicity;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeatures;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+import org.scijava.plugin.Plugin;
+
+public class GraphMLImportedSpotFeatures extends TrackMateImportedFeatures< Spot >
+{
+
+	public static final String KEY = "GraphML Spot features";
+
+	private static final String HELP_STRING =
+			"Stores the spot feature values imported from a GraphML file.";
+
+	private final Spec spec = new Spec();
+
+	@Plugin( type = FeatureSpec.class )
+	public static class Spec extends FeatureSpec< GraphMLImportedSpotFeatures, Spot >
+	{
+		public Spec()
+		{
+			super(
+					KEY,
+					HELP_STRING,
+					GraphMLImportedSpotFeatures.class,
+					Spot.class,
+					Multiplicity.SINGLE );
+		}
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Spot > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Spot > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureSpec< ? extends Feature< Spot >, Spot > getSpec()
+	{
+		return spec;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedSpotFeaturesSerializer.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportedSpotFeaturesSerializer.java
@@ -1,0 +1,33 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+import org.mastodon.collection.RefCollection;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.io.FeatureSerializer;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeaturesSerializer;
+import org.mastodon.mamut.model.Spot;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = FeatureSerializer.class )
+public class GraphMLImportedSpotFeaturesSerializer
+		extends TrackMateImportedFeaturesSerializer< GraphMLImportedSpotFeatures, Spot >
+{
+
+	@Override
+	public FeatureSpec< GraphMLImportedSpotFeatures, Spot > getFeatureSpec()
+	{
+		return new GraphMLImportedSpotFeatures.Spec();
+	}
+
+	@Override
+	public GraphMLImportedSpotFeatures deserialize( final FileIdToObjectMap< Spot > idmap,
+			final RefCollection< Spot > pool, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
+	{
+		final GraphMLImportedSpotFeatures feature = new GraphMLImportedSpotFeatures();
+		deserializeInto( feature, idmap, pool, ois );
+		return feature;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporter.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporter.java
@@ -1,0 +1,345 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.input.SAXBuilder;
+import org.mastodon.collection.ObjectRefMap;
+import org.mastodon.collection.RefMaps;
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.FeatureModel;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.importer.ModelImporter;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeatures;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+
+public class GraphMLImporter extends ModelImporter
+{
+
+	private static final String GRAPHML_TAG = "graphml";
+	private static final String KEY_TAG = "key";
+	private static final String GRAPH_TAG = "graph";
+	private static final String NODE_TAG = "node";
+	private static final String ID_TAG = "id";
+	private static final String DATA_TAG = "data";
+	private static final String EDGE_TAG = "edge";
+	private static final String SOURCE_TAG = "source";
+	private static final String TARGET_TAG = "target";
+
+	/**
+	 * Imports the data stored in the specified GraphML file into the model of
+	 * the specified project model. The X, Y, Z coordinates are scaled by the
+	 * pixel sizes read from the setup with the specified id.
+	 * <p>
+	 * The GraphML file must contain keys for properties with
+	 * <code>attr.name</code> 'x', 'y', 'z' and 'frame' to be properly imported.
+	 * If it contains the key with <code>attr.name</code> 'label', is is
+	 * imported as spot labels.
+	 * <p>
+	 * Other property keys are imported as projections in a new feature. Right
+	 * now, only properties declared for nodes are imported this way. The
+	 * properties are imported in Mastodon with no dimension.
+	 * 
+	 * @param graphMLFile
+	 *            the GraphML file.
+	 * @param pm
+	 *            the project model.
+	 * @param spotRadius
+	 *            the desired spot radius for imported nodes.
+	 * @param setupID
+	 *            the setup ID to read pixel size from.
+	 * @throws IOException
+	 *             if the GraphML file misses some of the required information.
+	 */
+	public static final void importGraphML( final String graphMLFile, final ProjectModel pm, final int setupID, final double spotRadius ) throws IOException
+	{
+		final Model model = pm.getModel();
+		final SourceAndConverter< ? > sac = pm.getSharedBdvData().getSources().get( setupID );
+		final Source< ? > source = sac.getSpimSource();
+		final double[] pixelSizes = new double[ 3 ];
+		source.getVoxelDimensions().dimensions( pixelSizes );
+		new GraphMLImporter( graphMLFile, model ).read( pixelSizes, spotRadius );
+	}
+
+	/**
+	 * Imports the data stored in the specified GraphML file into the specified
+	 * model. The X, Y, Z coordinates are supposed to be already scaled.
+	 * <p>
+	 * The GraphML file must contain keys for properties with
+	 * <code>attr.name</code> 'x', 'y', 'z' and 'frame' to be properly imported.
+	 * If it contains the key with <code>attr.name</code> 'label', is is
+	 * imported as spot labels.
+	 * <p>
+	 * Other property keys are imported as projections in a new feature. Right
+	 * now, only properties declared for nodes are imported this way. The
+	 * properties are imported in Mastodon with no dimension.
+	 * 
+	 * @param graphMLFile
+	 *            the GraphML file.
+	 * @param model
+	 *            the model to import data in.
+	 * @param spotRadius
+	 *            the desired spot radius for imported nodes.
+	 * @throws IOException
+	 *             if the GraphML file misses some of the required information.
+	 */
+	public static final void importGraphML( final String graphMLFile, final Model model, final double spotRadius ) throws IOException
+	{
+		new GraphMLImporter( graphMLFile, model ).read( new double[] { 1., 1., 1. }, spotRadius );
+	}
+
+	private final String graphMLFile;
+
+	private final Model model;
+
+	private GraphMLImporter( final String graphMLFile, final Model model )
+	{
+		super( model );
+		this.graphMLFile = graphMLFile;
+		this.model = model;
+	}
+
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	private void read( final double[] pixelSizes, final double radius ) throws IOException
+	{
+		final ModelGraph graph = model.getGraph();
+		final FeatureModel featureModel = model.getFeatureModel();
+
+		final Spot ref1 = graph.vertexRef();
+		final Spot ref2 = graph.vertexRef();
+		final Link eref = graph.edgeRef();
+
+		startImport();
+		try
+		{
+			/*
+			 * Get root element.
+			 */
+
+			final Document document = new SAXBuilder().build( graphMLFile );
+			final Element rootEl = document.getRootElement();
+			final Namespace ns = rootEl.getNamespace();
+			if ( !rootEl.getName().equals( GRAPHML_TAG ) )
+				throw new IOException( "Could not import GraphML file. No <" + GRAPHML_TAG + "> element found." );
+
+			/*
+			 * Parse key elements.
+			 */
+
+			final List< Element > keyEls = rootEl.getChildren( KEY_TAG, ns );
+			GraphMLKey xKey = null;
+			GraphMLKey yKey = null;
+			GraphMLKey zKey = null;
+			GraphMLKey frameKey = null;
+			GraphMLKey labelKey = null;
+			final Map< String, GraphMLKey > featureKeys = new HashMap<>();
+			for ( final Element keyEl : keyEls )
+			{
+				final GraphMLKey key = GraphMLKey.fromXML( keyEl );
+				switch ( key.name.toLowerCase() )
+				{
+				case "x":
+					xKey = key;
+					continue;
+				case "y":
+					yKey = key;
+					continue;
+				case "z":
+					zKey = key;
+					continue;
+				case "frame":
+					frameKey = key;
+					continue;
+				case "label":
+					labelKey = key;
+					continue;
+				default:
+					featureKeys.put( key.id, key );
+				}
+			}
+			final List< GraphMLKey > mandatoryKeys = Arrays.asList( xKey, yKey, zKey, frameKey );
+			final List< String > keyNames = Arrays.asList( "x", "y", "z", "frame" );
+			for ( int i = 0; i < mandatoryKeys.size(); i++ )
+			{
+				if ( mandatoryKeys.get( i ) == null )
+					throw new IOException( "Could not find the key element that specifies the mandatory information for " + keyNames.get( i ) );
+			}
+
+			/*
+			 * Create features for misc keys.
+			 */
+
+			// Create the feature storage objects.
+			final GraphMLImportedSpotFeatures spotFeatures = new GraphMLImportedSpotFeatures();
+			final GraphMLImportedLinkFeatures linkFeatures = new GraphMLImportedLinkFeatures();
+			final Map< String, FeatureProjectionKey > projectionKeyMap = new HashMap<>();
+			for ( final GraphMLKey key : featureKeys.values() )
+			{
+				final Dimension dimension = Dimension.NONE;
+				// Units are not stored in the GraphML file format.
+				final String units = dimension.getUnits( model.getSpaceUnits(), model.getTimeUnits() );
+				final TrackMateImportedFeatures< ? > feature;
+				switch ( key.target )
+				{
+				case EDGE:
+					feature = linkFeatures;
+					break;
+				case NODE:
+					feature = spotFeatures;
+					break;
+				default:
+					throw new IllegalArgumentException( "Unknown target type for GraphML: " + key.target );
+				}
+
+				final FeatureProjectionKey projectionKey;
+				switch ( key.type )
+				{
+				case FLOAT:
+					projectionKey = feature.store( key.name, dimension, units, new DoublePropertyMap( graph.vertices(), Double.NaN ) );
+					break;
+				case INT:
+					projectionKey = feature.store( key.name, dimension, units, new IntPropertyMap( graph.vertices(), Integer.MIN_VALUE ) );
+					break;
+				default:
+					throw new IllegalArgumentException( "Unknown value type for GraphML: " + key.type );
+				}
+				projectionKeyMap.put( key.id, projectionKey );
+			}
+
+			/*
+			 * Import spots.
+			 */
+
+			final Element graphEl = rootEl.getChild( GRAPH_TAG, ns );
+			if ( graphEl == null )
+				throw new IOException( "Could not find the graph element." );
+
+			final ObjectRefMap< String, Spot > spotMap = RefMaps.createObjectRefMap( graph.vertices() );
+			final double[] pos = new double[ 3 ]; // pixel coordinates
+			for ( final Element nodeEl : graphEl.getChildren( NODE_TAG, ns ) )
+			{
+				// Gather position & time-point.
+				Arrays.fill( pos, Double.NaN );
+				int frame = -1;
+				String label = null;
+				final String id = nodeEl.getAttributeValue( ID_TAG );
+				for ( final Element dataEl : nodeEl.getChildren( DATA_TAG, ns ) )
+				{
+					final String keyId = dataEl.getAttributeValue( KEY_TAG );
+					if ( keyId.equals( xKey.id ) )
+						pos[ 0 ] = Double.parseDouble( dataEl.getText() );
+					else if ( keyId.equals( yKey.id ) )
+						pos[ 1 ] = Double.parseDouble( dataEl.getText() );
+					else if ( keyId.equals( zKey.id ) )
+						pos[ 2 ] = Double.parseDouble( dataEl.getText() );
+					else if ( keyId.equals( frameKey.id ) )
+						frame = Integer.parseInt( dataEl.getText() );
+					else if ( keyId.equals( labelKey.id ) )
+						label = dataEl.getText();
+				}
+				if ( frame < 0 )
+					throw new IOException( "Could not find the frame infomation (key=" + frameKey.id + ") for node with id " + id );
+
+				if ( Arrays.stream( pos ).anyMatch( Double::isNaN ) )
+					throw new IOException( "Could not find the X, Y, Z infomation (keys=" + xKey.id + ", " + yKey.id + ", " + zKey.id
+							+ ") for node with id " + id );
+
+				// Map to physical coordinates.
+				for ( int d = 0; d < pos.length; d++ )
+					pos[ d ] *= pixelSizes[ d ];
+
+				// Create spot.
+				final Spot spot = graph.addVertex( ref1 ).init( frame, pos, radius );
+				if ( label != null )
+					spot.setLabel( label );
+
+				spotMap.put( id, ref1 );
+
+				// Misc spot features.
+				for ( final Element dataEl : nodeEl.getChildren( DATA_TAG, ns ) )
+				{
+					final String keyId = dataEl.getAttributeValue( KEY_TAG );
+					final GraphMLKey key = featureKeys.get( keyId );
+					if ( key == null )
+						continue;
+
+					final FeatureProjectionKey projectionKey = projectionKeyMap.get( keyId );
+					switch ( key.type )
+					{
+					case INT:
+					{
+						final IntPropertyMap< Spot > map = spotFeatures.getIntPropertyMap( projectionKey );
+						final int val = Integer.parseInt( dataEl.getText() );
+						map.set( spot, val );
+						break;
+					}
+					case FLOAT:
+					{
+						final DoublePropertyMap< Spot > map = spotFeatures.getDoublePropertyMap( projectionKey );
+						final double val = Double.parseDouble( dataEl.getText() );
+						map.set( spot, val );
+						break;
+					}
+					default:
+						throw new IllegalArgumentException( "Unknown value type for GraphML: " + key.type );
+					}
+				}
+			}
+
+			/*
+			 * Import links.
+			 */
+
+			for ( final Element edgeEl : graphEl.getChildren( EDGE_TAG, ns ) )
+			{
+				final String sourceID = edgeEl.getAttributeValue( SOURCE_TAG );
+				final Spot source = spotMap.get( sourceID, ref1 );
+				if ( source == null )
+					throw new IOException( "Could not find the source node with id " + sourceID + " in the node list." );
+
+				final String targetID = edgeEl.getAttributeValue( TARGET_TAG );
+				final Spot target = spotMap.get( targetID, ref2 );
+				if ( target == null )
+					throw new IOException( "Could not find the source node with id " + targetID + " in the node list." );
+
+				graph.addEdge( source, target, eref ).init();
+			}
+
+			/*
+			 * Feed property maps to feature model.
+			 */
+
+			featureModel.pauseListeners();
+			featureModel.declareFeature( spotFeatures );
+			featureModel.declareFeature( linkFeatures );
+		}
+		catch ( final JDOMException e )
+		{
+			throw new IOException( e );
+		}
+		finally
+		{
+			graph.releaseRef( ref1 );
+			graph.releaseRef( ref2 );
+			graph.releaseRef( eref );
+			featureModel.resumeListeners();
+			finishImport();
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPanel.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPanel.java
@@ -1,0 +1,148 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.ui.util.FileChooser;
+import org.mastodon.ui.util.FileChooser.DialogType;
+import org.mastodon.ui.util.FileChooser.SelectionMode;
+import org.mastodon.ui.util.SetupIDComboBox;
+
+import bdv.viewer.SourceAndConverter;
+
+public class GraphMLImporterPanel extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private final JTextField tfFile;
+
+	private final SpinnerNumberModel spinnerModel;
+
+	private final SetupIDComboBox setupIDComboBox;
+
+	private static String previousFile = System.getProperty( "user.home" );
+
+	public GraphMLImporterPanel( final List< SourceAndConverter< ? > > sources, final String units )
+	{
+		final GridBagLayout gridBagLayout = new GridBagLayout();
+		gridBagLayout.columnWidths = new int[] { 0, 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0 };
+		gridBagLayout.columnWeights = new double[] { 0.0, 1.0, 0.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE };
+		setLayout( gridBagLayout );
+
+		final JLabel lblFile = new JLabel( "GraphML file" );
+		final GridBagConstraints gbcLblFile = new GridBagConstraints();
+		gbcLblFile.anchor = GridBagConstraints.WEST;
+		gbcLblFile.insets = new Insets( 0, 0, 5, 5 );
+		gbcLblFile.gridx = 0;
+		gbcLblFile.gridy = 0;
+		add( lblFile, gbcLblFile );
+
+		final JButton btnBrowse = new JButton( "Browse" );
+		final GridBagConstraints gbcBtnBrowse = new GridBagConstraints();
+		gbcBtnBrowse.gridwidth = 2;
+		gbcBtnBrowse.anchor = GridBagConstraints.EAST;
+		gbcBtnBrowse.insets = new Insets( 0, 0, 5, 5 );
+		gbcBtnBrowse.gridx = 1;
+		gbcBtnBrowse.gridy = 0;
+		add( btnBrowse, gbcBtnBrowse );
+
+		tfFile = new JTextField( previousFile );
+		final GridBagConstraints gbcTextField = new GridBagConstraints();
+		gbcTextField.insets = new Insets( 0, 0, 5, 5 );
+		gbcTextField.gridwidth = 3;
+		gbcTextField.fill = GridBagConstraints.HORIZONTAL;
+		gbcTextField.gridx = 0;
+		gbcTextField.gridy = 1;
+		add( tfFile, gbcTextField );
+		tfFile.setColumns( 10 );
+
+		final JLabel lblSetup = new JLabel( "Setup ID" );
+		final GridBagConstraints gbcLblSetup = new GridBagConstraints();
+		gbcLblSetup.anchor = GridBagConstraints.EAST;
+		gbcLblSetup.insets = new Insets( 0, 0, 5, 5 );
+		gbcLblSetup.gridx = 0;
+		gbcLblSetup.gridy = 2;
+		add( lblSetup, gbcLblSetup );
+
+		this.setupIDComboBox = new SetupIDComboBox( sources );
+		final GridBagConstraints gbcSetupIDComboBox = new GridBagConstraints();
+		gbcSetupIDComboBox.gridwidth = 2;
+		gbcSetupIDComboBox.insets = new Insets( 0, 0, 5, 5 );
+		gbcSetupIDComboBox.anchor = GridBagConstraints.EAST;
+		gbcSetupIDComboBox.gridx = 1;
+		gbcSetupIDComboBox.gridy = 2;
+		add( setupIDComboBox, gbcSetupIDComboBox );
+
+		final JLabel lblRadius = new JLabel( "Spot radius" );
+		final GridBagConstraints gbcLblRadius = new GridBagConstraints();
+		gbcLblRadius.insets = new Insets( 0, 0, 0, 5 );
+		gbcLblRadius.gridx = 0;
+		gbcLblRadius.gridy = 3;
+		add( lblRadius, gbcLblRadius );
+
+		this.spinnerModel = new SpinnerNumberModel( 2.5, 0.1, 100, 0.1 );
+		final JSpinner spinner = new JSpinner( spinnerModel );
+		final GridBagConstraints gbcSpinner = new GridBagConstraints();
+		gbcSpinner.anchor = GridBagConstraints.EAST;
+		gbcSpinner.insets = new Insets( 0, 0, 0, 5 );
+		gbcSpinner.gridx = 1;
+		gbcSpinner.gridy = 3;
+		add( spinner, gbcSpinner );
+
+		final JLabel lblUnits = new JLabel( units );
+		final GridBagConstraints gbcLblUnits = new GridBagConstraints();
+		gbcLblUnits.gridx = 2;
+		gbcLblUnits.gridy = 3;
+		add( lblUnits, gbcLblUnits );
+		
+		btnBrowse.addActionListener( e -> browse() );
+	}
+
+	private void browse()
+	{
+		final File file = FileChooser.chooseFile(
+				false,
+				null,
+				tfFile.getText(),
+				new FileNameExtensionFilter( "GraphML files", "graphml" ),
+				"Browse to a GraphML file",
+				DialogType.LOAD,
+				SelectionMode.FILES_ONLY,
+				MastodonIcons.MASTODON_ICON_MEDIUM.getImage() );
+		if ( file != null )
+		{
+			tfFile.setText( file.getAbsolutePath() );
+			previousFile = file.getAbsolutePath();
+		}
+	}
+
+	public String getPath()
+	{
+		return tfFile.getText();
+	}
+
+	public double getRadius()
+	{
+		return spinnerModel.getNumber().doubleValue();
+	}
+
+	public int getSetupID()
+	{
+		return setupIDComboBox.getSelectedSetupID();
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPlugin.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPlugin.java
@@ -1,0 +1,122 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.menu;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JOptionPane;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.app.ui.ViewMenuBuilder;
+import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.plugin.MamutPlugin;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionProvider;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptions;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.RunnableAction;
+
+import bdv.viewer.SourceAndConverter;
+
+@Plugin( type = MamutPlugin.class )
+public class GraphMLImporterPlugin implements MamutPlugin
+{
+
+	private static final String IMPORT_GRAPHML = "import graphml";
+	private static final String[] IMPORT_GRAPHML_KEYS = new String[] { "not mapped" };
+
+	private ProjectModel projectModel;
+
+	private final RunnableAction importGraphMLAction;
+
+	private GraphMLImporterPanel panel;
+
+	public GraphMLImporterPlugin()
+	{
+		this.importGraphMLAction = new RunnableAction( IMPORT_GRAPHML, this::importGraphML );
+	}
+
+	@Override
+	public void setAppPluginModel( final ProjectModel projectModel )
+	{
+		this.projectModel = projectModel;
+		final ArrayList< SourceAndConverter< ? > > sources = projectModel.getSharedBdvData().getSources();
+		this.panel = new GraphMLImporterPanel( sources, projectModel.getModel().getSpaceUnits() );
+	}
+
+	@Override
+	public Map< String, String > getMenuTexts()
+	{
+		final Map< String, String > menuTexts = new HashMap<>();
+		menuTexts.put( IMPORT_GRAPHML, "Import GraphML" );
+		return menuTexts;
+	}
+
+	@Override
+	public List< ViewMenuBuilder.MenuItem > getMenuItems()
+	{
+		return Arrays.asList(
+				menu( "Plugins", menu( "Imports", item( IMPORT_GRAPHML ) ) ) );
+	}
+
+	@Override
+	public void installGlobalActions( final Actions actions )
+	{
+		actions.namedAction( importGraphMLAction, IMPORT_GRAPHML_KEYS );
+	}
+
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigScopes.MAMUT, KeyConfigContexts.MASTODON );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add(
+					IMPORT_GRAPHML,
+					IMPORT_GRAPHML_KEYS,
+					"Import a GraphML file into the current model." );
+		}
+	}
+
+	private void importGraphML()
+	{
+		final int answer = JOptionPane.showConfirmDialog( null,
+				panel,
+				"GraphML importer",
+				JOptionPane.OK_CANCEL_OPTION,
+				JOptionPane.PLAIN_MESSAGE,
+				MastodonIcons.MASTODON_ICON_MEDIUM );
+		if ( answer != JOptionPane.OK_OPTION )
+			return;
+
+		final int setupID = panel.getSetupID();
+		final double radius = panel.getRadius();
+		final String path = panel.getPath();
+		try
+		{
+			GraphMLImporter.importGraphML( path, projectModel, setupID, radius );
+		}
+		catch ( final IOException e )
+		{
+			JOptionPane.showMessageDialog(
+					null,
+					"Problem importing file " + path + "\n" + e.getMessage(),
+					"GraphML importer",
+					JOptionPane.ERROR_MESSAGE,
+					MastodonIcons.MASTODON_ICON_MEDIUM );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLKey.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLKey.java
@@ -1,0 +1,85 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import org.jdom2.Element;
+
+public class GraphMLKey
+{
+
+	public static final String ID_TAG = "id";
+
+	public static final String FOR_TAG = "for";
+
+	public static final String FOR_NODE = "node";
+
+	public static final String FOR_EDGE = "edge";
+
+	public static final String NAME_TAG = "attr.name";
+
+	public static final String TYPE_TAG = "attr.type";
+
+	public static final String INT_TYPE = "int";
+
+	public static final String FLOAT_TYPE = "float";
+
+	public static GraphMLKey fromXML( final Element keyEl )
+	{
+		final String id = keyEl.getAttributeValue( ID_TAG );
+		final GraphMLObject target = GraphMLObject.from( keyEl.getAttributeValue( FOR_TAG ) );
+		final String name = keyEl.getAttributeValue( NAME_TAG );
+		final GraphMLValueType type = GraphMLValueType.from( keyEl.getAttributeValue( TYPE_TAG ) );
+		return new GraphMLKey( id, target, name, type );
+	}
+
+	public final String id;
+
+	public final GraphMLObject target;
+
+	public final String name;
+
+	public final GraphMLValueType type;
+
+	public enum GraphMLValueType
+	{
+		INT, FLOAT;
+
+		public static GraphMLValueType from( final String str )
+		{
+			switch ( str.toLowerCase() )
+			{
+			case INT_TYPE:
+				return INT;
+			case FLOAT_TYPE:
+				return FLOAT;
+			default:
+				throw new IllegalArgumentException( "Unknown value type for GraphML: " + str );
+			}
+		}
+	}
+
+	public enum GraphMLObject
+	{
+		NODE, EDGE;
+
+		public static GraphMLObject from( final String str )
+		{
+			switch ( str.toLowerCase() )
+			{
+			case FOR_NODE:
+				return NODE;
+			case FOR_EDGE:
+				return EDGE;
+			default:
+				throw new IllegalArgumentException( "Unknown target type for GraphML: " + str );
+			}
+		}
+	}
+
+	public GraphMLKey( final String id, final GraphMLObject target, final String name, final GraphMLValueType type )
+	{
+		this.id = id;
+		this.target = target;
+		this.name = name;
+		this.type = type;
+	}
+
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedFeatures.java
@@ -58,20 +58,32 @@ public abstract class TrackMateImportedFeatures< O > implements Feature< O >
 		this.intPropertyMapMap = new HashMap<>();
 	}
 
-	void store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< O > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< O > values )
 	{
 		final FeatureProjectionSpec spec = new FeatureProjectionSpec( key, dimension );
 		final FeatureProjectionKey fpkey = FeatureProjectionKey.key( spec );
 		projectionMap.put( fpkey, FeatureProjections.project( fpkey, values, units ) );
 		doublePropertyMapMap.put( fpkey, values );
+		return fpkey;
 	}
 
-	void store( final String key, final Dimension dimension, final String units, final IntPropertyMap< O > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< O > values )
 	{
 		final FeatureProjectionSpec spec = new FeatureProjectionSpec( key, dimension );
 		final FeatureProjectionKey fpkey = FeatureProjectionKey.key( spec );
 		projectionMap.put( fpkey, FeatureProjections.project( fpkey, values, units ) );
 		intPropertyMapMap.put( fpkey, values );
+		return fpkey;
+	}
+
+	public DoublePropertyMap< O > getDoublePropertyMap( final FeatureProjectionKey key )
+	{
+		return doublePropertyMapMap.get( key );
+	}
+
+	public IntPropertyMap< O > getIntPropertyMap( final FeatureProjectionKey key )
+	{
+		return intPropertyMapMap.get( key );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedLinkFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedLinkFeatures.java
@@ -30,6 +30,7 @@ package org.mastodon.mamut.io.importer.trackmate;
 
 import org.mastodon.feature.Dimension;
 import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
 import org.mastodon.feature.FeatureProjectionSpec;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.feature.Multiplicity;
@@ -63,18 +64,19 @@ public class TrackMateImportedLinkFeatures extends TrackMateImportedFeatures< Li
 	}
 
 	@Override
-	void store( final String key, final Dimension dimension, final String units,
-			final DoublePropertyMap< Link > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Link > values )
 	{
-		super.store( key, dimension, units, values );
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
 		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
 	}
 
 	@Override
-	void store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Link > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Link > values )
 	{
-		super.store( key, dimension, units, values );
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
 		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedSpotFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImportedSpotFeatures.java
@@ -30,6 +30,7 @@ package org.mastodon.mamut.io.importer.trackmate;
 
 import org.mastodon.feature.Dimension;
 import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
 import org.mastodon.feature.FeatureProjectionSpec;
 import org.mastodon.feature.FeatureSpec;
 import org.mastodon.feature.Multiplicity;
@@ -63,18 +64,19 @@ public class TrackMateImportedSpotFeatures extends TrackMateImportedFeatures< Sp
 	}
 
 	@Override
-	void store( final String key, final Dimension dimension, final String units,
-			final DoublePropertyMap< Spot > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Spot > values )
 	{
-		super.store( key, dimension, units, values );
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
 		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
 	}
 
 	@Override
-	void store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Spot > values )
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Spot > values )
 	{
-		super.store( key, dimension, units, values );
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
 		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/ui/util/SetupIDComboBox.java
+++ b/src/main/java/org/mastodon/ui/util/SetupIDComboBox.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * mastodon-tracking
+ * %%
+ * Copyright (C) 2017 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.ui.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
+
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+
+/**
+ * A combo-box that lets the user select one of the setup ids present in a spim
+ * data.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class SetupIDComboBox extends JComboBox< String >
+{
+
+	private static final long serialVersionUID = 1L;
+
+	private final Map< String, Integer > idMap;
+
+	private final Map< Integer, String > strMap;
+
+	public SetupIDComboBox( final List< SourceAndConverter< ? > > sources )
+	{
+		if ( null == sources || sources.isEmpty() )
+		{
+			this.idMap = new HashMap<>( 1 );
+			this.strMap = new HashMap<>( 1 );
+			final String str = "No data";
+			final Integer id = Integer.valueOf( -1 );
+			idMap.put( str, id );
+			strMap.put( id, str );
+			final ComboBoxModel< String > aModel = new DefaultComboBoxModel<>( new String[] { str } );
+			setModel( aModel );
+		}
+		else
+		{
+			final int nSetups = sources.size();
+			this.idMap = new HashMap<>( nSetups );
+			this.strMap = new HashMap<>( nSetups );
+
+			final String[] items = new String[ nSetups ];
+			int i = 0;
+			for ( int setupID = 0; setupID < sources.size(); setupID++ )
+			{
+				final Source< ? > source = sources.get( setupID ).getSpimSource();
+				final String name = source.getName();
+				final long[] size = new long[ source.getSource( 0, 0 ).numDimensions() ];
+				source.getSource( 0, 0 ).dimensions( size );
+				final String str = ( null == name )
+						? setupID + "  -  " + size[ 0 ] + " x " + size[ 1 ] + " x " + size[ 2 ]
+						: setupID + "  -  " + name;
+				items[ i++ ] = str;
+				idMap.put( str, setupID );
+				strMap.put( setupID, str );
+			}
+
+			final ComboBoxModel< String > aModel = new DefaultComboBoxModel<>( items );
+			setModel( aModel );
+		}
+	}
+
+	/**
+	 * Returns the id of the setup id currently selected.
+	 *
+	 * @return the setup id.
+	 */
+	public int getSelectedSetupID()
+	{
+		final Integer id = idMap.get( getSelectedItem() );
+		if (null == id)
+			return idMap.values().iterator().next();
+
+		return idMap.get( getSelectedItem() );
+	}
+
+	/**
+	 * Sets the specified setup id as selection.
+	 *
+	 * @param setupID
+	 *            the setup id to select.
+	 */
+	public void setSelectedSetupID( final int setupID )
+	{
+		setSelectedItem( strMap.get( Integer.valueOf( setupID ) ) );
+	}
+}

--- a/src/test/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/graphml/GraphMLImportDemo.java
@@ -1,0 +1,32 @@
+package org.mastodon.mamut.io.importer.graphml;
+
+import java.io.IOException;
+
+import javax.swing.JFrame;
+
+import org.mastodon.mamut.MainWindow;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.ProjectLoader;
+import org.scijava.Context;
+
+import mpicbg.spim.data.SpimDataException;
+
+public class GraphMLImportDemo
+{
+
+	public static void main( final String[] args ) throws IOException, SpimDataException
+	{
+		try (Context context = new Context())
+		{
+			final String mastodonProject = "/Users/tinevez/Downloads/data_sharing/pos1_t1-50_cropped_H2B.mastodon";
+			final String graphMLFile = "/Users/tinevez/Downloads/data_sharing/graph.graphml";
+			
+			final ProjectModel pm = ProjectLoader.open( mastodonProject, context );
+			GraphMLImporter.importGraphML( graphMLFile, pm, 0, 2.5 );
+			
+			final MainWindow mainWindow = new MainWindow( pm );
+			mainWindow.setDefaultCloseOperation( JFrame.EXIT_ON_CLOSE );
+			mainWindow.setVisible( true );
+		}
+	}
+}


### PR DESCRIPTION
![Mastodon_GraphML-importer](https://github.com/mastodon-sc/mastodon/assets/3583203/150f7ad4-e1a6-43de-b36f-8b31058f0d1e)

This plugin can import data coming from a GraphML file (http://graphml.graphdrawing.org/) generated by Python software using networkx graph.
    
It requires the properties with keys 'x', 'y', 'z' and 'frame' to be present and can handle supplemental properties that are imported as Mastodon features. The features values are saved and restored along with the data.

A simple dialog allows specifying from where the take pixel size; apparently the x, y, z position are saved in pixel coordinates. Right now the radius or covariance matrix for the ellipsoid are not imported. The user must specify a radius.
