### PR TITLE
Make WindowsManager.getViewList(  final Class< T > klass ) public

### DIFF
--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -420,7 +420,7 @@ public class WindowManager
 	 *            the view class, must extend {@link MamutViewI}.
 	 * @return the list of view of specified class, or <code>null</code>.
 	 */
-	private < T extends MamutViewI > List< T > getViewList( final Class< T > klass )
+	public < T extends MamutViewI > List< T > getViewList( final Class< T > klass )
 	{
 		@SuppressWarnings( "unchecked" )
 		final List< T > list = ( List< T > ) openedViews.get( klass );


### PR DESCRIPTION
It is helpful if a plugin has access to a list of views.
Use case: https://github.com/elephant-track/elephant-client/blob/951a2c60115d30d9debae453436ddfbd40ac8042/src/main/java/org/elephant/actions/mixins/WindowManagerMixin.java#L55