### PR TITLE
Add method Spot.isLabelSet()

### DIFF
--- a/src/main/java/org/mastodon/mamut/model/Spot.java
+++ b/src/main/java/org/mastodon/mamut/model/Spot.java
@@ -167,7 +167,7 @@ public final class Spot extends AbstractSpot< Spot, Link, SpotPool, ByteMappedEl
 	@Override
 	public String getLabel()
 	{
-		if ( pool.label.isSet( this ) )
+		if ( isLabelSet() )
 			return pool.label.get( this );
 		else
 			return Integer.toString( getInternalPoolIndex() );
@@ -177,6 +177,11 @@ public final class Spot extends AbstractSpot< Spot, Link, SpotPool, ByteMappedEl
 	public void setLabel( final String label )
 	{
 		pool.label.set( this, label );
+	}
+
+	public boolean isLabelSet()
+	{
+		return pool.label.isSet( this );
 	}
 
 	@Override


### PR DESCRIPTION
When analyzing a Mastodon dataset the ability to know for which spots the user specified a label can be very helpful.

This makes it easier, for example, to implement Mastodon plugins that automatically derive a name for spots whose label has not been manually set.

PR https://github.com/mastodon-sc/mastodon-tomancak/pull/61 would benefit from having this method.