### PR TITLE
Add grapher branch view

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
@@ -1,0 +1,288 @@
+package org.mastodon.mamut.views.grapher;
+
+import net.imglib2.loops.LoopBuilder;
+import org.apache.commons.lang3.function.TriFunction;
+import org.mastodon.Ref;
+import org.mastodon.app.ui.MastodonFrameViewActions;
+import org.mastodon.app.ui.SearchVertexLabel;
+import org.mastodon.app.ui.ViewMenu;
+import org.mastodon.app.ui.ViewMenuBuilder;
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.Vertex;
+import org.mastodon.grouping.GroupHandle;
+import org.mastodon.mamut.MainWindow;
+import org.mastodon.mamut.MamutMenuBuilder;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.UndoActions;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.views.MamutViewI;
+import org.mastodon.model.AutoNavigateFocusModel;
+import org.mastodon.model.FocusModel;
+import org.mastodon.model.HasLabel;
+import org.mastodon.model.HighlightModel;
+import org.mastodon.model.NavigationHandler;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.spatial.HasTimepoint;
+import org.mastodon.ui.EditTagActions;
+import org.mastodon.ui.ExportViewActions;
+import org.mastodon.ui.FocusActions;
+import org.mastodon.ui.SelectionActions;
+import org.mastodon.ui.coloring.ColorBarOverlay;
+import org.mastodon.ui.coloring.ColoringModel;
+import org.mastodon.ui.coloring.GraphColorGeneratorAdapter;
+import org.mastodon.views.context.ContextChooser;
+import org.mastodon.views.grapher.datagraph.DataContextListener;
+import org.mastodon.views.grapher.datagraph.DataEdge;
+import org.mastodon.views.grapher.datagraph.DataGraph;
+import org.mastodon.views.grapher.datagraph.DataGraphLayout;
+import org.mastodon.views.grapher.datagraph.DataVertex;
+import org.mastodon.views.grapher.display.DataDisplayFrame;
+import org.mastodon.views.grapher.display.DataDisplayOptions;
+import org.mastodon.views.grapher.display.DataDisplayPanel;
+import org.mastodon.views.grapher.display.DataDisplayZoom;
+import org.mastodon.views.grapher.display.FeatureGraphConfig;
+import org.mastodon.views.grapher.display.OffsetAxes;
+import org.mastodon.views.grapher.display.style.DataDisplayStyle;
+import org.mastodon.views.grapher.display.style.DataDisplayStyleManager;
+import org.mastodon.views.trackscheme.display.TrackSchemeNavigationActions;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.Behaviours;
+
+import javax.swing.ActionMap;
+import javax.swing.JPanel;
+import java.util.function.BiConsumer;
+
+import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.separator;
+import static org.mastodon.mamut.MamutMenuBuilder.colorMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.colorbarMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
+import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
+
+public class GrapherInitializer< V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > >
+{
+	private final DataGraph< V, E > viewGraph;
+
+	private final ProjectModel appModel;
+
+	private final Model model;
+
+	private final DataDisplayFrame< V, E > frame;
+
+	private final DataDisplayPanel< V, E > panel;
+
+	private final DataGraphLayout< V, E > layout;
+
+	private final DataDisplayStyle forwardDefaultStyle;
+
+	private final DataDisplayStyle.UpdateListener styleUpdateListener;
+
+	private final ContextChooser< V > contextChooser;
+
+	private ColoringModel coloringModel;
+
+	private ColorBarOverlay colorBarOverlay;
+
+	private final GraphColorGeneratorAdapter< V, E, DataVertex, DataEdge > coloringAdapter;
+
+	private final AutoNavigateFocusModel< DataVertex, DataEdge > navigateFocusModel;
+
+	private final SelectionModel< DataVertex, DataEdge > selectionModel;
+
+	private final NavigationHandler< DataVertex, DataEdge > navigationHandler;
+
+	private final FocusModel< DataVertex > focusModel;
+
+	GrapherInitializer( final DataGraph< V, E > graph, final ProjectModel appModel,
+			final SelectionModel< DataVertex, DataEdge > selectionModel, final NavigationHandler< DataVertex, DataEdge > navigationHandler,
+			final FocusModel< DataVertex > focusModel, final HighlightModel< DataVertex, DataEdge > highlightModel,
+			final GroupHandle groupHandle
+	)
+	{
+		this.viewGraph = graph;
+		this.appModel = appModel;
+		this.model = appModel.getModel();
+		this.selectionModel = selectionModel;
+		this.navigationHandler = navigationHandler;
+		this.focusModel = focusModel;
+
+		// The layout.
+		layout = new DataGraphLayout<>( viewGraph, selectionModel );
+
+		// ContextChooser
+		final DataContextListener< V > contextListener = new DataContextListener<>( viewGraph );
+		contextChooser = new ContextChooser<>( contextListener );
+
+		// Style
+		final DataDisplayStyleManager dataDisplayStyleManager = appModel.getWindowManager().getManager( DataDisplayStyleManager.class );
+		forwardDefaultStyle = dataDisplayStyleManager.getForwardDefaultStyle();
+
+		// A reference on the {@code GraphColorGeneratorAdapter} created and registered with this instance/window
+		coloringAdapter = new GraphColorGeneratorAdapter<>( viewGraph.getVertexMap(), viewGraph.getEdgeMap() );
+
+		// Options
+		final DataDisplayOptions options = DataDisplayOptions.options()
+				.shareKeyPressedEvents( appModel.getKeyPressedManager() )
+				.style( forwardDefaultStyle )
+				.graphColorGenerator( coloringAdapter );
+
+		// Navigation
+		navigateFocusModel = new AutoNavigateFocusModel<>( focusModel, navigationHandler );
+
+		// Frame
+		this.frame = new DataDisplayFrame<>(
+				viewGraph,
+				appModel.getModel().getFeatureModel(),
+				appModel.getSharedBdvData().getSources().size(),
+				layout,
+				highlightModel,
+				navigateFocusModel,
+				selectionModel,
+				navigationHandler,
+				model,
+				groupHandle,
+				contextChooser,
+				options );
+
+		// Panel
+		this.panel = frame.getDataDisplayPanel();
+		contextListener.setContextListener( panel );
+
+		// Style listener
+		styleUpdateListener = panel::repaint;
+		forwardDefaultStyle.updateListeners().add( styleUpdateListener );
+
+		// Label listener
+		appModel.getModel().getGraph().addVertexLabelListener( vertex -> panel.entitiesAttributesChanged() );
+	}
+
+	void setOnClose( final MamutViewI view )
+	{
+		view.onClose( () -> forwardDefaultStyle.updateListeners().remove( styleUpdateListener ) );
+	}
+
+	void initFeatureConfig( final FeatureGraphConfig featureGraphConfig )
+	{
+		frame.getVertexSidePanel().setGraphConfig( featureGraphConfig );
+		panel.graphChanged();
+	}
+
+	void addMenusAndRegisterColors(
+			final TriFunction< ViewMenuBuilder.JMenuHandle, GraphColorGeneratorAdapter< V, E, DataVertex, DataEdge >,
+					DataDisplayPanel< V, E >, ColoringModel > colorModelRegistration,
+			final LoopBuilder.TriConsumer< ColorBarOverlay, ViewMenuBuilder.JMenuHandle,
+					DataDisplayPanel< V, E > > colorBarRegistration,
+			final BiConsumer< ViewMenuBuilder.JMenuHandle, DataDisplayPanel< V, E > > tagSetMenuRegistration,
+			final String[] keyConfigContexts )
+	{
+		final ViewMenu viewMenu = new ViewMenu( frame.getJMenuBar(), appModel.getKeymap(), keyConfigContexts );
+		final ActionMap actionMap = frame.getKeybindings().getConcatenatedActionMap();
+
+		final ViewMenuBuilder.JMenuHandle coloringMenuHandle = new ViewMenuBuilder.JMenuHandle();
+		final ViewMenuBuilder.JMenuHandle colorbarMenuHandle = new ViewMenuBuilder.JMenuHandle();
+		final ViewMenuBuilder.JMenuHandle tagSetMenuHandle = new ViewMenuBuilder.JMenuHandle();
+
+		MainWindow.addMenus( viewMenu, actionMap );
+		appModel.getWindowManager().addWindowMenu( viewMenu, actionMap );
+		MamutMenuBuilder.build( viewMenu, actionMap,
+				fileMenu(
+						separator(),
+						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
+						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
+				viewMenu(
+						colorMenu( coloringMenuHandle ),
+						colorbarMenu( colorbarMenuHandle ),
+						separator(),
+						item( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL ) ),
+				editMenu(
+						item( UndoActions.UNDO ),
+						item( UndoActions.REDO ),
+						separator(),
+						item( SelectionActions.DELETE_SELECTION ),
+						item( SelectionActions.SELECT_WHOLE_TRACK ),
+						item( SelectionActions.SELECT_TRACK_DOWNWARD ),
+						item( SelectionActions.SELECT_TRACK_UPWARD ),
+						separator(),
+						tagSetMenu( tagSetMenuHandle ) ) );
+		appModel.getPlugins().addMenus( viewMenu );
+
+		registerColoring( colorModelRegistration, coloringMenuHandle );
+		registerColorBar( colorBarRegistration, colorbarMenuHandle );
+		registerTagSetMenu( tagSetMenuRegistration, tagSetMenuHandle );
+	}
+
+	void layout()
+	{
+		layout.layout();
+		panel.repaint();
+		panel.getDisplay().requestFocusInWindow();
+	}
+
+	void installActions( final Actions viewActions, final Behaviours viewBehaviours )
+	{
+		MastodonFrameViewActions.install( viewActions, () -> frame );
+		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
+		EditTagActions.install( viewActions, frame.getKeybindings(), frame.getTriggerbindings(), model.getTagSetModel(),
+				appModel.getSelectionModel(), viewGraph.getLock(), panel, panel.getDisplay(), model );
+		DataDisplayZoom.install( viewBehaviours, panel );
+		ExportViewActions.install( viewActions, panel.getDisplay(), frame, frame.getTitle() );
+
+		panel.getNavigationActions().install( viewActions, TrackSchemeNavigationActions.NavigatorEtiquette.FINDER_LIKE );
+		panel.getNavigationBehaviours().install( viewBehaviours );
+		panel.getTransformEventHandler().install( viewBehaviours );
+	}
+
+	void addSearchPanel( final Actions viewActions )
+	{
+		final JPanel searchPanel =
+				SearchVertexLabel.install( viewActions, viewGraph, navigationHandler, selectionModel, focusModel, panel );
+		frame.getSettingsPanel().add( searchPanel );
+	}
+
+	private void
+			registerColoring(
+					final TriFunction< ViewMenuBuilder.JMenuHandle, GraphColorGeneratorAdapter< V, E, DataVertex, DataEdge >,
+							DataDisplayPanel< V, E >, ColoringModel > colorModelRegistration,
+					final ViewMenuBuilder.JMenuHandle coloringMenuHandle )
+	{
+		coloringModel = colorModelRegistration.apply( coloringMenuHandle, coloringAdapter, panel );
+	}
+
+	private void registerColorBar( final LoopBuilder.TriConsumer< ColorBarOverlay, ViewMenuBuilder.JMenuHandle,
+			DataDisplayPanel< V, E > > colorBarRegistration, final ViewMenuBuilder.JMenuHandle colorbarMenuHandle )
+	{
+		colorBarOverlay = new ColorBarOverlay( coloringModel, panel::getBackground );
+		final OffsetAxes offset = panel.getOffsetAxes();
+		offset.listeners().add( ( w, h ) -> colorBarOverlay.setInsets( 15, w + 15, h + 15, 15 ) );
+		colorBarRegistration.accept( colorBarOverlay, colorbarMenuHandle, panel );
+		panel.getDisplay().overlays().add( colorBarOverlay );
+	}
+
+	private void registerTagSetMenu( final BiConsumer< ViewMenuBuilder.JMenuHandle, DataDisplayPanel< V, E > > tagSetMenuRegistration,
+			final ViewMenuBuilder.JMenuHandle tagSetMenuHandle )
+	{
+		tagSetMenuRegistration.accept( tagSetMenuHandle, panel );
+	}
+
+	ContextChooser< V > getContextChooser()
+	{
+		return contextChooser;
+	}
+
+	DataDisplayFrame< V, E > getFrame()
+	{
+		return frame;
+	}
+
+	ColoringModel getColoringModel()
+	{
+		return coloringModel;
+	}
+
+	ColorBarOverlay getColorBarOverlay()
+	{
+		return colorBarOverlay;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -53,6 +53,7 @@ import org.mastodon.views.grapher.display.DataDisplayPanel;
 import org.mastodon.views.grapher.display.FeatureGraphConfig;
 import org.mastodon.views.grapher.display.FeatureGraphConfig.GraphDataItemsSource;
 import org.mastodon.views.grapher.display.FeatureSpecPair;
+import org.mastodon.views.grapher.display.InertialScreenTransformEventHandler;
 
 import java.util.Iterator;
 import java.util.function.BiConsumer;
@@ -75,6 +76,9 @@ public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSp
 		grapherInitializer = new GrapherInitializer<>( viewGraph, appModel, selectionModel, navigationHandler, focusModel, highlightModel,
 				getGroupHandle() );
 		grapherInitializer.getFrame().setTitle( "Grapher Branch" );
+		InertialScreenTransformEventHandler handler = grapherInitializer.getFrame().getDataDisplayPanel().getTransformEventHandler();
+		handler.setMinScaleX( 0.1d );
+		handler.setMinScaleY( 0.1d );
 		grapherInitializer.setOnClose( this );
 		grapherInitializer.initFeatureConfig( getFeatureGraphConfig() );
 		setFrame( grapherInitializer.getFrame() ); // this creates viewActions and viewBehaviours thus must be called before installActions

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -1,0 +1,135 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2024 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.views.grapher;
+
+import net.imglib2.loops.LoopBuilder;
+import org.apache.commons.lang3.function.TriFunction;
+import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.feature.branch.BranchDisplacementDurationFeature;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.mamut.views.MamutBranchView;
+import org.mastodon.ui.coloring.ColorBarOverlay;
+import org.mastodon.ui.coloring.ColoringModel;
+import org.mastodon.ui.coloring.GraphColorGeneratorAdapter;
+import org.mastodon.ui.coloring.HasColorBarOverlay;
+import org.mastodon.ui.coloring.HasColoringModel;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.mastodon.views.context.ContextChooser;
+import org.mastodon.views.context.HasContextChooser;
+import org.mastodon.views.grapher.datagraph.DataEdge;
+import org.mastodon.views.grapher.datagraph.DataGraph;
+import org.mastodon.views.grapher.datagraph.DataVertex;
+import org.mastodon.views.grapher.display.DataDisplayFrame;
+import org.mastodon.views.grapher.display.DataDisplayPanel;
+import org.mastodon.views.grapher.display.FeatureGraphConfig;
+import org.mastodon.views.grapher.display.FeatureGraphConfig.GraphDataItemsSource;
+import org.mastodon.views.grapher.display.FeatureSpecPair;
+
+import java.util.Iterator;
+import java.util.function.BiConsumer;
+
+public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSpot, BranchLink >, DataVertex, DataEdge >
+		implements HasContextChooser< BranchSpot >, HasColoringModel, HasColorBarOverlay
+{
+
+	private final GrapherInitializer< BranchSpot, BranchLink > grapherInitializer;
+
+	MamutBranchViewGrapher( final ProjectModel appModel )
+	{
+		super( appModel,
+				new DataGraph<>(
+						appModel.getModel().getBranchGraph(),
+						appModel.getModel().getBranchGraphIdBimap(),
+						appModel.getModel().getGraph().getLock() ),
+				new String[] { KeyConfigContexts.GRAPHER } );
+
+		grapherInitializer = new GrapherInitializer<>( viewGraph, appModel, selectionModel, navigationHandler, focusModel, highlightModel,
+				getGroupHandle() );
+		grapherInitializer.getFrame().setTitle( "Grapher Branch" );
+		grapherInitializer.setOnClose( this );
+		grapherInitializer.initFeatureConfig( getFeatureGraphConfig() );
+		setFrame( grapherInitializer.getFrame() ); // this creates viewActions and viewBehaviours thus must be called before installActions
+		grapherInitializer.installActions( viewActions, viewBehaviours );
+		grapherInitializer.addSearchPanel( viewActions );
+
+		TriFunction< JMenuHandle, GraphColorGeneratorAdapter< BranchSpot, BranchLink, DataVertex, DataEdge >,
+				DataDisplayPanel< BranchSpot, BranchLink >, ColoringModel > colorModelRegistration =
+						( menuHandle, coloringAdaptor, panel ) -> registerBranchColoring( coloringAdaptor, menuHandle,
+								panel::entitiesAttributesChanged );
+		LoopBuilder.TriConsumer< ColorBarOverlay, JMenuHandle, DataDisplayPanel< BranchSpot, BranchLink > > colorBarRegistration =
+				( overlay, menuHandle, panel ) -> registerColorbarOverlay( overlay, menuHandle, panel::repaint );
+		BiConsumer< JMenuHandle, DataDisplayPanel< BranchSpot, BranchLink > > tagSetMenuRegistration =
+				( menuHandle, panel ) -> registerTagSetMenu( menuHandle, panel::entitiesAttributesChanged );
+
+		grapherInitializer.addMenusAndRegisterColors( colorModelRegistration, colorBarRegistration, tagSetMenuRegistration,
+				keyConfigContexts );
+		grapherInitializer.layout();
+	}
+
+	private static FeatureGraphConfig getFeatureGraphConfig()
+	{
+		// If they are available, set some sensible defaults for the feature.
+		Iterator< FeatureProjectionSpec > projections = BranchDisplacementDurationFeature.SPEC.getProjectionSpecs().iterator();
+		FeatureProjectionSpec displacementSpec = projections.next();
+		FeatureProjectionSpec durationSpec = projections.next();
+		final FeatureSpecPair featureSpecX =
+				new FeatureSpecPair( BranchDisplacementDurationFeature.SPEC, displacementSpec, false, false );
+		final FeatureSpecPair featureSpecY =
+				new FeatureSpecPair( BranchDisplacementDurationFeature.SPEC, durationSpec, false, false );
+		return new FeatureGraphConfig( featureSpecX, featureSpecY, GraphDataItemsSource.TRACK_OF_SELECTION, true );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	@Override
+	public DataDisplayFrame< BranchSpot, BranchLink > getFrame()
+	{
+		return ( DataDisplayFrame< BranchSpot, BranchLink > ) super.getFrame();
+	}
+
+	@Override
+	public ContextChooser< BranchSpot > getContextChooser()
+	{
+		return grapherInitializer.getContextChooser();
+	}
+
+	@Override
+	public ColoringModel getColoringModel()
+	{
+		return grapherInitializer.getColoringModel();
+	}
+
+	@Override
+	public ColorBarOverlay getColorBarOverlay()
+	{
+		return grapherInitializer.getColorBarOverlay();
+	}
+}

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapherFactory.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapherFactory.java
@@ -1,0 +1,43 @@
+package org.mastodon.mamut.views.grapher;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.views.AbstractMamutViewFactory;
+import org.mastodon.mamut.views.MamutViewFactory;
+import org.scijava.Priority;
+import org.scijava.plugin.Plugin;
+
+@Plugin( type = MamutViewFactory.class, priority = Priority.NORMAL - 8 )
+public class MamutBranchViewGrapherFactory extends AbstractMamutViewFactory< MamutBranchViewGrapher >
+{
+	public static final String NEW_GRAPHER_BRANCH_VIEW = "new grapher branch view";
+
+	@Override
+	public MamutBranchViewGrapher create( final ProjectModel projectModel )
+	{
+		return new MamutBranchViewGrapher( projectModel );
+	}
+
+	@Override
+	public String getCommandName()
+	{
+		return NEW_GRAPHER_BRANCH_VIEW;
+	}
+
+	@Override
+	public String getCommandDescription()
+	{
+		return "Open a new Grapher Branch view.";
+	}
+
+	@Override
+	public String getCommandMenuText()
+	{
+		return "New Grapher Branch View";
+	}
+
+	@Override
+	public Class< MamutBranchViewGrapher > getViewClass()
+	{
+		return MamutBranchViewGrapher.class;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -1,251 +1,78 @@
-/*-
- * #%L
- * Mastodon
- * %%
- * Copyright (C) 2014 - 2024 Tobias Pietzsch, Jean-Yves Tinevez
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.mastodon.mamut.views.grapher;
 
-import static org.mastodon.app.ui.ViewMenuBuilder.item;
-import static org.mastodon.app.ui.ViewMenuBuilder.separator;
-import static org.mastodon.mamut.MamutMenuBuilder.colorMenu;
-import static org.mastodon.mamut.MamutMenuBuilder.colorbarMenu;
-import static org.mastodon.mamut.MamutMenuBuilder.editMenu;
-import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
-import static org.mastodon.mamut.MamutMenuBuilder.tagSetMenu;
-import static org.mastodon.mamut.MamutMenuBuilder.viewMenu;
-
-import javax.swing.ActionMap;
-import javax.swing.JPanel;
-
-import org.mastodon.app.ui.MastodonFrameViewActions;
-import org.mastodon.app.ui.SearchVertexLabel;
-import org.mastodon.app.ui.ViewMenu;
-import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
-import org.mastodon.mamut.MainWindow;
-import org.mastodon.mamut.MamutMenuBuilder;
+import net.imglib2.loops.LoopBuilder;
+import org.apache.commons.lang3.function.TriFunction;
+import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.mamut.ProjectModel;
-import org.mastodon.mamut.UndoActions;
 import org.mastodon.mamut.feature.SpotFrameFeature;
 import org.mastodon.mamut.feature.SpotQuickMeanIntensityFeature;
 import org.mastodon.mamut.model.Link;
-import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
-import org.mastodon.mamut.model.branch.BranchLink;
-import org.mastodon.mamut.model.branch.BranchSpot;
 import org.mastodon.mamut.views.MamutView;
-import org.mastodon.model.AutoNavigateFocusModel;
-import org.mastodon.ui.EditTagActions;
-import org.mastodon.ui.ExportViewActions;
-import org.mastodon.ui.FocusActions;
-import org.mastodon.ui.SelectionActions;
 import org.mastodon.ui.coloring.ColorBarOverlay;
-import org.mastodon.ui.coloring.ColoringModelMain;
+import org.mastodon.ui.coloring.ColoringModel;
 import org.mastodon.ui.coloring.GraphColorGeneratorAdapter;
 import org.mastodon.ui.coloring.HasColorBarOverlay;
 import org.mastodon.ui.coloring.HasColoringModel;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.views.context.ContextChooser;
 import org.mastodon.views.context.HasContextChooser;
-import org.mastodon.views.grapher.datagraph.DataContextListener;
 import org.mastodon.views.grapher.datagraph.DataEdge;
 import org.mastodon.views.grapher.datagraph.DataGraph;
-import org.mastodon.views.grapher.datagraph.DataGraphLayout;
 import org.mastodon.views.grapher.datagraph.DataVertex;
 import org.mastodon.views.grapher.display.DataDisplayFrame;
-import org.mastodon.views.grapher.display.DataDisplayOptions;
 import org.mastodon.views.grapher.display.DataDisplayPanel;
-import org.mastodon.views.grapher.display.DataDisplayZoom;
 import org.mastodon.views.grapher.display.FeatureGraphConfig;
-import org.mastodon.views.grapher.display.FeatureGraphConfig.GraphDataItemsSource;
 import org.mastodon.views.grapher.display.FeatureSpecPair;
-import org.mastodon.views.grapher.display.OffsetAxes;
-import org.mastodon.views.grapher.display.style.DataDisplayStyle;
-import org.mastodon.views.grapher.display.style.DataDisplayStyleManager;
-import org.mastodon.views.trackscheme.display.TrackSchemeNavigationActions;
-import org.scijava.ui.behaviour.KeyPressedManager;
 
-public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVertex, DataEdge > implements HasContextChooser< Spot >, HasColoringModel, HasColorBarOverlay
+import java.util.function.BiConsumer;
+
+public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVertex, DataEdge >
+		implements HasContextChooser< Spot >, HasColoringModel, HasColorBarOverlay
 {
 
-	private final ContextChooser< Spot > contextChooser;
+	private final GrapherInitializer< Spot, Link > grapherInitializer;
 
-	/**
-	 * a reference on the {@code GraphColorGeneratorAdapter} created and
-	 * registered with this instance/window
-	 */
-	private final GraphColorGeneratorAdapter< Spot, Link, DataVertex, DataEdge > coloringAdapter;
-
-	/**
-	 * a reference on a supervising instance of the {@code ColoringModel} that
-	 * is bound to this instance/window
-	 */
-	private final ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel;
-
-	private final ColorBarOverlay colorbarOverlay;
-
-	public MamutViewGrapher( final ProjectModel appModel )
+	MamutViewGrapher( final ProjectModel appModel )
 	{
 		super( appModel,
-				new DataGraph< Spot, Link >(
+				new DataGraph<>(
 						appModel.getModel().getGraph(),
 						appModel.getModel().getGraphIdBimap(),
-						appModel.getModel().getGraph().getLock() ),
+						appModel.getModel().getGraph().getLock()
+				),
 				new String[] { KeyConfigContexts.GRAPHER } );
 
-		final KeyPressedManager keyPressedManager = appModel.getKeyPressedManager();
-		final Model model = appModel.getModel();
 
-		/*
-		 * The layout.
-		 */
-		final DataGraphLayout< Spot, Link > layout = new DataGraphLayout<>( viewGraph, selectionModel );
+		grapherInitializer = new GrapherInitializer<>( viewGraph, appModel, selectionModel, navigationHandler, focusModel, highlightModel,
+				getGroupHandle() );
+		grapherInitializer.setOnClose( this );
+		grapherInitializer.initFeatureConfig( getFeatureGraphConfig() );
+		setFrame( grapherInitializer.getFrame() ); // this creates viewActions and viewBehaviours thus must be called before installActions
+		grapherInitializer.installActions( viewActions, viewBehaviours );
+		grapherInitializer.addSearchPanel( viewActions );
 
-		/*
-		 * ContextChooser
-		 */
-		final DataContextListener< Spot > contextListener = new DataContextListener<>( viewGraph );
-		contextChooser = new ContextChooser<>( contextListener );
+		TriFunction< ViewMenuBuilder.JMenuHandle, GraphColorGeneratorAdapter< Spot, Link, DataVertex, DataEdge >,
+				DataDisplayPanel< Spot, Link >, ColoringModel > colorModelRegistration = ( menuHandle, coloringAdaptor,
+						panel ) -> registerColoring( coloringAdaptor, menuHandle, panel::entitiesAttributesChanged );
+		LoopBuilder.TriConsumer< ColorBarOverlay, ViewMenuBuilder.JMenuHandle, DataDisplayPanel< Spot, Link > > colorBarRegistration =
+				( overlay, menuHandle, panel ) -> registerColorbarOverlay( overlay, menuHandle, panel::repaint );
+		BiConsumer< ViewMenuBuilder.JMenuHandle, DataDisplayPanel< Spot, Link > > tagSetMenuRegistration =
+				( menuHandle, panel ) -> registerTagSetMenu( menuHandle, panel::entitiesAttributesChanged );
 
-		/*
-		 * Show the frame
-		 */
+		grapherInitializer.addMenusAndRegisterColors( colorModelRegistration, colorBarRegistration, tagSetMenuRegistration,
+				keyConfigContexts );
+		grapherInitializer.layout();
+	}
 
-		final DataDisplayStyleManager dataDisplayStyleManager = appModel.getWindowManager().getManager( DataDisplayStyleManager.class );
-		final DataDisplayStyle forwardDefaultStyle = dataDisplayStyleManager.getForwardDefaultStyle();
-		coloringAdapter = new GraphColorGeneratorAdapter<>( viewGraph.getVertexMap(), viewGraph.getEdgeMap() );
-		final DataDisplayOptions options = DataDisplayOptions.options()
-				.shareKeyPressedEvents( keyPressedManager )
-				.style( forwardDefaultStyle )
-				.graphColorGenerator( coloringAdapter );
-		final AutoNavigateFocusModel< DataVertex, DataEdge > navigateFocusModel =
-				new AutoNavigateFocusModel<>( focusModel, navigationHandler );
-
-		final DataDisplayFrame< Spot, Link > frame = new DataDisplayFrame< Spot, Link >(
-				viewGraph,
-				appModel.getModel().getFeatureModel(),
-				appModel.getSharedBdvData().getSources().size(),
-				layout,
-				highlightModel,
-				navigateFocusModel,
-				selectionModel,
-				navigationHandler,
-				model,
-				groupHandle,
-				contextChooser,
-				options );
-		final DataDisplayPanel< Spot, Link > dataDisplayPanel = frame.getDataDisplayPanel();
-
+	private static FeatureGraphConfig getFeatureGraphConfig()
+	{
 		// If they are available, set some sensible defaults for the feature.
 		final FeatureSpecPair spvx = new FeatureSpecPair( SpotFrameFeature.SPEC,
 				SpotFrameFeature.SPEC.getProjectionSpecs().iterator().next(), false, false );
 		final FeatureSpecPair spvy = new FeatureSpecPair( SpotQuickMeanIntensityFeature.SPEC,
 				SpotQuickMeanIntensityFeature.PROJECTION_SPEC, 0, false, false );
-		final FeatureGraphConfig gcv =
-				new FeatureGraphConfig( spvx, spvy, GraphDataItemsSource.TRACK_OF_SELECTION, true );
-		frame.getVertexSidePanel().setGraphConfig( gcv );
-
-		dataDisplayPanel.graphChanged();
-		contextListener.setContextListener( dataDisplayPanel );
-
-		final DataDisplayStyle.UpdateListener updateListener = () -> dataDisplayPanel.repaint();
-		forwardDefaultStyle.updateListeners().add( updateListener );
-		onClose( () -> forwardDefaultStyle.updateListeners().remove( updateListener ) );
-
-		setFrame( frame );
-
-		MastodonFrameViewActions.install( viewActions, this );
-		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
-		EditTagActions.install( viewActions, frame.getKeybindings(), frame.getTriggerbindings(), model.getTagSetModel(),
-				appModel.getSelectionModel(), viewGraph.getLock(), dataDisplayPanel, dataDisplayPanel.getDisplay(),
-				model );
-		DataDisplayZoom.install( viewBehaviours, dataDisplayPanel );
-		ExportViewActions.install( viewActions, dataDisplayPanel.getDisplay(), frame, frame.getTitle() );
-
-		final JPanel searchPanel = SearchVertexLabel.install( viewActions, viewGraph, navigationHandler, selectionModel,
-				focusModel, dataDisplayPanel );
-		frame.getSettingsPanel().add( searchPanel );
-
-		dataDisplayPanel.getNavigationActions().install( viewActions,
-				TrackSchemeNavigationActions.NavigatorEtiquette.FINDER_LIKE );
-		dataDisplayPanel.getNavigationBehaviours().install( viewBehaviours );
-		dataDisplayPanel.getTransformEventHandler().install( viewBehaviours );
-
-		/*
-		 * Menus
-		 */
-		final ViewMenu menu = new ViewMenu( this );
-		final ActionMap actionMap = frame.getKeybindings().getConcatenatedActionMap();
-
-		final JMenuHandle coloringMenuHandle = new JMenuHandle();
-		final JMenuHandle tagSetMenuHandle = new JMenuHandle();
-		final JMenuHandle colorbarMenuHandle = new JMenuHandle();
-
-		MainWindow.addMenus( menu, actionMap );
-		appModel.getWindowManager().addWindowMenu( menu, actionMap );
-		MamutMenuBuilder.build( menu, actionMap,
-				fileMenu(
-						separator(),
-						item( ExportViewActions.EXPORT_VIEW_TO_SVG ),
-						item( ExportViewActions.EXPORT_VIEW_TO_PNG ) ),
-				viewMenu(
-						colorMenu( coloringMenuHandle ),
-						colorbarMenu( colorbarMenuHandle ),
-						separator(),
-						item( MastodonFrameViewActions.TOGGLE_SETTINGS_PANEL ) ),
-				editMenu(
-						item( UndoActions.UNDO ),
-						item( UndoActions.REDO ),
-						separator(),
-						item( SelectionActions.DELETE_SELECTION ),
-						item( SelectionActions.SELECT_WHOLE_TRACK ),
-						item( SelectionActions.SELECT_TRACK_DOWNWARD ),
-						item( SelectionActions.SELECT_TRACK_UPWARD ),
-						separator(),
-						tagSetMenu( tagSetMenuHandle ) ) );
-		appModel.getPlugins().addMenus( menu );
-
-		/*
-		 * Coloring & colobar.
-		 */
-		coloringModel = registerColoring( coloringAdapter, coloringMenuHandle,
-				() -> dataDisplayPanel.entitiesAttributesChanged() );
-		registerTagSetMenu( tagSetMenuHandle,
-				() -> dataDisplayPanel.entitiesAttributesChanged() );
-		colorbarOverlay = new ColorBarOverlay( coloringModel, () -> dataDisplayPanel.getBackground() );
-		final OffsetAxes offset = dataDisplayPanel.getOffsetAxes();
-		offset.listeners().add( ( w, h ) -> colorbarOverlay.setInsets( 15, w + 15, h + 15, 15 ) );
-		registerColorbarOverlay( colorbarOverlay, colorbarMenuHandle, () -> dataDisplayPanel.repaint() );
-		dataDisplayPanel.getDisplay().overlays().add( colorbarOverlay );
-
-		// Listen to label changes.
-		model.getGraph().addVertexLabelListener( v -> dataDisplayPanel.entitiesAttributesChanged() );
-
-		layout.layout();
-		dataDisplayPanel.repaint();
-		dataDisplayPanel.getDisplay().requestFocusInWindow();
+		return new FeatureGraphConfig( spvx, spvy, FeatureGraphConfig.GraphDataItemsSource.TRACK_OF_SELECTION, true );
 	}
 
 	@SuppressWarnings( "unchecked" )
@@ -258,18 +85,18 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 	@Override
 	public ContextChooser< Spot > getContextChooser()
 	{
-		return contextChooser;
+		return grapherInitializer.getContextChooser();
 	}
 
 	@Override
-	public ColoringModelMain< Spot, Link, BranchSpot, BranchLink > getColoringModel()
+	public ColoringModel getColoringModel()
 	{
-		return coloringModel;
+		return grapherInitializer.getColoringModel();
 	}
 
 	@Override
 	public ColorBarOverlay getColorBarOverlay()
 	{
-		return colorbarOverlay;
+		return grapherInitializer.getColorBarOverlay();
 	}
 }

--- a/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
@@ -274,6 +274,16 @@ public class InertialScreenTransformEventHandler
 		updateTransformScreenSize();
 	}
 
+	public void setMinScaleY( final double minScaleY )
+	{
+		this.minScaleY = minScaleY;
+	}
+
+	public void setMinScaleX( final double minScaleX )
+	{
+		this.minScaleX = minScaleX;
+	}
+
 	private void updateTransformScreenSize()
 	{
 		final ScreenTransform transform = transformState.get();

--- a/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
@@ -214,6 +214,10 @@ public class InertialScreenTransformEventHandler
 	 */
 	private boolean stayFullyZoomedOut;
 
+	private double minScaleX;
+
+	private double minScaleY;
+
 	/**
 	 * Timer that runs {@link #currentTimerTask}.
 	 */
@@ -240,6 +244,8 @@ public class InertialScreenTransformEventHandler
 		zoomScrollBehaviourX = new ZoomScrollBehaviour( ZOOM_X, ScrollAxis.X );
 		zoomScrollBehaviourY = new ZoomScrollBehaviour( ZOOM_Y, ScrollAxis.Y );
 		zoomScrollBehaviourXY = new ZoomScrollBehaviour( ZOOM_XY, ScrollAxis.XY );
+		minScaleX = DEFAULT_MIN_SCALE_X;
+		minScaleY = DEFAULT_MIN_SCALE_Y;
 	}
 
 	@Override
@@ -289,18 +295,18 @@ public class InertialScreenTransformEventHandler
 		boundYMin = layout.getCurrentLayoutMinY() - boundYLayoutBorder;
 		boundYMax = layout.getCurrentLayoutMaxY() + boundYLayoutBorder;
 
-		if ( boundXMax - boundXMin < DEFAULT_MIN_SCALE_X )
+		if ( boundXMax - boundXMin < minScaleX )
 		{
 			final double c = ( boundXMax + boundXMin ) / 2;
-			boundXMin = c - DEFAULT_MIN_SCALE_X / 2;
-			boundXMax = c + DEFAULT_MIN_SCALE_X / 2;
+			boundXMin = c - minScaleX / 2;
+			boundXMax = c + minScaleX / 2;
 		}
 		updateMaxSizeX( transform.getScreenWidth() );
-		if ( boundYMax - boundYMin < DEFAULT_MIN_SCALE_X )
+		if ( boundYMax - boundYMin < minScaleX )
 		{
 			final double c = ( boundYMax + boundYMin ) / 2;
-			boundYMin = c - DEFAULT_MIN_SCALE_X / 2;
-			boundYMax = c + DEFAULT_MIN_SCALE_X / 2;
+			boundYMin = c - minScaleX / 2;
+			boundYMax = c + minScaleX / 2;
 		}
 		updateMaxSizeY( transform.getScreenHeight() );
 
@@ -331,11 +337,11 @@ public class InertialScreenTransformEventHandler
 		boundYMin = layoutMinY - boundYLayoutBorder;
 		boundYMax = layoutMaxY + boundYLayoutBorder;
 
-		if ( boundYMax - boundYMin < DEFAULT_MIN_SCALE_Y )
+		if ( boundYMax - boundYMin < minScaleY )
 		{
 			final double c = ( boundYMax + boundYMin ) / 2;
-			boundYMin = c - DEFAULT_MIN_SCALE_Y / 2;
-			boundYMax = c + DEFAULT_MIN_SCALE_Y / 2;
+			boundYMin = c - minScaleY / 2;
+			boundYMax = c + minScaleY / 2;
 		}
 
 		updateMaxSizeY( transformState.get().getScreenHeight() );
@@ -345,7 +351,7 @@ public class InertialScreenTransformEventHandler
 	{
 		ConstrainScreenTransform.constrainTransform(
 				transform,
-				DEFAULT_MIN_SCALE_X, DEFAULT_MIN_SCALE_Y,
+				minScaleX, minScaleY,
 				maxSizeX, maxSizeY,
 				boundXMin, boundXMax, boundYMin, boundYMax,
 				borderRatioX, borderRatioY,
@@ -374,12 +380,12 @@ public class InertialScreenTransformEventHandler
 
 	private boolean hasMinSizeX( final ScreenTransform transform )
 	{
-		return ConstrainScreenTransform.hasMinSizeX( transform, DEFAULT_MIN_SCALE_X + EPSILON );
+		return ConstrainScreenTransform.hasMinSizeX( transform, minScaleX + EPSILON );
 	}
 
 	private boolean hasMinSizeY( final ScreenTransform transform )
 	{
-		return ConstrainScreenTransform.hasMinSizeY( transform, DEFAULT_MIN_SCALE_Y + EPSILON );
+		return ConstrainScreenTransform.hasMinSizeY( transform, minScaleY + EPSILON );
 	}
 
 	private boolean hasMaxSizeX( final ScreenTransform transform )

--- a/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
@@ -126,12 +126,12 @@ public class InertialScreenTransformEventHandler
 	/**
 	 * Sets the maximal zoom level in X.
 	 */
-	private static final double MIN_SIBLINGS_ON_CANVAS = 4;
+	private static final double DEFAULT_MIN_SCALE_X = 4;
 
 	/**
 	 * Sets the maximal zoom level in Y.
 	 */
-	private static final double MIN_TIMEPOINTS_ON_CANVAS = 4;
+	private static final double DEFAULT_MIN_SCALE_Y = 4;
 
 	private static final double EPSILON = 0.0000000001;
 
@@ -289,18 +289,18 @@ public class InertialScreenTransformEventHandler
 		boundYMin = layout.getCurrentLayoutMinY() - boundYLayoutBorder;
 		boundYMax = layout.getCurrentLayoutMaxY() + boundYLayoutBorder;
 
-		if ( boundXMax - boundXMin < MIN_SIBLINGS_ON_CANVAS )
+		if ( boundXMax - boundXMin < DEFAULT_MIN_SCALE_X )
 		{
 			final double c = ( boundXMax + boundXMin ) / 2;
-			boundXMin = c - MIN_SIBLINGS_ON_CANVAS / 2;
-			boundXMax = c + MIN_SIBLINGS_ON_CANVAS / 2;
+			boundXMin = c - DEFAULT_MIN_SCALE_X / 2;
+			boundXMax = c + DEFAULT_MIN_SCALE_X / 2;
 		}
 		updateMaxSizeX( transform.getScreenWidth() );
-		if ( boundYMax - boundYMin < MIN_SIBLINGS_ON_CANVAS )
+		if ( boundYMax - boundYMin < DEFAULT_MIN_SCALE_X )
 		{
 			final double c = ( boundYMax + boundYMin ) / 2;
-			boundYMin = c - MIN_SIBLINGS_ON_CANVAS / 2;
-			boundYMax = c + MIN_SIBLINGS_ON_CANVAS / 2;
+			boundYMin = c - DEFAULT_MIN_SCALE_X / 2;
+			boundYMax = c + DEFAULT_MIN_SCALE_X / 2;
 		}
 		updateMaxSizeY( transform.getScreenHeight() );
 
@@ -331,11 +331,11 @@ public class InertialScreenTransformEventHandler
 		boundYMin = layoutMinY - boundYLayoutBorder;
 		boundYMax = layoutMaxY + boundYLayoutBorder;
 
-		if ( boundYMax - boundYMin < MIN_TIMEPOINTS_ON_CANVAS )
+		if ( boundYMax - boundYMin < DEFAULT_MIN_SCALE_Y )
 		{
 			final double c = ( boundYMax + boundYMin ) / 2;
-			boundYMin = c - MIN_TIMEPOINTS_ON_CANVAS / 2;
-			boundYMax = c + MIN_TIMEPOINTS_ON_CANVAS / 2;
+			boundYMin = c - DEFAULT_MIN_SCALE_Y / 2;
+			boundYMax = c + DEFAULT_MIN_SCALE_Y / 2;
 		}
 
 		updateMaxSizeY( transformState.get().getScreenHeight() );
@@ -345,7 +345,7 @@ public class InertialScreenTransformEventHandler
 	{
 		ConstrainScreenTransform.constrainTransform(
 				transform,
-				MIN_SIBLINGS_ON_CANVAS, MIN_TIMEPOINTS_ON_CANVAS,
+				DEFAULT_MIN_SCALE_X, DEFAULT_MIN_SCALE_Y,
 				maxSizeX, maxSizeY,
 				boundXMin, boundXMax, boundYMin, boundYMax,
 				borderRatioX, borderRatioY,
@@ -374,12 +374,12 @@ public class InertialScreenTransformEventHandler
 
 	private boolean hasMinSizeX( final ScreenTransform transform )
 	{
-		return ConstrainScreenTransform.hasMinSizeX( transform, MIN_SIBLINGS_ON_CANVAS + EPSILON );
+		return ConstrainScreenTransform.hasMinSizeX( transform, DEFAULT_MIN_SCALE_X + EPSILON );
 	}
 
 	private boolean hasMinSizeY( final ScreenTransform transform )
 	{
-		return ConstrainScreenTransform.hasMinSizeY( transform, MIN_TIMEPOINTS_ON_CANVAS + EPSILON );
+		return ConstrainScreenTransform.hasMinSizeY( transform, DEFAULT_MIN_SCALE_Y + EPSILON );
 	}
 
 	private boolean hasMaxSizeX( final ScreenTransform transform )
@@ -507,7 +507,7 @@ public class InertialScreenTransformEventHandler
 			{
 				if ( zoomIn )
 				{
-					if ( !hasMinSizeY( transform ) )
+					if ( !hasMinSizeY( transform ) || true )
 						transform.zoomY( dScale, y );
 				}
 				else


### PR DESCRIPTION
This PR adds a new Window to Mastodon: the Grapher Branch View

![grafik](https://github.com/user-attachments/assets/6e79e3df-95d7-46da-ac96-8f756ff09f81)

* The Grapher Branch View can be used to plot of features on the branch graph, i.e. BranchSpot and BranchLink features
* This is similar to the existing Grapher that can show features on Spot level

In order to avoid too much of duplicated code in Grapher and Grapher Branch, this PR adds a new class: GrapherInitializer

* The intention of this class is to allow creating a GrapherView for Spot+Link and BranchSpot+BranchLink while reducing code duplication
* Methods that will be needed for both type of views, such as menu generation, color registration, creation of dataframe and datapanel can be found in this class

Since with the default max zoom in settings, it was sometimes not possible to see the labels of the branchspots, I introduced parameters and initialized the Grapher Branch View with higher max zoom in settings