### PR TITLE
Replace custom distance method by distance method of imglib2

### DIFF
--- a/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputer.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/BranchDisplacementDurationFeatureComputer.java
@@ -28,6 +28,7 @@
  */
 package org.mastodon.mamut.feature.branch;
 
+import net.imglib2.util.Util;
 import org.mastodon.mamut.feature.MamutFeatureComputer;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.ModelGraph;
@@ -94,19 +95,8 @@ public class BranchDisplacementDurationFeatureComputer implements MamutFeatureCo
 		// get target spot
 		final Spot target = branchGraph.getLastLinkedVertex( branchSpot, ref2 );
 
-		output.dispMap.set( branchSpot, distance( source, target ) );
+		output.dispMap.set( branchSpot, Util.distance( source, target ) );
 		output.durMap.set( branchSpot, duration( source, target ) );
-	}
-
-	private double distance( Spot source, Spot target )
-	{
-		double d2 = 0.;
-		for ( int d = 0; d < 3; d++ )
-		{
-			final double dx = source.getDoublePosition( d ) - target.getDoublePosition( d );
-			d2 += dx * dx;
-		}
-		return Math.sqrt( d2 );
 	}
 
 	private double duration( Spot source, Spot target )


### PR DESCRIPTION
While searching for a method that can directly compute the distance between 2 spots in the Mastodon code base, I found the distance method in this class. Later, I learned that there is the same method in imglib2.

In order to simplify the code I suggest to replace this re-implementation by using the imglib2 version of this method.