### PR TITLE
Focus the created Spot of AddSpotAndLinkIt behaviour directly, when it is created

### DIFF
--- a/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
@@ -475,7 +475,7 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 				// Create new vertex under click location.
 				source.getCovariance( mat );
 				final int timepoint = viewer.state().getCurrentTimepoint();
-				overlayGraph.addVertex( target ).init( timepoint, pos, mat );
+				V vertex = overlayGraph.addVertex( target ).init( timepoint, pos, mat );
 
 				// Link it to source vertex. Careful for oriented edge.
 				if ( forward )
@@ -489,6 +489,8 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 				overlay.paintGhostLink = true;
 				overlay.paintGhostVertex = true;
 				overlayGraph.notifyGraphChanged();
+				if ( FOCUS_EDITED_SPOT )
+					focus.focusVertex( vertex );
 
 				lock.readLock().lock();
 				lock.writeLock().unlock();


### PR DESCRIPTION
I tried to find the reason for #295.

I found a potential solution. With the changes of this PR the described bug cannot be reproduced anymore.
Big disclaimer: I am quite unsure about potential side effects of this change.

Also: https://github.com/mastodon-sc/mastodon/blob/373a2a95901c0d496a18a78b4a5ee37ada822a7b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java#L525 may be removed after this change. This as well I am unsure about.
