### PR TITLE
Fix Garbage Collection

### DIFF
--- a/src/main/java/org/mastodon/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/mamut/WindowManager.java
@@ -222,14 +222,18 @@ public class WindowManager
 		settings.addPage( new FeatureColorModeConfigPage( "Settings > Feature Color Modes", featureColorModeManager,
 				featureProjectionsManager, "Spot", "Link" ) );
 		settings.pack();
+		appModel.projectClosedListeners().add( settings::dispose );
 
 		/*
 		 * Tag-set and feature computation dialogs
 		 */
 		tagSetDialog = new TagSetDialog( null, model.getTagSetModel(), model, keymap, new String[] { KeyConfigContexts.MASTODON } );
 		tagSetDialog.setIconImages( TAGS_ICON );
+		appModel.projectClosedListeners().add( tagSetDialog::dispose );
+
 		featureComputationDialog = MamutFeatureComputation.getDialog( appModel, context );
 		featureComputationDialog.setIconImages( FEATURES_ICON );
+		appModel.projectClosedListeners().add( featureComputationDialog::dispose );
 
 		/*
 		 * Register windows.


### PR DESCRIPTION
The unit test in `GarbageCollectionTest` fails currently, when executed with an enabled graphics environement.
This is because `TagSetDialog`, `FeatureComputationDialog` and `PreferencesDialog` are no longer disposed properly since the latest changes to the app model.

This PR fixes the problem by adding the dialog's `dispose()` methods to the `ProjectModel.projectClosedListeners()`.