### PR TITLE
Add the panel that showing current timepoint and number of spots to bdv views

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutBranchViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutBranchViewBdv.java
@@ -49,6 +49,7 @@ import org.mastodon.graph.GraphIdBimap;
 import org.mastodon.mamut.MainWindow;
 import org.mastodon.mamut.MamutMenuBuilder;
 import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.TimepointAndNumberOfSpotsPanel;
 import org.mastodon.mamut.model.BoundingSphereRadiusStatistics;
 import org.mastodon.mamut.model.BranchGraphModelOverlayProperties;
 import org.mastodon.mamut.model.Link;
@@ -209,6 +210,11 @@ public class MamutBranchViewBdv extends MamutBranchView<
 		BdvSelectionBehaviours.install( viewBehaviours, viewGraph, tracksOverlay, selectionModel, focusModel,
 				navigationHandler );
 		OverlayActions.install( viewActions, viewer, tracksOverlay );
+
+		// Add the timepoint and number of spots panel.
+		final TimepointAndNumberOfSpotsPanel timepointAndNumberOfSpotsPanel =
+				new TimepointAndNumberOfSpotsPanel( this.timepointModel, model );
+		frame.getSettingsPanel().add( timepointAndNumberOfSpotsPanel );
 
 		/*
 		 * We must make a search action using the underlying model graph,

--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
@@ -48,6 +48,7 @@ import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.mamut.MainWindow;
 import org.mastodon.mamut.MamutMenuBuilder;
 import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.TimepointAndNumberOfSpotsPanel;
 import org.mastodon.mamut.UndoActions;
 import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
@@ -231,6 +232,11 @@ public class MamutViewBdv
 		final Runnable onCloseMIPDialog = RecordMaxProjectionMovieDialog.install( viewActions, bdv, tracksOverlay,
 				colorBarOverlay, appModel.getKeymap() );
 		onClose( onCloseMIPDialog );
+
+		// Add the timepoint and number of spots panel.
+		final TimepointAndNumberOfSpotsPanel timepointAndNumberOfSpotsPanel =
+				new TimepointAndNumberOfSpotsPanel( this.timepointModel, model );
+		frame.getSettingsPanel().add( timepointAndNumberOfSpotsPanel );
 
 		/*
 		 * We must make a search action using the underlying model graph,


### PR DESCRIPTION
This PR adds the the info of the current timepoint and the current number of spots to the BDV

![grafik](https://github.com/mastodon-sc/mastodon/assets/10515534/32492c50-3040-445e-86de-d4369590653b)


Resolves #277 