### PR TITLE
Add methods getMaxTimepoint() and getMinTimepoint() to TreeUtils

### DIFF
--- a/src/main/java/org/mastodon/util/TreeUtils.java
+++ b/src/main/java/org/mastodon/util/TreeUtils.java
@@ -37,6 +37,9 @@ import org.mastodon.collection.RefStack;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Graph;
 import org.mastodon.graph.Vertex;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.pool.PoolCollectionWrapper;
 
 public class TreeUtils
 {
@@ -226,5 +229,31 @@ public class TreeUtils
 			if ( node.incomingEdges().isEmpty() )
 				roots.add( node );
 		return roots;
+	}
+
+	/**
+	 * Gets the minimum timepoint in the given {@link Model} at which at least one {@link Spot} exists in the Model.
+	 * @param model the {@link Model}
+	 * @return the timepoint
+	 */
+	public static int getMinTimepoint( final Model model )
+	{
+		int minTimepoint = Integer.MAX_VALUE;
+		for ( Spot spot : model.getGraph().vertices() )
+			minTimepoint = Math.min( minTimepoint, spot.getTimepoint() );
+		return minTimepoint;
+	}
+
+	/**
+	 * Gets the maximum timepoint in the given {@link Model} at which at least one {@link Spot} exists in the Model.
+	 * @param model the {@link Model}
+	 * @return the timepoint
+	 */
+	public static int getMaxTimepoint( final Model model )
+	{
+		int max = 0;
+		for ( Spot spot : model.getGraph().vertices() )
+			max = Math.max( max, spot.getTimepoint() );
+		return max;
 	}
 }

--- a/src/test/java/org/mastodon/util/TreeUtilsTest.java
+++ b/src/test/java/org/mastodon/util/TreeUtilsTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefSet;
+import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph1;
 import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph2;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
@@ -174,5 +175,20 @@ public class TreeUtilsTest
 	private static < T > Set< T > createSet( final T... elements )
 	{
 		return new HashSet<>( Arrays.asList( elements ) );
+	}
+
+	@Test
+	public void testGetMinTimepoint()
+	{
+		assertEquals( 0, TreeUtils.getMinTimepoint( new ExampleGraph1().getModel() ) );
+		assertEquals( 0, TreeUtils.getMinTimepoint( new ExampleGraph2().getModel() ) );
+
+	}
+
+	@Test
+	public void testGetMaxTimepoint()
+	{
+		assertEquals( 3, TreeUtils.getMaxTimepoint( new ExampleGraph1().getModel() ) );
+		assertEquals( 7, TreeUtils.getMaxTimepoint( new ExampleGraph2().getModel() ) );
 	}
 }


### PR DESCRIPTION
* These methods exist now in 2 plugins and by moving them to the core one could reduce code duplication
* cf. https://github.com/mastodon-sc/mastodon-tomancak/blob/1c2c684cd209bc8db7d75e0183674cf010434a2e/src/main/java/org/mastodon/mamut/tomancak/merging/Dataset.java#L63
* cf. https://github.com/mastodon-sc/mastodon-deep-lineage/blob/master/src/main/java/org/mastodon/mamut/util/LineageTreeUtils.java#L130