### PR TITLE
Add svg and png export to trackscheme panels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,12 @@
 		<dependency>
 			<groupId>io.humble</groupId>
 			<artifactId>humble-video-all</artifactId>
-		</dependency>		
+		</dependency>
+		<!-- export of panels to svg -->
+		<dependency>
+			<groupId>org.jfree</groupId>
+			<artifactId>jfreesvg</artifactId>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
@@ -63,6 +63,7 @@ import org.mastodon.model.FocusModel;
 import org.mastodon.model.HighlightModel;
 import org.mastodon.model.NavigationHandler;
 import org.mastodon.model.SelectionModel;
+import org.mastodon.ui.ExportViewActions;
 import org.mastodon.ui.FocusActions;
 import org.mastodon.ui.HighlightBehaviours;
 import org.mastodon.ui.SelectionActions;
@@ -259,6 +260,8 @@ public class MamutViewBdv
 		viewer.timePointListeners().add( timePointIndex -> timepointModel.setTimepoint( timePointIndex ) );
 		timepointModel.listeners().add( () -> viewer.setTimepoint( timepointModel.getTimepoint() ) );
 
+		ExportViewActions.install( viewActions, frame.getViewerPanel(), frame, "BDV" );
+
 		final RenderSettingsManager renderSettingsManager = appModel.getWindowManager().getManager( RenderSettingsManager.class );
 		final RenderSettings renderSettings = renderSettingsManager.getForwardDefaultStyle();
 		tracksOverlay.setRenderSettings( renderSettings );
@@ -284,7 +287,10 @@ public class MamutViewBdv
 						item( BigDataViewerActions.SAVE_SETTINGS ),
 						separator(),
 						item( RecordMovieDialog.RECORD_MOVIE_DIALOG ),
-						item( RecordMaxProjectionMovieDialog.RECORD_MIP_MOVIE_DIALOG ) ),
+						item( RecordMaxProjectionMovieDialog.RECORD_MIP_MOVIE_DIALOG ),
+						separator(),
+						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
+						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
 				viewMenu(
 						separator(),
 						item( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL ) ),

--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
@@ -260,7 +260,7 @@ public class MamutViewBdv
 		viewer.timePointListeners().add( timePointIndex -> timepointModel.setTimepoint( timePointIndex ) );
 		timepointModel.listeners().add( () -> viewer.setTimepoint( timepointModel.getTimepoint() ) );
 
-		ExportViewActions.install( viewActions, frame.getViewerPanel(), frame, "BDV" );
+		ExportViewActions.install( viewActions, frame.getViewerPanel().getDisplayComponent(), frame, "BDV" );
 
 		final RenderSettingsManager renderSettingsManager = appModel.getWindowManager().getManager( RenderSettingsManager.class );
 		final RenderSettings renderSettings = renderSettingsManager.getForwardDefaultStyle();

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -207,6 +207,7 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 		appModel.getWindowManager().addWindowMenu( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
 				fileMenu(
+						separator(),
 						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
 						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
 				viewMenu(

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -33,6 +33,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.mamut.MamutMenuBuilder.colorMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.colorbarMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
 
@@ -57,6 +58,7 @@ import org.mastodon.mamut.model.branch.BranchSpot;
 import org.mastodon.mamut.views.MamutView;
 import org.mastodon.model.AutoNavigateFocusModel;
 import org.mastodon.ui.EditTagActions;
+import org.mastodon.ui.ExportViewActions;
 import org.mastodon.ui.FocusActions;
 import org.mastodon.ui.SelectionActions;
 import org.mastodon.ui.coloring.ColorBarOverlay;
@@ -180,6 +182,7 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 				appModel.getSelectionModel(), viewGraph.getLock(), dataDisplayPanel, dataDisplayPanel.getDisplay(),
 				model );
 		DataDisplayZoom.install( viewBehaviours, dataDisplayPanel );
+		ExportViewActions.install( viewActions, dataDisplayPanel.getDisplay(), frame, frame.getTitle() );
 
 		final JPanel searchPanel = SearchVertexLabel.install( viewActions, viewGraph, navigationHandler, selectionModel,
 				focusModel, dataDisplayPanel );
@@ -203,6 +206,9 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 		MainWindow.addMenus( menu, actionMap );
 		appModel.getWindowManager().addWindowMenu( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
+				fileMenu(
+						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
+						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
 				viewMenu(
 						colorMenu( coloringMenuHandle ),
 						colorbarMenu( colorbarMenuHandle ),

--- a/src/main/java/org/mastodon/mamut/views/trackscheme/MamutBranchViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/views/trackscheme/MamutBranchViewTrackScheme.java
@@ -189,7 +189,7 @@ public class MamutBranchViewTrackScheme
 				frame.getTrackschemePanel().getDisplay(), model );
 		ShowSelectedTracksActions.install( viewActions, viewGraph, selectionModel, rootsModel,
 				frame.getTrackschemePanel() );
-		ExportViewActions.install( viewActions, frame.getTrackschemePanel(), frame, "TrackScheme Branch" );
+		ExportViewActions.install( viewActions, frame.getTrackschemePanel().getDisplay(), frame, "TrackScheme Branch" );
 
 		frame.getTrackschemePanel().getNavigationActions().install( viewActions,
 				TrackSchemeNavigationActions.NavigatorEtiquette.FINDER_LIKE );

--- a/src/main/java/org/mastodon/mamut/views/trackscheme/MamutBranchViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/views/trackscheme/MamutBranchViewTrackScheme.java
@@ -33,6 +33,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.mamut.MamutMenuBuilder.branchColorMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.colorbarMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
 
@@ -66,6 +67,7 @@ import org.mastodon.model.HighlightModel;
 import org.mastodon.model.RootsModel;
 import org.mastodon.model.TimepointModel;
 import org.mastodon.ui.EditTagActions;
+import org.mastodon.ui.ExportViewActions;
 import org.mastodon.ui.FocusActions;
 import org.mastodon.ui.SelectionActions;
 import org.mastodon.ui.coloring.ColorBarOverlay;
@@ -187,6 +189,7 @@ public class MamutBranchViewTrackScheme
 				frame.getTrackschemePanel().getDisplay(), model );
 		ShowSelectedTracksActions.install( viewActions, viewGraph, selectionModel, rootsModel,
 				frame.getTrackschemePanel() );
+		ExportViewActions.install( viewActions, frame.getTrackschemePanel(), frame, "TrackScheme Branch" );
 
 		frame.getTrackschemePanel().getNavigationActions().install( viewActions,
 				TrackSchemeNavigationActions.NavigatorEtiquette.FINDER_LIKE );
@@ -219,6 +222,10 @@ public class MamutBranchViewTrackScheme
 		MainWindow.addMenus( menu, actionMap );
 		appModel.getWindowManager().addWindowMenu( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
+				fileMenu(
+						separator(),
+						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
+						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
 				viewMenu(
 						branchColorMenu( coloringMenuHandle ),
 						colorbarMenu( colorbarMenuHandle ),

--- a/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
@@ -33,6 +33,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.mamut.MamutMenuBuilder.colorMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.colorbarMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
 
@@ -63,6 +64,7 @@ import org.mastodon.model.AutoNavigateFocusModel;
 import org.mastodon.model.DefaultRootsModel;
 import org.mastodon.model.RootsModel;
 import org.mastodon.ui.EditTagActions;
+import org.mastodon.ui.ExportViewActions;
 import org.mastodon.ui.FocusActions;
 import org.mastodon.ui.HighlightBehaviours;
 import org.mastodon.ui.SelectionActions;
@@ -183,6 +185,7 @@ public class MamutViewTrackScheme
 				appModel.getSelectionModel(), viewGraph.getLock(), frame.getTrackschemePanel(),
 				frame.getTrackschemePanel().getDisplay(), model );
 		ShowSelectedTracksActions.install( viewActions, viewGraph, selectionModel, rootsModel, frame.getTrackschemePanel() );
+		ExportViewActions.install( viewActions, frame.getTrackschemePanel(), frame, "TrackScheme" );
 
 		// Timepoint and number of spots.
 		final TimepointAndNumberOfSpotsPanel timepointAndNumberOfSpotsPanel = new TimepointAndNumberOfSpotsPanel( timepointModel, model );
@@ -208,6 +211,10 @@ public class MamutViewTrackScheme
 		MainWindow.addMenus( menu, actionMap );
 		appModel.getWindowManager().addWindowMenu( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
+				fileMenu(
+						separator(),
+						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
+						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
 				viewMenu(
 						colorMenu( coloringMenuHandle ),
 						colorbarMenu( colorbarMenuHandle ),

--- a/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
@@ -185,7 +185,7 @@ public class MamutViewTrackScheme
 				appModel.getSelectionModel(), viewGraph.getLock(), frame.getTrackschemePanel(),
 				frame.getTrackschemePanel().getDisplay(), model );
 		ShowSelectedTracksActions.install( viewActions, viewGraph, selectionModel, rootsModel, frame.getTrackschemePanel() );
-		ExportViewActions.install( viewActions, frame.getTrackschemePanel(), frame, "TrackScheme" );
+		ExportViewActions.install( viewActions, frame.getTrackschemePanel().getDisplay(), frame, "TrackScheme" );
 
 		// Timepoint and number of spots.
 		final TimepointAndNumberOfSpotsPanel timepointAndNumberOfSpotsPanel = new TimepointAndNumberOfSpotsPanel( timepointModel, model );

--- a/src/main/java/org/mastodon/ui/ExportViewActions.java
+++ b/src/main/java/org/mastodon/ui/ExportViewActions.java
@@ -1,0 +1,43 @@
+package org.mastodon.ui;
+
+import org.mastodon.ui.util.ExportUtils;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.RunnableAction;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+public class ExportViewActions
+{
+	public static final String EXPORT_VIEW_TO_SVG = "Export current view to SVG";
+
+	protected static final String[] EXPORT_VIEW_TO_SVG_KEYS = new String[] { "ctrl P" };
+
+	public static final String EXPORT_VIEW_TO_PNG = "Export current view to PNG";
+
+	protected static final String[] EXPORT_VIEW_TO_PNG_KEYS = new String[] { "ctrl shift P" };
+
+	private final RunnableAction exportToSvgAction;
+
+	private final RunnableAction exportToPngAction;
+
+	public static void install( final Actions actions, final JPanel jPanel, final JFrame jFrame,
+			final String name )
+	{
+		new ExportViewActions( jPanel, jFrame, name ).install( actions );
+	}
+
+	private ExportViewActions( final JPanel jPanel, final JFrame jFrame, final String name )
+	{
+		exportToSvgAction = new RunnableAction( EXPORT_VIEW_TO_SVG, () -> ExportUtils.chooseFileAndExport(
+				ExportUtils.SVG_EXTENSION, file -> ExportUtils.exportSvg( file, jPanel ), name, jFrame ) );
+		exportToPngAction = new RunnableAction( EXPORT_VIEW_TO_PNG, () -> ExportUtils.chooseFileAndExport(
+				ExportUtils.PNG_EXTENSION, file -> ExportUtils.exportPng( file, jPanel ), name, jFrame ) );
+	}
+
+	private void install( final Actions actions )
+	{
+		actions.namedAction( exportToSvgAction, EXPORT_VIEW_TO_SVG_KEYS );
+		actions.namedAction( exportToPngAction, EXPORT_VIEW_TO_PNG_KEYS );
+	}
+}

--- a/src/main/java/org/mastodon/ui/ExportViewActions.java
+++ b/src/main/java/org/mastodon/ui/ExportViewActions.java
@@ -1,11 +1,12 @@
 package org.mastodon.ui;
 
+import java.awt.Component;
+
+import javax.swing.JFrame;
+
 import org.mastodon.ui.util.ExportUtils;
 import org.scijava.ui.behaviour.util.Actions;
 import org.scijava.ui.behaviour.util.RunnableAction;
-
-import javax.swing.JFrame;
-import javax.swing.JPanel;
 
 public class ExportViewActions
 {
@@ -21,18 +22,18 @@ public class ExportViewActions
 
 	private final RunnableAction exportToPngAction;
 
-	public static void install( final Actions actions, final JPanel jPanel, final JFrame jFrame,
+	public static void install( final Actions actions, final Component comp, final JFrame frame,
 			final String name )
 	{
-		new ExportViewActions( jPanel, jFrame, name ).install( actions );
+		new ExportViewActions( comp, frame, name ).install( actions );
 	}
 
-	private ExportViewActions( final JPanel jPanel, final JFrame jFrame, final String name )
+	private ExportViewActions( final Component comp, final JFrame frame, final String name )
 	{
 		exportToSvgAction = new RunnableAction( EXPORT_VIEW_TO_SVG, () -> ExportUtils.chooseFileAndExport(
-				ExportUtils.SVG_EXTENSION, file -> ExportUtils.exportSvg( file, jPanel ), name, jFrame ) );
+				ExportUtils.SVG_EXTENSION, file -> ExportUtils.exportSvg( file, comp ), name, frame ) );
 		exportToPngAction = new RunnableAction( EXPORT_VIEW_TO_PNG, () -> ExportUtils.chooseFileAndExport(
-				ExportUtils.PNG_EXTENSION, file -> ExportUtils.exportPng( file, jPanel ), name, jFrame ) );
+				ExportUtils.PNG_EXTENSION, file -> ExportUtils.exportPng( file, comp ), name, frame ) );
 	}
 
 	private void install( final Actions actions )

--- a/src/main/java/org/mastodon/ui/util/ExportUtils.java
+++ b/src/main/java/org/mastodon/ui/util/ExportUtils.java
@@ -1,12 +1,6 @@
 package org.mastodon.ui.util;
 
-import org.jfree.graphics2d.svg.SVGGraphics2D;
-import org.jfree.graphics2d.svg.SVGUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.imageio.ImageIO;
-import javax.swing.JComponent;
+import java.awt.Component;
 import java.awt.Container;
 import java.awt.Desktop;
 import java.awt.Graphics2D;
@@ -17,6 +11,13 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
+
+import javax.imageio.ImageIO;
+
+import org.jfree.graphics2d.svg.SVGGraphics2D;
+import org.jfree.graphics2d.svg.SVGUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for exporting JComponents as PNG or SVG files.
@@ -37,43 +38,49 @@ public class ExportUtils
 	private static final int PRINT_RESOLUTION = 600;
 
 	/**
-	 * Export the given JComponent as PNG to the specified file.
-	 * @param file the file to export to
-	 * @param paintComponent the component to export
+	 * Export the given Component as PNG to the specified file.
+	 * 
+	 * @param file
+	 *            the file to export to
+	 * @param paintComponent
+	 *            the component to export
 	 */
-	public static void exportPng( final File file, final JComponent paintComponent )
+	public static void exportPng( final File file, final Component paintComponent )
 	{
-		int screenResolution = Toolkit.getDefaultToolkit().getScreenResolution();
-		double scale = PRINT_RESOLUTION / ( double ) screenResolution;
-		BufferedImage image = new BufferedImage( ( int ) ( paintComponent.getWidth() * scale ),
+		final int screenResolution = Toolkit.getDefaultToolkit().getScreenResolution();
+		final double scale = PRINT_RESOLUTION / ( double ) screenResolution;
+		final BufferedImage image = new BufferedImage( ( int ) ( paintComponent.getWidth() * scale ),
 				( int ) ( paintComponent.getHeight() * scale ), BufferedImage.TYPE_INT_RGB );
-		Graphics2D g = image.createGraphics();
+		final Graphics2D g = image.createGraphics();
 		g.setTransform( AffineTransform.getScaleInstance( scale, scale ) );
 		paintComponent.paint( g );
 		try
 		{
 			ImageIO.write( image, PNG_EXTENSION, file );
 		}
-		catch ( IOException e )
+		catch ( final IOException e )
 		{
 			logger.error( "Could not export trackscheme as PNG to File: {}.", file.getAbsolutePath(), e );
 		}
 	}
 
 	/**
-	 * Export the given JComponent as SVG to the specified file.
-	 * @param file the file to export to
-	 * @param paintComponent the component to export
+	 * Export the given Component as SVG to the specified file.
+	 * 
+	 * @param file
+	 *            the file to export to
+	 * @param paintComponent
+	 *            the component to export
 	 */
-	public static void exportSvg( final File file, final JComponent paintComponent )
+	public static void exportSvg( final File file, final Component paintComponent )
 	{
-		SVGGraphics2D g2 = new SVGGraphics2D( paintComponent.getWidth(), paintComponent.getHeight() );
+		final SVGGraphics2D g2 = new SVGGraphics2D( paintComponent.getWidth(), paintComponent.getHeight() );
 		paintComponent.paint( g2 );
 		try
 		{
 			SVGUtils.writeToSVG( file, g2.getSVGElement() );
 		}
-		catch ( IOException e )
+		catch ( final IOException e )
 		{
 			logger.error( "Could not export trackscheme as SVG to File: {}.", file.getAbsolutePath(), e );
 		}
@@ -89,7 +96,7 @@ public class ExportUtils
 	public static void chooseFileAndExport( final String extension, final Consumer< File > exportFunction, final String name,
 			final Container parentComponent )
 	{
-		File chosenFile = FileChooser.chooseFile( parentComponent, name + "." + extension, new ExtensionFileFilter( extension ),
+		final File chosenFile = FileChooser.chooseFile( parentComponent, name + "." + extension, new ExtensionFileFilter( extension ),
 				"Save " + name + " to " + extension, FileChooser.DialogType.SAVE );
 		if ( chosenFile != null )
 		{
@@ -104,7 +111,7 @@ public class ExportUtils
 		{
 			Desktop.getDesktop().open( chosenFile );
 		}
-		catch ( IOException e )
+		catch ( final IOException e )
 		{
 			logger.error( "Could not open file: {}", chosenFile.getAbsolutePath(), e );
 		}


### PR DESCRIPTION
I recently added the functionality to export the content of the lineage classification dendrogram to SVG/PNG files, cf.: https://github.com/mastodon-sc/mastodon-deep-lineage/releases/tag/mastodon-deep-lineage-0.2.0

After this was released, I was asked by a user, if this could be added as a functionality to the track scheme windows as well.

This PR adds exactly this functionality to all TrackScheme Panels and the BDV Panel. It also adds a generic ExportUtils class that can be re-used in all plugin projects to achieve similar behavior in different components.

* UI view: 
![grafik](https://github.com/mastodon-sc/mastodon/assets/10515534/0e58ea86-2855-4e29-9ded-10e2ef0b8db3)
* Resulting SVG: [trackscheme.zip](https://github.com/mastodon-sc/mastodon/files/15418057/trackscheme.zip)
* Resulting PNG: ![trackscheme](https://github.com/mastodon-sc/mastodon/assets/10515534/4d49aa83-8ff1-493d-bf31-f0c44f5129ce)

