### PR TITLE
Update LinkTargetIdFeature.java

### DIFF
--- a/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/LinkTargetIdFeature.java
@@ -31,7 +31,7 @@ package org.mastodon.mamut.feature;
 import static org.mastodon.feature.FeatureProjectionKey.key;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.mastodon.feature.Dimension;
@@ -103,7 +103,7 @@ public class LinkTargetIdFeature implements Feature< Link >
 	@Override
 	public Set< FeatureProjection< Link > > projections()
 	{
-		final Set< FeatureProjection< Link > > projections = new HashSet<>();
+		final Set< FeatureProjection< Link > > projections = new LinkedHashSet<>();
 		projections.add( new SourceIdProjection( graph.vertexRef() ) );
 		projections.add( new TargetIdProjection( graph.vertexRef() ) );
 		return Collections.unmodifiableSet( projections );


### PR DESCRIPTION
Resolves: https://github.com/mastodon-sc/mastodon/issues/217

Replace `HashSet `used as return value for the projections() method by `LinkedHashSet`, since the order of entry needs to be stable in process using this method.

