### PR TITLE
Make TrackMateImporter robust against non integer frame numbers

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImporter.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/trackmate/TrackMateImporter.java
@@ -376,7 +376,7 @@ public class TrackMateImporter
 						pos[ 1 ] = Double.parseDouble( spotEl.getAttributeValue( POSITION_Y_FEATURE_NAME ) );
 						pos[ 2 ] = Double.parseDouble( spotEl.getAttributeValue( POSITION_Z_FEATURE_NAME ) );
 						final double radius = Double.parseDouble( spotEl.getAttributeValue( RADIUS_FEATURE_NAME ) );
-						final int frame = Integer.parseInt( spotEl.getAttributeValue( FRAME_FEATURE_NAME ) );
+						final int frame = ( int ) Double.parseDouble( spotEl.getAttributeValue( FRAME_FEATURE_NAME ) );
 						final int id = Integer.parseInt( spotEl.getAttributeValue( ID_FEATURE_NAME ) );
 						final String label = spotEl.getAttributeValue( LABEL_FEATURE_NAME );
 


### PR DESCRIPTION
This PR aims at making the TrackMateImporter more robust against non pure integer frame numbers.

I received a MaMuT file from a collaborator that contained frame numbers, such as `FRAME=0.0`, `FRAME=1.0`, etc.
While the decimal digit does not make any sense, it seems to be the case that some MaMuT version are storing them, cf. this snippet from a MaMuT file:
![grafik](https://github.com/mastodon-sc/mastodon/assets/10515534/da911f4e-2ee8-4de9-89d1-9191bf2fbe01)

This lead to an exception while importing the MaMuT file into Mastodon:
![grafik](https://github.com/mastodon-sc/mastodon/assets/10515534/85d464b3-9f96-4d56-9428-ccaf4d0ba8d2)

This PR provides a workaround for this situation.
