### PR TITLE
Update pom.xml with pom-scijava 37.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>35.1.1</version>
+		<version>37.0.0</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>

--- a/src/main/java/org/mastodon/io/yaml/WorkaroundConstructor.java
+++ b/src/main/java/org/mastodon/io/yaml/WorkaroundConstructor.java
@@ -31,15 +31,17 @@ package org.mastodon.io.yaml;
 import java.util.List;
 import java.util.Map;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 
 public class WorkaroundConstructor extends Constructor
 {
-	public WorkaroundConstructor( final Class< ? > theRoot )
+
+	public WorkaroundConstructor( LoaderOptions loadingConfig )
 	{
-		super( theRoot );
+		super( loadingConfig );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/io/yaml/WorkaroundRepresenter.java
+++ b/src/main/java/org/mastodon/io/yaml/WorkaroundRepresenter.java
@@ -30,6 +30,7 @@ package org.mastodon.io.yaml;
 
 import java.util.Map;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -37,6 +38,11 @@ import org.yaml.snakeyaml.representer.Representer;
 
 public class WorkaroundRepresenter extends Representer
 {
+	public WorkaroundRepresenter( DumperOptions options )
+	{
+		super( options );
+	}
+
 	@Override
 	protected Node representSequence( final Tag tag, final Iterable< ? > sequence, final FlowStyle flowStyle )
 	{

--- a/src/main/java/org/mastodon/ui/keymap/KeymapManager.java
+++ b/src/main/java/org/mastodon/ui/keymap/KeymapManager.java
@@ -46,6 +46,7 @@ import org.scijava.ui.behaviour.io.InputTriggerDescription;
 import org.scijava.ui.behaviour.io.InputTriggerDescriptionsBuilder;
 import org.scijava.ui.behaviour.io.yaml.YamlConfigIO;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -229,9 +230,9 @@ public class KeymapManager extends AbstractStyleManager< KeymapManager, Keymap >
 	{
 		final DumperOptions dumperOptions = new DumperOptions();
 		dumperOptions.setDefaultFlowStyle( DumperOptions.FlowStyle.BLOCK );
-		final Representer representer = new Representer();
+		final Representer representer = new Representer( new DumperOptions() );
 		representer.addClassTag( KeymapsListIO.class, new Tag( "!keymapslist" ) );
-		final Constructor constructor = new Constructor();
+		final Constructor constructor = new Constructor( new LoaderOptions() );
 		constructor.addTypeDescription( new TypeDescription( KeymapsListIO.class, "!keymapslist" ) );
 		return new Yaml( constructor, representer, dumperOptions );
 	}

--- a/src/main/java/org/mastodon/util/MastodonDebugSettings.java
+++ b/src/main/java/org/mastodon/util/MastodonDebugSettings.java
@@ -35,6 +35,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -143,9 +144,9 @@ public interface MastodonDebugSettings
 		{
 			final DumperOptions dumperOptions = new DumperOptions();
 			dumperOptions.setDefaultFlowStyle( DumperOptions.FlowStyle.BLOCK );
-			final Representer representer = new Representer();
+			final Representer representer = new Representer( new DumperOptions() );
 			representer.addClassTag( DebugSettingsImpl.class, new Tag( "!debugsettings" ) );
-			final Constructor constructor = new Constructor();
+			final Constructor constructor = new Constructor( new LoaderOptions() );
 			constructor.addTypeDescription( new TypeDescription( DebugSettingsImpl.class, "!debugsettings" ) );
 			return new Yaml( constructor, representer, dumperOptions );
 		}


### PR DESCRIPTION
* Updates the pom-scijava version from 35.1.0 to 37.0.0
* KeymapManager, MastodonDebugSettings, WorkaroundConstructor and WorkaroundRepresenter needed to be adapted as well, since the empty constructors of Representer and Constructor do no exist anymore