### PR TITLE
Introduce new method areListenersPaused() to interface SelectionModel

### DIFF
--- a/src/main/java/org/mastodon/adapter/SelectionModelAdapter.java
+++ b/src/main/java/org/mastodon/adapter/SelectionModelAdapter.java
@@ -162,4 +162,10 @@ public class SelectionModelAdapter< V extends Vertex< E >, E extends Edge< V >, 
 	{
 		selection.pauseListeners();
 	}
+
+	@Override
+	public boolean areListenersPaused()
+	{
+		return selection.areListenersPaused();
+	}
 }

--- a/src/main/java/org/mastodon/model/DefaultSelectionModel.java
+++ b/src/main/java/org/mastodon/model/DefaultSelectionModel.java
@@ -389,4 +389,10 @@ public class DefaultSelectionModel< V extends Vertex< E >, E extends Edge< V > >
 	{
 		emitEvents = false;
 	}
+
+	@Override
+	public boolean areListenersPaused()
+	{
+		return !emitEvents;
+	}
 }

--- a/src/main/java/org/mastodon/model/SelectionModel.java
+++ b/src/main/java/org/mastodon/model/SelectionModel.java
@@ -163,9 +163,33 @@ public interface SelectionModel< V extends Vertex< E >, E extends Edge< V > >
 	 */
 	public Listeners< SelectionListener > listeners();
 
-	public void resumeListeners();
+	/**
+	 * Pauses the selection listeners. While paused, no listener that are contained in {@link #listeners()} will be notified
+	 * of selection changes.
+	 * <br>
+	 * However, this {@link SelectionModel} may record changes in selection state, and listeners may be notified of such a change, when the listeners are resumed with {@link #resumeListeners()}.
+	 * <br>
+	 * Changes the state of {@link #areListenersPaused()} to {@code true}.
+	 * <br>
+	 * Call {@link #resumeListeners()} to resume the listeners.
+	 */
+	void pauseListeners();
 
-	public void pauseListeners();
+	/**
+	 * Unpauses the selection listeners. All listeners that are contained in {@link #listeners()} will be notified of selection changes again.
+	 * <br>
+	 * If this {@link SelectionModel} has recorded changes in selection state while the listeners were paused, listeners will be notified of these changes.
+	 * <br>
+	 * Changes the state of {@link #areListenersPaused()} to {@code false}.
+	 */
+	void resumeListeners();
 
+	/**
+	 * Checks if the selection listeners are paused.
+	 * <br>
+	 * When paused, no listener that are contained in {@link #listeners()} will be notified of selection changes.
+	 *
+	 * @return {@code true} if the listeners are paused, {@code false} otherwise.
+	 */
 	boolean areListenersPaused();
 }

--- a/src/main/java/org/mastodon/model/SelectionModel.java
+++ b/src/main/java/org/mastodon/model/SelectionModel.java
@@ -166,4 +166,6 @@ public interface SelectionModel< V extends Vertex< E >, E extends Edge< V > >
 	public void resumeListeners();
 
 	public void pauseListeners();
+
+	boolean areListenersPaused();
 }

--- a/src/main/java/org/mastodon/model/branch/BranchGraphSelectionAdapter.java
+++ b/src/main/java/org/mastodon/model/branch/BranchGraphSelectionAdapter.java
@@ -76,6 +76,12 @@ public class BranchGraphSelectionAdapter<
 	}
 
 	@Override
+	public boolean areListenersPaused()
+	{
+		return selection.areListenersPaused();
+	}
+
+	@Override
 	public boolean isSelected( final BV vertex )
 	{
 		Iterator< V > vIter = branchGraph.vertexBranchIterator( vertex );
@@ -123,9 +129,15 @@ public class BranchGraphSelectionAdapter<
 	@Override
 	public void setSelected( final BV vertex, final boolean selected )
 	{
-		selection.pauseListeners();
-		setVertexSelected( vertex, selected );
-		selection.resumeListeners();
+		boolean areListenersPaused = selection.areListenersPaused();
+		if ( areListenersPaused )
+			setVertexSelected( vertex, selected );
+		else
+		{
+			selection.pauseListeners();
+			setVertexSelected( vertex, selected );
+			selection.resumeListeners();
+		}
 	}
 
 	private boolean setVertexSelected( final BV branchVertex, final boolean selected )


### PR DESCRIPTION
This PR introduces a new method `areListenersPaused()` to the interface `SelectionModel`

* The method `areListenersPaused()` is used in `BranchGraphSelectionAdapter` to find out, if listeners have been paused outside of this method and only in case they are not perform
  * pause listeners
  * select the branch vertex
  * resume listeners
* In case they are already paused, then they are neither paused again nor are they resumed after selecting the branch vertex
* Without this change a selection of many branch spots at the same time caused that resumeListeners() was called with high frequency resulting in low performance, when selecting many branch spots at the same time

Resolves #322 