### PR TITLE
Fix "File > Save Project As...".

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/ProjectActions.java
+++ b/src/main/java/org/mastodon/mamut/io/ProjectActions.java
@@ -110,8 +110,8 @@ public class ProjectActions
 	 */
 	public static void installAppActions( final Actions actions, final ProjectModel appModel, final Frame parentComponent )
 	{
-		final RunnableAction saveProjectAction = new RunnableAction( SAVE_PROJECT, () -> ProjectSaver.saveProject( appModel, parentComponent ) );
-		final RunnableAction saveProjectAsAction = new RunnableAction( SAVE_PROJECT_AS, () -> ProjectSaver.saveProjectAs( appModel, parentComponent ) );
+		final RunnableAction saveProjectAction = new RunnableAction( SAVE_PROJECT, runInNewThread( () -> ProjectSaver.saveProject( appModel, parentComponent ) ) );
+		final RunnableAction saveProjectAsAction = new RunnableAction( SAVE_PROJECT_AS, runInNewThread( () -> ProjectSaver.saveProjectAs( appModel, parentComponent ) ) );
 		final RunnableAction importTgmmAction = new RunnableAction( IMPORT_TGMM, () -> ProjectImporter.importTgmmDataWithDialog( appModel, parentComponent ) );
 		final RunnableAction importSimiAction = new RunnableAction( IMPORT_TGMM, () -> ProjectImporter.importSimiDataWithDialog( appModel, parentComponent ) );
 		final RunnableAction exportMamutAction = new RunnableAction( EXPORT_MAMUT, () -> ProjectExporter.exportMamut( appModel, parentComponent ) );
@@ -121,6 +121,22 @@ public class ProjectActions
 		actions.namedAction( importTgmmAction, IMPORT_TGMM_KEYS );
 		actions.namedAction( importSimiAction, IMPORT_SIMI_KEYS );
 		actions.namedAction( exportMamutAction, EXPORT_MAMUT_KEYS );
+	}
+
+	private static Runnable runInNewThread( Runnable o )
+	{
+		return () -> {
+			new Thread( () -> {
+				try
+				{
+					o.run();
+				}
+				catch ( Throwable t )
+				{
+					t.printStackTrace();
+				}
+			} ).start();
+		};
 	}
 
 	/*


### PR DESCRIPTION
In Mastodon beta-27 there is an exception when user runs "File > Save Project As...".

**The stack trace:**
```
Exception in thread "AWT-EventQueue-0" java.lang.Error: Cannot call invokeAndWait from the event dispatcher thread
	at java.awt.EventQueue.invokeAndWait(EventQueue.java:1331)
	at java.awt.EventQueue.invokeAndWait(EventQueue.java:1324)
	at javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1353)
	at org.mastodon.mamut.io.ProjectSaver.saveProjectAs(ProjectSaver.java:159)
	at org.mastodon.mamut.io.ProjectActions.lambda$installAppActions$4(ProjectActions.java:114)
	at org.scijava.ui.behaviour.util.RunnableAction.actionPerformed(RunnableAction.java:47)
	at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
```

**Why do we get thist exception?**

The `ProjectLoader.saveAs(...)` is called from the AWT thread. But method's implementation expects the method not to be called from the AWT thread. Hence the exception.

**Solution**

This PR fixes the problem by creating a new "worker thread" which than executes the "save as" method.

@tinevez I'm not sure if you are happy with this solution. Feel free to solve the problem differently.