### PR TITLE
Prevent TrackScheme From Freezing When Removing A Root Spot

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/mamut/views/trackscheme/MamutViewTrackScheme.java
@@ -144,6 +144,7 @@ public class MamutViewTrackScheme
 				new AutoNavigateFocusModel<>( focusModel, navigationHandler, timepointModel );
 
 		final RootsModel< TrackSchemeVertex > rootsModel = new DefaultRootsModel<>( model.getGraph(), viewGraph );
+		onClose( () -> rootsModel.close() );
 
 		final FadingModelAdapter< Spot, Link, TrackSchemeVertex, TrackSchemeEdge > fadingModelAdapter =
 				new FadingModelAdapter<>( null, viewGraph.getVertexMap(), viewGraph.getEdgeMap() );

--- a/src/main/java/org/mastodon/model/BranchTrackSchemeRootsModel.java
+++ b/src/main/java/org/mastodon/model/BranchTrackSchemeRootsModel.java
@@ -31,6 +31,8 @@ package org.mastodon.model;
 import org.mastodon.adapter.RefBimap;
 import org.mastodon.collection.RefList;
 import org.mastodon.collection.ref.RefArrayList;
+import org.mastodon.graph.GraphListener;
+import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchLink;
@@ -42,7 +44,7 @@ import org.mastodon.views.trackscheme.TrackSchemeVertex;
 import java.util.List;
 
 public class BranchTrackSchemeRootsModel
-		implements RootsModel< TrackSchemeVertex >
+		implements RootsModel< TrackSchemeVertex >, GraphListener< Spot, Link >
 {
 	private final ModelGraph modelGraph;
 
@@ -59,6 +61,17 @@ public class BranchTrackSchemeRootsModel
 		this.branchGraph = branchGraph;
 		this.viewGraph = viewGraph;
 		this.list = new RefArrayList<>( graph.vertices().getRefPool() );
+		this.modelGraph.addGraphListener( this );
+	}
+
+	/**
+	 * This method should be called when the model is no longer needed.
+	 * It removes listeners to allow garbage collection.
+	 */
+	@Override
+	public void close()
+	{
+		modelGraph.removeGraphListener( this );
 	}
 
 	@Override
@@ -92,5 +105,35 @@ public class BranchTrackSchemeRootsModel
 		viewGraph.releaseRef( vertexRef );
 		branchGraph.releaseRef( branchSpotRef );
 		return roots;
+	}
+
+	@Override
+	public void graphRebuilt()
+	{
+		list.clear();
+	}
+
+	@Override
+	public void vertexAdded( Spot vertex )
+	{
+
+	}
+
+	@Override
+	public void vertexRemoved( Spot vertex )
+	{
+		list.remove( vertex );
+	}
+
+	@Override
+	public void edgeAdded( Link edge )
+	{
+
+	}
+
+	@Override
+	public void edgeRemoved( Link edge )
+	{
+
 	}
 }

--- a/src/main/java/org/mastodon/model/RootsModel.java
+++ b/src/main/java/org/mastodon/model/RootsModel.java
@@ -37,4 +37,6 @@ public interface RootsModel< V >
 	void setRoots( List< V > roots );
 
 	RefList< V > getRoots();
+
+	void close();
 }

--- a/src/test/java/org/mastodon/model/BranchTrackSchemeRootsModelTest.java
+++ b/src/test/java/org/mastodon/model/BranchTrackSchemeRootsModelTest.java
@@ -1,0 +1,65 @@
+package org.mastodon.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.mamut.model.branch.ModelBranchGraph;
+import org.mastodon.views.trackscheme.TrackSchemeGraph;
+import org.mastodon.views.trackscheme.TrackSchemeVertex;
+import org.mastodon.views.trackscheme.wrap.DefaultModelGraphProperties;
+import org.mastodon.views.trackscheme.wrap.ModelGraphProperties;
+
+/**
+ * Tests for {@link BranchTrackSchemeRootsModel}.
+ */
+public class BranchTrackSchemeRootsModelTest
+{
+	@Test
+	public void testUpdateWhenRootIsRemoved()
+	{
+		// setup
+		final Model model = new Model();
+		final ModelGraph modelGraph = model.getGraph();
+		final Spot spotA = modelGraph.addVertex().init( 0, new double[ 3 ], 1 );
+		final ModelBranchGraph branchGraph = model.getBranchGraph();
+		branchGraph.graphRebuilt();
+		final TrackSchemeGraph< BranchSpot, BranchLink > viewGraph = createTrackSchemeGraph( branchGraph );
+		final TrackSchemeVertex vertexA = viewGraph.getRoots().iterator().next();
+
+		// run
+		final RootsModel< TrackSchemeVertex > rootsModel = new BranchTrackSchemeRootsModel( modelGraph, branchGraph, viewGraph );
+		rootsModel.setRoots( Collections.singletonList( vertexA ) );
+		modelGraph.remove( spotA );
+
+		// test
+		assertEquals( 0, rootsModel.getRoots().size() );
+	}
+
+	private static TrackSchemeGraph< BranchSpot, BranchLink > createTrackSchemeGraph( ModelBranchGraph branchGraph )
+	{
+		final ModelGraphProperties< BranchSpot, BranchLink > properties =
+				new DefaultModelGraphProperties< BranchSpot, BranchLink >()
+				{
+
+					@Override
+					public String getFirstLabel( final BranchSpot branchSpot )
+					{
+						return branchSpot.getFirstLabel();
+					}
+
+					@Override
+					public int getFirstTimePoint( final BranchSpot branchSpot )
+					{
+						return branchSpot.getFirstTimePoint();
+					}
+				};
+		return new TrackSchemeGraph<>( branchGraph, branchGraph.getGraphIdBimap(), properties );
+	}
+}

--- a/src/test/java/org/mastodon/model/DefaultRootsModelTest.java
+++ b/src/test/java/org/mastodon/model/DefaultRootsModelTest.java
@@ -1,0 +1,37 @@
+package org.mastodon.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.ModelGraphTrackSchemeProperties;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.views.trackscheme.TrackSchemeGraph;
+import org.mastodon.views.trackscheme.TrackSchemeVertex;
+
+/**
+ * Tests for {@link DefaultRootsModel}.
+ */
+public class DefaultRootsModelTest
+{
+	@Test
+	public void testUpdateWhenRootIsRemoved()
+	{
+		// setup
+		final ModelGraph graph = new ModelGraph();
+		final Spot spotA = graph.addVertex().init( 0, new double[ 3 ], 1 );
+		final TrackSchemeGraph< Spot, Link > viewGraph = new TrackSchemeGraph<>( graph, graph.getGraphIdBimap(), new ModelGraphTrackSchemeProperties( graph ) );
+		final TrackSchemeVertex vertexA = viewGraph.getRoots().iterator().next();
+
+		// run
+		final RootsModel< TrackSchemeVertex > rootsModel = new DefaultRootsModel<>( graph, viewGraph );
+		rootsModel.setRoots( Collections.singletonList( vertexA ) );
+		graph.remove( spotA );
+
+		// test
+		assertEquals( 0, rootsModel.getRoots().size() );
+	}
+}


### PR DESCRIPTION
This PR fixes a bug that causes the TrackScheme window to freeze after the following two steps:
1. Use "View > Show Only Selected Tracks"
2. Delete one of the visible root nodes

Here is a screen cast, demonstrating how to reproduce the problem:

![trackscheme-roots-bug](https://github.com/mastodon-sc/mastodon/assets/24407711/b81c10de-22aa-49b1-a352-5044613580f0)


The bug is triggered because the `DefaultRootsModel` and `BranchTrackSchemeRootsModel` keep a list of roots to be shown in the TrackScheme view. If one of the roots is removed from the `ModelGraph`, it becomes invalid, but the invalid entry still remains in the list of roots. The exception is triggered when the invalid object is processed by the `PainterThread`.

This PR fixes the bug, by removing the invalid entry from the list of roots as soon as the corresponding Spot is removed from the `ModelGraph`.