### PR TITLE
Update pom scijava to 38.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>38.0.1</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>


### PR DESCRIPTION
There was an update of pom-scijava to 38.0.1, which should be reflected in mastodon to stay up-to-date