### PR TITLE
Add Unit Test to Thoroughly Tests Mastodon's Undo Redo Mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
 
-		<mastodon-collection.version>1.0.0-beta-25</mastodon-collection.version>
+		<mastodon-collection.version>1.0.0-beta-26-SNAPSHOT</mastodon-collection.version>
 		<mastodon-graph.version>1.0.0-beta-25</mastodon-graph.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->

--- a/src/main/java/org/mastodon/mamut/model/ModelUtils.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelUtils.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -143,9 +144,9 @@ public class ModelUtils
 		spotsTable.defineColumn( 9, "Id", "", spot -> Integer.toString( spot.getInternalPoolIndex() ) );
 		spotsTable.defineColumn( 9, "Label", "", Spot::getLabel );
 		spotsTable.defineColumn( 6, "Frame", "", spot -> Integer.toString( spot.getTimepoint() ) );
-		spotsTable.defineColumn( 9, "X", bracket( spaceUnits ), spot -> String.format( "%9.1f", spot.getDoublePosition( 0 ) ) );
-		spotsTable.defineColumn( 9, "Y", bracket( spaceUnits ), spot -> String.format( "%9.1f", spot.getDoublePosition( 1 ) ) );
-		spotsTable.defineColumn( 9, "Z", bracket( spaceUnits ), spot -> String.format( "%9.1f", spot.getDoublePosition( 2 ) ) );
+		spotsTable.defineColumn( 9, "X", bracket( spaceUnits ), spot -> String.format( Locale.US, "%9.1f", spot.getDoublePosition( 0 ) ) );
+		spotsTable.defineColumn( 9, "Y", bracket( spaceUnits ), spot -> String.format( Locale.US, "%9.1f", spot.getDoublePosition( 1 ) ) );
+		spotsTable.defineColumn( 9, "Z", bracket( spaceUnits ), spot -> String.format( Locale.US, "%9.1f", spot.getDoublePosition( 2 ) ) );
 		if ( optionsSet.contains( DumpFlags.PRINT_TAGS ) )
 			addTagColumns( spotsTable, model.getTagSetModel().getTagSetStructure(), model.getTagSetModel().getVertexTags() );
 		if ( optionsSet.contains( DumpFlags.PRINT_FEATURES ) )
@@ -253,11 +254,11 @@ public class ModelUtils
 	{
 		if ( projection.isSet( t ) )
 			if ( projection instanceof IntFeatureProjection )
-				return String.format( "%" + width + "d", ( int ) projection.value( t ) );
+				return String.format( Locale.US, "%" + width + "d", ( int ) projection.value( t ) );
 			else
-				return String.format( "%" + width + ".1f", projection.value( t ) );
+				return String.format( Locale.US, "%" + width + ".1f", projection.value( t ) );
 		else
-			return String.format( "%" + width + "s", "unset" );
+			return String.format( Locale.US, "%" + width + "s", "unset" );
 	}
 
 	private static class TablePrinter< T >
@@ -273,10 +274,10 @@ public class ModelUtils
 		public void print( StringBuilder str, Iterable< T > rows, long maxLines )
 		{
 			for ( Column< T > column : columns )
-				str.append( String.format( column.template, column.header ) );
+				str.append( String.format( Locale.US, column.template, column.header ) );
 			str.append( '\n' );
 			for ( Column< T > column : columns )
-				str.append( String.format( column.template, column.unit ) );
+				str.append( String.format( Locale.US, column.template, column.unit ) );
 			str.append( '\n' );
 			int totalWidth = columns.stream().mapToInt( c -> c.width + 2 ).sum() - 2;
 			for ( int i = 0; i < totalWidth; i++ )
@@ -286,7 +287,7 @@ public class ModelUtils
 			for ( T row : rows )
 			{
 				for ( Column< T > column : columns )
-					str.append( String.format( column.template, column.valueToString.apply( row ) ) );
+					str.append( String.format( Locale.US, column.template, column.valueToString.apply( row ) ) );
 				str.append( '\n' );
 				i++;
 				if ( i >= maxLines )

--- a/src/main/java/org/mastodon/mamut/model/ModelUtils.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelUtils.java
@@ -45,15 +45,31 @@ import org.mastodon.feature.IntFeatureProjection;
 import org.mastodon.mamut.feature.SpotTrackIDFeature;
 import org.mastodon.model.tag.ObjTagMap;
 import org.mastodon.model.tag.ObjTags;
-import org.mastodon.model.tag.TagSetModel;
 import org.mastodon.model.tag.TagSetStructure;
 
 public class ModelUtils
 {
 	public enum DumpFlags
 	{
+		/**
+		 * If this flag is provided, {@link #dump(Model, DumpFlags...)} will include
+		 * the string returned by {@link Model#toString()} and hence the value of
+		 * {@link Model#hashCode()}. This can be useful to associate the "dump" with
+		 * a specific model instance. But it comes at the cost of making the output
+		 * less predictable.
+		 */
 		PRINT_HASH,
+
+		/**
+		 * If this flag is provided, {@link #dump(Model, DumpFlags...)} will include
+		 * the values stored in th {@link Model#getFeatureModel() feature model}.
+		 */
 		PRINT_FEATURES,
+
+		/**
+		 * If this flag is provided, {@link #dump(Model, DumpFlags...)} will include
+		 * the tags stored in the {@link Model#getTagSetModel() tag set model}.
+		 */
 		PRINT_TAGS
 	}
 
@@ -64,7 +80,7 @@ public class ModelUtils
 	 * The tables by default contain all spot and link properties as well
 	 * as the feature values.
 	 * <p>
-	 * There is also a method that {@link #dump(Model, DumpFlags...)}
+	 * There is also a method {@link #dump(Model, DumpFlags...)} that
 	 * allows to select which information to include in the table.
 	 */
 	public static final String dump( final Model model )
@@ -75,9 +91,8 @@ public class ModelUtils
 	/**
 	 * Returns a string representation of the specified model content as two
 	 * text tables.
-	 * <p>
-	 * Which information to include in the table can be changed using
-	 * {@link DumpFlags}.
+	 * @param model The model to generate the dump for.
+	 * @param options Which information to include in the tables can be changed using {@link DumpFlags}.
 	 */
 	public static final String dump( final Model model, final DumpFlags... options )
 	{
@@ -86,13 +101,15 @@ public class ModelUtils
 
 	/**
 	 * Returns a string representation of the specified model content as two
-	 * text tables. The number of lines in each table is limeted to {@code maxLines}.
+	 * text tables. The number of lines in each table is limited to {@code maxLines}.
 	 * <p>
 	 * The tables by default contain all spot and link properties as well
 	 * as the feature values.
 	 * <p>
-	 * There is also a method that {@link #dump(Model, long, DumpFlags...)}
+	 * There is also a method {@link #dump(Model, long, DumpFlags...)} that
 	 * allows to select which information to include in the table.
+	 *
+	 * @param maxLines the max number of rows to print in the two tables.
 	 */
 	public static final String dump( final Model model, final long maxLines )
 	{
@@ -101,12 +118,10 @@ public class ModelUtils
 
 	/**
 	 * Returns a string representation of the specified model content as two
-	 * text tables. The number of lines in each table is limeted to {@code maxLines}.
-	 * <p>
-	 * The printed content is limited to the specified number of lines.
-	 * <p>
-	 * Which information to include in the table can be changed using
-	 * {@link DumpFlags}.
+	 * text tables.
+	 * @param model The model to generate the dump for.
+	 * @param maxLines the max number of rows to print in the two tables.
+	 * @param options Which information to include in the tables can be changed using {@link DumpFlags}.
 	 */
 	public static final String dump( final Model model, final long maxLines, final DumpFlags... options )
 	{
@@ -303,7 +318,7 @@ public class ModelUtils
 		}
 	}
 
-	private static final String bracket( final String str )
+	private static String bracket( final String str )
 	{
 		return str.isEmpty() ? "" : "(" + str + ")";
 	}

--- a/src/main/java/org/mastodon/mamut/model/ModelUtils.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelUtils.java
@@ -127,7 +127,7 @@ public class ModelUtils
 	 */
 	public static final String dump( final Model model, final long maxLines, final DumpFlags... options )
 	{
-		Set< DumpFlags > optionsSet = EnumSet.copyOf( Arrays.asList( options ) );
+		final Set< DumpFlags > optionsSet = EnumSet.copyOf( Arrays.asList( options ) );
 		final FeatureModel featureModel = model.getFeatureModel();
 		final List< FeatureSpec< ?, ? > > featureSpecs = new ArrayList<>( featureModel.getFeatureSpecs() );
 		featureSpecs.sort( Comparator.comparing( FeatureSpec::getKey ) );
@@ -145,12 +145,12 @@ public class ModelUtils
 		return str.toString();
 	}
 
-	private static void addSpotsTable( Model model, long maxLines, Set< DumpFlags > optionsSet, List< FeatureSpec< ?, ? > > featureSpecs, StringBuilder str )
+	private static void addSpotsTable( final Model model, final long maxLines, final Set< DumpFlags > optionsSet, final List< FeatureSpec< ?, ? > > featureSpecs, final StringBuilder str )
 	{
 		final String spaceUnits = Optional.ofNullable( model.getSpaceUnits() ).orElse( "" );
 		final ModelGraph graph = model.getGraph();
 		final FeatureModel featureModel = model.getFeatureModel();
-		TablePrinter< Spot > spotsTable = new TablePrinter<>();
+		final TablePrinter< Spot > spotsTable = new TablePrinter<>();
 		spotsTable.defineColumn( 9, "Id", "", spot -> Integer.toString( spot.getInternalPoolIndex() ) );
 		spotsTable.defineColumn( 9, "Label", "", Spot::getLabel );
 		spotsTable.defineColumn( 6, "Frame", "", spot -> Integer.toString( spot.getTimepoint() ) );
@@ -162,15 +162,15 @@ public class ModelUtils
 		if ( optionsSet.contains( DumpFlags.PRINT_FEATURES ) )
 			addFeatureColumns( featureSpecs, featureModel, spotsTable, Spot.class );
 
-		List< Spot > spots = getSortedSpots( graph, featureModel );
+		final List< Spot > spots = getSortedSpots( graph, featureModel );
 		spotsTable.print( str, spots, maxLines );
 	}
 
-	private static void addLinksTable( Model model, long maxLines, Set< DumpFlags > optionsSet, List< FeatureSpec< ?, ? > > featureSpecs, StringBuilder str )
+	private static void addLinksTable( final Model model, final long maxLines, final Set< DumpFlags > optionsSet, final List< FeatureSpec< ?, ? > > featureSpecs, final StringBuilder str )
 	{
 		final ModelGraph graph = model.getGraph();
 		final FeatureModel featureModel = model.getFeatureModel();
-		TablePrinter< Link > linkTable = new TablePrinter<>();
+		final TablePrinter< Link > linkTable = new TablePrinter<>();
 		linkTable.defineColumn( 9, "Id", "", link -> Integer.toString( link.getInternalPoolIndex() ) );
 		final Spot ref = graph.vertexRef();
 		linkTable.defineColumn( 9, "Source Id", "", link -> Integer.toString( link.getSource( ref ).getInternalPoolIndex() ) );
@@ -183,21 +183,20 @@ public class ModelUtils
 		linkTable.print( str, graph.edges(), maxLines );
 	}
 
-
-	private static < T > void addTagColumns( TablePrinter< T > table, TagSetStructure tagSetStructure, ObjTags< T > tags )
+	private static < T > void addTagColumns( final TablePrinter< T > table, final TagSetStructure tagSetStructure, final ObjTags< T > tags )
 	{
-		for ( TagSetStructure.TagSet tagSet : tagSetStructure.getTagSets() )
+		for ( final TagSetStructure.TagSet tagSet : tagSetStructure.getTagSets() )
 		{
-			String header = tagSet.getName();
-			ObjTagMap< T, TagSetStructure.Tag > tagSetTags = tags.tags( tagSet );
+			final String header = tagSet.getName();
+			final ObjTagMap< T, TagSetStructure.Tag > tagSetTags = tags.tags( tagSet );
 			table.defineColumn( header.length(), header, "", spotOrLink -> {
-				TagSetStructure.Tag tag = tagSetTags.get( spotOrLink );
+				final TagSetStructure.Tag tag = tagSetTags.get( spotOrLink );
 				return tag == null ? "" : tag.label();
 			} );
 		}
 	}
 
-	private static < T > void addFeatureColumns( List< FeatureSpec< ?, ? > > featureSpecs, FeatureModel featureModel, TablePrinter< T > table, Class< T > targetClass )
+	private static < T > void addFeatureColumns( final List< FeatureSpec< ?, ? > > featureSpecs, final FeatureModel featureModel, final TablePrinter< T > table, final Class< T > targetClass )
 	{
 		for ( final FeatureSpec< ?, ? > featureSpec : featureSpecs )
 		{
@@ -218,7 +217,7 @@ public class ModelUtils
 		}
 	}
 
-	private static RefArrayList< Spot > getSortedSpots( ModelGraph graph, FeatureModel featureModel )
+	private static RefArrayList< Spot > getSortedSpots( final ModelGraph graph, final FeatureModel featureModel )
 	{
 		final RefArrayList< Spot > spots = new RefArrayList<>( graph.vertices().getRefPool(), graph.vertices().size() );
 		spots.addAll( graph.vertices() );
@@ -226,7 +225,7 @@ public class ModelUtils
 		return spots;
 	}
 
-	private static Comparator< Spot > getSpotComparator( FeatureModel featureModel )
+	private static Comparator< Spot > getSpotComparator( final FeatureModel featureModel )
 	{
 		if ( featureModel.getFeatureSpecs().contains( SpotTrackIDFeature.SPEC ) )
 		{
@@ -239,7 +238,7 @@ public class ModelUtils
 			return Comparator.comparingInt( Spot::getTimepoint ).thenComparing( Spot::getInternalPoolIndex );
 	}
 
-	private static < T > String valueAsString( FeatureProjection< T > projection, T t, int width )
+	private static < T > String valueAsString( final FeatureProjection< T > projection, final T t, final int width )
 	{
 		if ( !projection.isSet( t ) )
 			return String.format( Locale.US, "%" + width + "s", "unset" );
@@ -255,27 +254,27 @@ public class ModelUtils
 
 		private final List< Column< T > > columns = new ArrayList<>();
 
-		public void defineColumn( int width, String title, String unit, Function< T, String > toString )
+		public void defineColumn( final int width, final String title, final String unit, final Function< T, String > toString )
 		{
 			columns.add( new Column<>( columns.isEmpty(), width, title, unit, toString ) );
 		}
 
-		public void print( StringBuilder str, Iterable< T > rows, long maxLines )
+		public void print( final StringBuilder str, final Iterable< T > rows, final long maxLines )
 		{
-			for ( Column< T > column : columns )
+			for ( final Column< T > column : columns )
 				str.append( String.format( Locale.US, column.template, column.header ) );
 			str.append( '\n' );
-			for ( Column< T > column : columns )
+			for ( final Column< T > column : columns )
 				str.append( String.format( Locale.US, column.template, column.unit ) );
 			str.append( '\n' );
-			int totalWidth = columns.stream().mapToInt( c -> c.width + 2 ).sum() - 2;
+			final int totalWidth = columns.stream().mapToInt( c -> c.width + 2 ).sum() - 2;
 			for ( int i = 0; i < totalWidth; i++ )
 				str.append( '-' );
 			str.append( '\n' );
 			long i = 0;
-			for ( T row : rows )
+			for ( final T row : rows )
 			{
-				for ( Column< T > column : columns )
+				for ( final Column< T > column : columns )
 					str.append( String.format( Locale.US, column.template, column.valueToString.apply( row ) ) );
 				str.append( '\n' );
 				i++;
@@ -298,7 +297,7 @@ public class ModelUtils
 
 		private final Function< T, String > valueToString;
 
-		private Column( boolean isFirst, int width, String header, String unit, Function< T, String > valueToString )
+		private Column( final boolean isFirst, final int width, final String header, final String unit, final Function< T, String > valueToString )
 		{
 			this.header = header;
 			this.unit = unit;

--- a/src/main/java/org/mastodon/mamut/model/ModelUtils.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelUtils.java
@@ -241,13 +241,13 @@ public class ModelUtils
 
 	private static < T > String valueAsString( FeatureProjection< T > projection, T t, int width )
 	{
-		if ( projection.isSet( t ) )
-			if ( projection instanceof IntFeatureProjection )
-				return String.format( Locale.US, "%" + width + "d", ( int ) projection.value( t ) );
-			else
-				return String.format( Locale.US, "%" + width + ".1f", projection.value( t ) );
-		else
+		if ( !projection.isSet( t ) )
 			return String.format( Locale.US, "%" + width + "s", "unset" );
+
+		if ( projection instanceof IntFeatureProjection )
+			return String.format( Locale.US, "%" + width + "d", ( int ) projection.value( t ) );
+		else
+			return String.format( Locale.US, "%" + width + ".1f", projection.value( t ) );
 	}
 
 	private static class TablePrinter< T >

--- a/src/test/java/org/mastodon/mamut/model/ModelUndoRedoTest.java
+++ b/src/test/java/org/mastodon/mamut/model/ModelUndoRedoTest.java
@@ -55,14 +55,14 @@ public class ModelUndoRedoTest
 	@Test
 	public void testUndoRedo()
 	{
-		Model model = new Model();
-		ModelGraph graph = model.getGraph();
+		final Model model = new Model();
+		final ModelGraph graph = model.getGraph();
 		model.setUndoPoint();
-		Spot a = graph.addVertex().init( 0, new double[ 3 ], 1 );
+		final Spot a = graph.addVertex().init( 0, new double[ 3 ], 1 );
 		a.setLabel( "A" );
 		model.setUndoPoint();
 		assertEquals( "A", graphAsString( graph ) );
-		Spot b = graph.addVertex().init( 0, new double[ 3 ], 1 );
+		final Spot b = graph.addVertex().init( 0, new double[ 3 ], 1 );
 		b.setLabel( "B" );
 		model.setUndoPoint();
 		assertEquals( "A, B", graphAsString( graph ) );
@@ -86,17 +86,17 @@ public class ModelUndoRedoTest
 	/**
 	 * Returns a readable sting representation of the graph.
 	 */
-	private String graphAsString( ModelGraph graph )
+	private String graphAsString( final ModelGraph graph )
 	{
-		List< String > spots = new ArrayList<>();
-		for ( Spot spot : graph.vertices() )
+		final List< String > spots = new ArrayList<>();
+		for ( final Spot spot : graph.vertices() )
 			spots.add( spot.getLabel() );
 		Collections.sort( spots );
-		List< String > links = new ArrayList<>();
-		for ( Link link : graph.edges() )
+		final List< String > links = new ArrayList<>();
+		for ( final Link link : graph.edges() )
 			links.add( link.getSource().getLabel() + "->" + link.getTarget().getLabel() );
 		Collections.sort( links );
-		StringJoiner joiner = new StringJoiner( ", " );
+		final StringJoiner joiner = new StringJoiner( ", " );
 		spots.forEach( joiner::add );
 		links.forEach( joiner::add );
 		return joiner.toString();
@@ -109,7 +109,7 @@ public class ModelUndoRedoTest
 	@Test
 	public void testUndoRedoOnEmptyModel()
 	{
-		Model model = new Model();
+		final Model model = new Model();
 		testUndoRedo( model );
 	}
 
@@ -119,7 +119,7 @@ public class ModelUndoRedoTest
 	 * set. Then, the undo and redo methods are called to test if the model is
 	 * restored to the intended state.
 	 */
-	private static void testUndoRedo( Model model )
+	private static void testUndoRedo( final Model model )
 	{
 		final List< String > states = new ArrayList<>();
 		makeVariousChangesAndRecordUndoPoints( model, states );
@@ -127,29 +127,29 @@ public class ModelUndoRedoTest
 		redoAllRecordedPointsAndVerifyCorrectness( model, states );
 	}
 
-	private static void makeVariousChangesAndRecordUndoPoints( Model model, List< String > states )
+	private static void makeVariousChangesAndRecordUndoPoints( final Model model, final List< String > states )
 	{
-		ModelGraph graph = model.getGraph();
+		final ModelGraph graph = model.getGraph();
 		// add spot A
-		Spot a = graph.addVertex().init( 2, new double[] { 1, 2, 3 }, 1.5 );
+		final Spot a = graph.addVertex().init( 2, new double[] { 1, 2, 3 }, 1.5 );
 		a.setLabel( "spot A" );
 		setUndoPointAndRecordState( model, states );
 
 		// add spot B
-		Spot b = graph.addVertex().init( 3, new double[] { 1, 2, 4 }, 1.7 );
+		final Spot b = graph.addVertex().init( 3, new double[] { 1, 2, 4 }, 1.7 );
 		b.setLabel( "spot B" );
 		setUndoPointAndRecordState( model, states );
 
 		// add edge
-		Link edge = graph.addEdge( a, b ).init();
+		final Link edge = graph.addEdge( a, b ).init();
 		setUndoPointAndRecordState( model, states );
 
 		// add tag set
-		TagSetStructure.TagSet tagset = TagSetUtils.addNewTagSetToModel( model, "tag set 1", Arrays.asList(
+		final TagSetStructure.TagSet tagset = TagSetUtils.addNewTagSetToModel( model, "tag set 1", Arrays.asList(
 				Pair.of( "tag1", Color.red.getRGB() ),
 				Pair.of( "tag2", Color.green.getRGB() ) ) );
-		TagSetStructure.Tag tag1 = tagset.getTags().get( 0 );
-		TagSetStructure.Tag tag2 = tagset.getTags().get( 1 );
+		final TagSetStructure.Tag tag1 = tagset.getTags().get( 0 );
+		final TagSetStructure.Tag tag2 = tagset.getTags().get( 1 );
 		TagSetUtils.tagSpot( model, tagset, tag1, a );
 		TagSetUtils.tagSpot( model, tagset, tag2, b );
 		TagSetUtils.tagLinks( model, tagset, tag1, Collections.singletonList( edge ) );
@@ -165,7 +165,7 @@ public class ModelUndoRedoTest
 		setUndoPointAndRecordState( model, states );
 
 		// change covariance
-		double[][] cov = { { 2, 0.1, 0 }, { 0.1, 2.5, 0 }, { 0, 0, 2.1 } };
+		final double[][] cov = { { 2, 0.1, 0 }, { 0.1, 2.5, 0 }, { 0, 0, 2.1 } };
 		a.setCovariance( cov );
 		setUndoPointAndRecordState( model, states );
 
@@ -178,13 +178,13 @@ public class ModelUndoRedoTest
 		setUndoPointAndRecordState( model, states );
 	}
 
-	public static void setUndoPointAndRecordState( Model model, List< String > states )
+	public static void setUndoPointAndRecordState( final Model model, final List< String > states )
 	{
 		model.setUndoPoint();
 		states.add( modelAsString( model ) );
 	}
 
-	public static void undoAllRecordedPointsAndVerifyCorrectness( Model model, List< String > states )
+	public static void undoAllRecordedPointsAndVerifyCorrectness( final Model model, final List< String > states )
 	{
 		for ( int i = states.size() - 1; i > 0; i-- )
 		{
@@ -194,7 +194,7 @@ public class ModelUndoRedoTest
 		assertEquals( states.get( 0 ), modelAsString( model ) );
 	}
 
-	public static void redoAllRecordedPointsAndVerifyCorrectness( Model model, List< String > states )
+	public static void redoAllRecordedPointsAndVerifyCorrectness( final Model model, final List< String > states )
 	{
 		assertEquals( states.get( 0 ), modelAsString( model ) );
 		for ( int i = 1; i < states.size(); i++ )
@@ -204,7 +204,7 @@ public class ModelUndoRedoTest
 		}
 	}
 
-	private static String modelAsString( Model model )
+	private static String modelAsString( final Model model )
 	{
 		return ModelUtils.dump( model, ModelUtils.DumpFlags.PRINT_TAGS );
 	}
@@ -222,7 +222,7 @@ public class ModelUndoRedoTest
 	@Test
 	public void testUndoRedoAfterModelImporter()
 	{
-		Model model = new Model();
+		final Model model = new Model();
 		// Fill the undo-redo history with many different entries:
 		makeVariousChangesAndRecordUndoPoints( model, new ArrayList<>() );
 		addFourSpotGraph( model );
@@ -240,14 +240,14 @@ public class ModelUndoRedoTest
 	/**
 	 * Adds three spots and two edges to the model.
 	 */
-	private void addThreeSpotGraph( Model model )
+	private void addThreeSpotGraph( final Model model )
 	{
-		ModelGraph graph = model.getGraph();
-		Spot a = graph.addVertex().init( 0, new double[] { 1, 0, 0 }, 1 );
+		final ModelGraph graph = model.getGraph();
+		final Spot a = graph.addVertex().init( 0, new double[] { 1, 0, 0 }, 1 );
 		a.setLabel( "A" );
-		Spot b = graph.addVertex().init( 1, new double[] { 0, 2, 0 }, 1 );
+		final Spot b = graph.addVertex().init( 1, new double[] { 0, 2, 0 }, 1 );
 		b.setLabel( "B" );
-		Spot c = graph.addVertex().init( 1, new double[] { 0, 0, 3 }, 1 );
+		final Spot c = graph.addVertex().init( 1, new double[] { 0, 0, 3 }, 1 );
 		c.setLabel( "C" );
 		graph.addEdge( a, b ).init();
 		graph.addEdge( a, c ).init();
@@ -257,16 +257,16 @@ public class ModelUndoRedoTest
 	/**
 	 * Adds four spots and three edges to the model.
 	 */
-	private void addFourSpotGraph( Model model )
+	private void addFourSpotGraph( final Model model )
 	{
-		ModelGraph graph = model.getGraph();
-		Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		final ModelGraph graph = model.getGraph();
+		final Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
 		a.setLabel( "A" );
-		Spot b = graph.addVertex().init( 1, new double[] { 2, 2, 3 }, 1 );
+		final Spot b = graph.addVertex().init( 1, new double[] { 2, 2, 3 }, 1 );
 		b.setLabel( "B" );
-		Spot c = graph.addVertex().init( 2, new double[] { 3, 2, 3 }, 1 );
+		final Spot c = graph.addVertex().init( 2, new double[] { 3, 2, 3 }, 1 );
 		c.setLabel( "C" );
-		Spot d = graph.addVertex().init( 3, new double[] { 4, 2, 3 }, 1 );
+		final Spot d = graph.addVertex().init( 3, new double[] { 4, 2, 3 }, 1 );
 		d.setLabel( "D" );
 		graph.addEdge( a, b ).init();
 		graph.addEdge( b, c ).init();

--- a/src/test/java/org/mastodon/mamut/model/ModelUndoRedoTest.java
+++ b/src/test/java/org/mastodon/mamut/model/ModelUndoRedoTest.java
@@ -1,0 +1,276 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2023 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.mastodon.mamut.io.importer.ModelImporter;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.util.TagSetUtils;
+
+/**
+ * The robustness of the undo and redo methods is crucial for Mastodon. This
+ * test thoroughly tests the undo and redo methods of the {@link Model} class.
+ */
+public class ModelUndoRedoTest
+{
+	/**
+	 * Test if undo and redo works for basic operations: adding spots and edges.
+	 */
+	@Test
+	public void testUndoRedo()
+	{
+		Model model = new Model();
+		ModelGraph graph = model.getGraph();
+		model.setUndoPoint();
+		Spot a = graph.addVertex().init( 0, new double[ 3 ], 1 );
+		a.setLabel( "A" );
+		model.setUndoPoint();
+		assertEquals( "A", graphAsString( graph ) );
+		Spot b = graph.addVertex().init( 0, new double[ 3 ], 1 );
+		b.setLabel( "B" );
+		model.setUndoPoint();
+		assertEquals( "A, B", graphAsString( graph ) );
+		graph.addEdge( a, b ).init();
+		model.setUndoPoint();
+		assertEquals( "A, B, A->B", graphAsString( graph ) );
+		model.undo();
+		assertEquals( "A, B", graphAsString( graph ) );
+		model.undo();
+		assertEquals( "A", graphAsString( graph ) );
+		model.undo();
+		assertEquals( "", graphAsString( graph ) );
+		model.redo();
+		assertEquals( "A", graphAsString( graph ) );
+		model.redo();
+		assertEquals( "A, B", graphAsString( graph ) );
+		model.redo();
+		assertEquals( "A, B, A->B", graphAsString( graph ) );
+	}
+
+	/**
+	 * Returns a readable sting representation of the graph.
+	 */
+	private String graphAsString( ModelGraph graph )
+	{
+		List< String > spots = new ArrayList<>();
+		for ( Spot spot : graph.vertices() )
+			spots.add( spot.getLabel() );
+		Collections.sort( spots );
+		List< String > links = new ArrayList<>();
+		for ( Link link : graph.edges() )
+			links.add( link.getSource().getLabel() + "->" + link.getTarget().getLabel() );
+		Collections.sort( links );
+		StringJoiner joiner = new StringJoiner( ", " );
+		spots.forEach( joiner::add );
+		links.forEach( joiner::add );
+		return joiner.toString();
+	}
+
+	/**
+	 * This test makes various changes to the model and then tests if the undo
+	 * and redo methods work as expected.
+	 */
+	@Test
+	public void testUndoRedoOnEmptyModel()
+	{
+		Model model = new Model();
+		testUndoRedo( model );
+	}
+
+	/**
+	 * This method makes various changes to the graph and the tag set model. The
+	 * changes are divided into several steps, and at each step, an undo point is
+	 * set. Then, the undo and redo methods are called to test if the model is
+	 * restored to the intended state.
+	 */
+	private static void testUndoRedo( Model model )
+	{
+		final List< String > states = new ArrayList<>();
+		makeVariousChangesAndRecordUndoPoints( model, states );
+		undoAllRecordedPointsAndVerifyCorrectness( model, states );
+		redoAllRecordedPointsAndVerifyCorrectness( model, states );
+	}
+
+	private static void makeVariousChangesAndRecordUndoPoints( Model model, List< String > states )
+	{
+		ModelGraph graph = model.getGraph();
+		// add spot A
+		Spot a = graph.addVertex().init( 2, new double[] { 1, 2, 3 }, 1.5 );
+		a.setLabel( "spot A" );
+		setUndoPointAndRecordState( model, states );
+
+		// add spot B
+		Spot b = graph.addVertex().init( 3, new double[] { 1, 2, 4 }, 1.7 );
+		b.setLabel( "spot B" );
+		setUndoPointAndRecordState( model, states );
+
+		// add edge
+		Link edge = graph.addEdge( a, b ).init();
+		setUndoPointAndRecordState( model, states );
+
+		// add tag set
+		TagSetStructure.TagSet tagset = TagSetUtils.addNewTagSetToModel( model, "tag set 1", Arrays.asList(
+				Pair.of( "tag1", Color.red.getRGB() ),
+				Pair.of( "tag2", Color.green.getRGB() ) ) );
+		TagSetStructure.Tag tag1 = tagset.getTags().get( 0 );
+		TagSetStructure.Tag tag2 = tagset.getTags().get( 1 );
+		TagSetUtils.tagSpot( model, tagset, tag1, a );
+		TagSetUtils.tagSpot( model, tagset, tag2, b );
+		TagSetUtils.tagLinks( model, tagset, tag1, Collections.singletonList( edge ) );
+		setUndoPointAndRecordState( model, states );
+
+		// change label
+		a.setLabel( "A0" );
+		b.setLabel( "B0" );
+		setUndoPointAndRecordState( model, states );
+
+		// change tag
+		TagSetUtils.tagSpot( model, tagset, tag2, a );
+		setUndoPointAndRecordState( model, states );
+
+		// change covariance
+		double[][] cov = { { 2, 0.1, 0 }, { 0.1, 2.5, 0 }, { 0, 0, 2.1 } };
+		a.setCovariance( cov );
+		setUndoPointAndRecordState( model, states );
+
+		// change spot position
+		b.setPosition( new double[] { 2.1, 2.3, 2.2 } );
+		setUndoPointAndRecordState( model, states );
+
+		// remove spot B
+		graph.remove( b );
+		setUndoPointAndRecordState( model, states );
+	}
+
+	public static void setUndoPointAndRecordState( Model model, List< String > states )
+	{
+		model.setUndoPoint();
+		states.add( modelAsString( model ) );
+	}
+
+	public static void undoAllRecordedPointsAndVerifyCorrectness( Model model, List< String > states )
+	{
+		for ( int i = states.size() - 1; i > 0; i-- )
+		{
+			assertEquals( states.get( i ), modelAsString( model ) );
+			model.undo();
+		}
+		assertEquals( states.get( 0 ), modelAsString( model ) );
+	}
+
+	public static void redoAllRecordedPointsAndVerifyCorrectness( Model model, List< String > states )
+	{
+		assertEquals( states.get( 0 ), modelAsString( model ) );
+		for ( int i = 1; i < states.size(); i++ )
+		{
+			model.redo();
+			assertEquals( states.get( i ), modelAsString( model ) );
+		}
+	}
+
+	private static String modelAsString( Model model )
+	{
+		return ModelUtils.dump( model, ModelUtils.DumpFlags.PRINT_TAGS );
+	}
+
+	/**
+	 * This test ensures that the undo and redo methods work as expected even
+	 * after the running ModelImporter.
+	 * <p>
+	 * The test first performs various changes to the model. Simply to fill the
+	 * undo-redo history with many different entries. Then running the ModelImporter
+	 * will reset the model and the undo-redo history.
+	 * This test ensures that the undo and redo methods work as expected even after
+	 * the model has been reset by the ModelImporter.
+	 */
+	@Test
+	public void testUndoRedoAfterModelImporter()
+	{
+		Model model = new Model();
+		// Fill the undo-redo history with many different entries:
+		makeVariousChangesAndRecordUndoPoints( model, new ArrayList<>() );
+		addFourSpotGraph( model );
+		// Reset the model by running the ModelImporter / Simulate an import operation:
+		new ModelImporter( model )
+		{{
+			this.startImport();
+			addThreeSpotGraph( model );
+			this.finishImport();
+		}};
+		// Test if the undo and redo still work as expected:
+		testUndoRedo( model );
+	}
+
+	/**
+	 * Adds three spots and two edges to the model.
+	 */
+	private void addThreeSpotGraph( Model model )
+	{
+		ModelGraph graph = model.getGraph();
+		Spot a = graph.addVertex().init( 0, new double[] { 1, 0, 0 }, 1 );
+		a.setLabel( "A" );
+		Spot b = graph.addVertex().init( 1, new double[] { 0, 2, 0 }, 1 );
+		b.setLabel( "B" );
+		Spot c = graph.addVertex().init( 1, new double[] { 0, 0, 3 }, 1 );
+		c.setLabel( "C" );
+		graph.addEdge( a, b ).init();
+		graph.addEdge( a, c ).init();
+		model.setUndoPoint();
+	}
+
+	/**
+	 * Adds four spots and three edges to the model.
+	 */
+	private void addFourSpotGraph( Model model )
+	{
+		ModelGraph graph = model.getGraph();
+		Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		a.setLabel( "A" );
+		Spot b = graph.addVertex().init( 1, new double[] { 2, 2, 3 }, 1 );
+		b.setLabel( "B" );
+		Spot c = graph.addVertex().init( 2, new double[] { 3, 2, 3 }, 1 );
+		c.setLabel( "C" );
+		Spot d = graph.addVertex().init( 3, new double[] { 4, 2, 3 }, 1 );
+		d.setLabel( "D" );
+		graph.addEdge( a, b ).init();
+		graph.addEdge( b, c ).init();
+		graph.addEdge( c, d ).init();
+		model.setUndoPoint();
+	}
+}

--- a/src/test/java/org/mastodon/mamut/model/ModelUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/model/ModelUtilsTest.java
@@ -46,15 +46,15 @@ public class ModelUtilsTest
 	@Test
 	public void testDump()
 	{
-		Model model = new Model();
-		ModelGraph graph = model.getGraph();
-		Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
-		Spot b = graph.addVertex().init( 1, new double[] { 1, 2, 3.2 }, 1 );
+		final Model model = new Model();
+		final ModelGraph graph = model.getGraph();
+		final Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		final Spot b = graph.addVertex().init( 1, new double[] { 1, 2, 3.2 }, 1 );
 		a.setLabel( "A" );
 		b.setLabel( "B" );
 		graph.addEdge( a, b ).init();
-		String actual = ModelUtils.dump( model );
-		String expexted = "Model " + model + "\n"
+		final String actual = ModelUtils.dump( model );
+		final String expexted = "Model " + model + "\n"
 				+ "Spots:\n"
 				+ "       Id      Label   Frame          X          Y          Z    N incoming links    N outgoing links    Spot N links    Spot frame          X          Y          Z    Spot radius\n"
 				+ "                                (pixel)    (pixel)    (pixel)                                                                          (pixel)    (pixel)    (pixel)        (pixel)\n"
@@ -72,24 +72,24 @@ public class ModelUtilsTest
 	@Test
 	public void testDumpWithTagSets()
 	{
-		Model model = new Model();
-		ModelGraph graph = model.getGraph();
-		Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
-		Spot b = graph.addVertex().init( 1, new double[] { 1, 2, 3.2 }, 1 );
+		final Model model = new Model();
+		final ModelGraph graph = model.getGraph();
+		final Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		final Spot b = graph.addVertex().init( 1, new double[] { 1, 2, 3.2 }, 1 );
 		a.setLabel( "A" );
 		b.setLabel( "B" );
-		Link edge = graph.addEdge( a, b ).init();
+		final Link edge = graph.addEdge( a, b ).init();
 		TagSetUtils.addNewTagSetToModel( model, "my tag set", Arrays.asList(
 				Pair.of( "tag1", Color.YELLOW.getRGB() ),
 				Pair.of( "tag2", Color.BLUE.getRGB() )
 		) );
-		TagHelper tag1 = new TagHelper( model, "my tag set", "tag1" );
+		final TagHelper tag1 = new TagHelper( model, "my tag set", "tag1" );
 		tag1.tagSpot( a );
-		TagHelper tag2 = new TagHelper( model, "my tag set", "tag2" );
+		final TagHelper tag2 = new TagHelper( model, "my tag set", "tag2" );
 		tag2.tagSpot( b );
 		tag2.tagLink( edge );
-		String actual = ModelUtils.dump( model, ModelUtils.DumpFlags.PRINT_TAGS );
-		String expected = "Spots:\n"
+		final String actual = ModelUtils.dump( model, ModelUtils.DumpFlags.PRINT_TAGS );
+		final String expected = "Spots:\n"
 				+ "       Id      Label   Frame          X          Y          Z  my tag set\n"
 				+ "                                (pixel)    (pixel)    (pixel)            \n"
 				+ "-------------------------------------------------------------------------\n"

--- a/src/test/java/org/mastodon/model/ModelUtilsTest.java
+++ b/src/test/java/org/mastodon/model/ModelUtilsTest.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2023 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.ModelUtils;
+import org.mastodon.mamut.model.Spot;
+
+public class ModelUtilsTest
+{
+	@Test
+	public void testDump()
+	{
+		Model model = new Model();
+		ModelGraph graph = model.getGraph();
+		Spot a = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		Spot b = graph.addVertex().init( 1, new double[] { 1, 2, 3.2 }, 1 );
+		a.setLabel( "A" );
+		b.setLabel( "B" );
+		graph.addEdge( a, b ).init();
+		String actual = ModelUtils.dump( model );
+		String expexted = "Model -\n"
+				+ "Spots:\n"
+				+ "       Id      Label   Frame          X          Y          Z    N incoming links    N outgoing links    Spot N links    Spot frame          X          Y          Z    Spot radius\n"
+				+ "                                (pixel)    (pixel)    (pixel)                                                                          (pixel)    (pixel)    (pixel)        (pixel)\n"
+				+ "-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n"
+				+ "        0          A       0        1.0        2.0        3.0                   0                   1               1             0        1.0        2.0        3.0            1.0\n"
+				+ "        1          B       1        1.0        2.0        3.2                   1                   0               1             1        1.0        2.0        3.2            1.0\n"
+				+ "Links:\n"
+				+ "       Id  Source Id  Target Id    Link delta T    Link displacement    Source spot id    Target spot id    Link velocity\n"
+				+ "                                                             (pixel)                                        (pixel/frame)\n"
+				+ "-------------------------------------------------------------------------------------------------------------------------\n"
+				+ "        0          0          1             1.0                  0.2               0.0               1.0              0.2\n";
+		assertEquals( expexted, actual.replaceFirst( "^Model.*", "Model -" ) );
+	}
+}


### PR DESCRIPTION
There is a PR to fix a small problem in Mastodon's undo/redo mechanism: https://github.com/mastodon-sc/mastodon-collection/pull/16

The goal of this PR is to ensure that Mastodons very important undo/redo mechanism works properly. I there for added a unit test `ModelUndoRedoTest`. The unit test uses the `ModelUtils.dump(...)` method to convert the current status of the `Model` into a string. Converting the model status into string allows me to test if the model is correctly rolled back into a specific (previously) recorded state.

It was necessary to extend the `ModelUtils.dump(...)` method to also print the tag sets. (The undo redo mechanism handle tags as well.)