### PR TITLE
Changes required for the integration of a 3D view based on BigVolumeViewer

### DIFF
--- a/src/main/java/org/mastodon/app/MastodonIcons.java
+++ b/src/main/java/org/mastodon/app/MastodonIcons.java
@@ -203,6 +203,9 @@ public class MastodonIcons
 	public static final List< Image > BDV_VIEW_ICON = Arrays
 			.asList( new Image[] { BDV_ICON_SMALL.getImage(), BDV_ICON_MEDIUM.getImage(), BDV_ICON_LARGE.getImage() } );
 
+	public static final List< Image > BVV_VIEW_ICON = Arrays
+			.asList( new Image[] { BVV_ICON_SMALL.getImage(), BVV_ICON_MEDIUM.getImage(), BVV_ICON_LARGE.getImage() } );
+
 	public static final List< Image > TRACKSCHEME_VIEW_ICON =
 			Arrays.asList( new Image[] { TRACKSCHEME_ICON_SMALL.getImage(), TRACKSCHEME_ICON_MEDIUM.getImage(),
 					TRACKSCHEME_ICON_LARGE.getImage() } );

--- a/src/main/java/org/mastodon/mamut/model/ModelGraph.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelGraph.java
@@ -86,7 +86,7 @@ public class ModelGraph extends AbstractModelGraph< ModelGraph, SpotPool, LinkPo
 	 * @return {@code true} if the listener was successfully registered.
 	 *         {@code false} if it was already registered.
 	 */
-	public boolean addCovarianceLabelListener( final PropertyChangeListener< Spot > listener )
+	public boolean addVertexCovarianceListener( final PropertyChangeListener< Spot > listener )
 	{
 		return vertexPool.covariance.propertyChangeListeners().add( listener );
 	}

--- a/src/main/java/org/mastodon/mamut/model/ModelGraph.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelGraph.java
@@ -119,4 +119,4 @@ public class ModelGraph extends AbstractModelGraph< ModelGraph, SpotPool, LinkPo
 		return vertexPool.covariance.propertyChangeListeners().remove( listener );
 	}
 }
-}
+

--- a/src/main/java/org/mastodon/mamut/model/ModelGraph.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelGraph.java
@@ -76,6 +76,20 @@ public class ModelGraph extends AbstractModelGraph< ModelGraph, SpotPool, LinkPo
 	{
 		return vertexPool.label.propertyChangeListeners().add( listener );
 	}
+	
+	/**
+	 * Register a {@link PropertyChangeListener} that will be notified when
+	 * a {@code Spot}s covariance is changed.
+	 *
+	 * @param listener
+	 *            the listener to register.
+	 * @return {@code true} if the listener was successfully registered.
+	 *         {@code false} if it was already registered.
+	 */
+	public boolean addCovarianceLabelListener( final PropertyChangeListener< Spot > listener )
+	{
+		return vertexPool.covariance.propertyChangeListeners().add( listener );
+	}
 
 	/**
 	 * Removes the specified {@link PropertyChangeListener} from the set of
@@ -90,4 +104,19 @@ public class ModelGraph extends AbstractModelGraph< ModelGraph, SpotPool, LinkPo
 	{
 		return vertexPool.label.propertyChangeListeners().remove( listener );
 	}
+	
+	/**
+	 * Removes the specified {@link PropertyChangeListener} from the set of
+	 * vertex covariance listeners.
+	 *
+	 * @param listener
+	 *            the listener to remove.
+	 * @return {@code true} if the listener was present in the listeners of this
+	 *         model and was successfully removed.
+	 */
+	public boolean removeVertexCovarianceListener( final PropertyChangeListener< Spot > listener )
+	{
+		return vertexPool.covariance.propertyChangeListeners().remove( listener );
+	}
+}
 }

--- a/src/main/java/org/mastodon/mamut/model/Spot.java
+++ b/src/main/java/org/mastodon/mamut/model/Spot.java
@@ -29,6 +29,7 @@
 package org.mastodon.mamut.model;
 
 import org.mastodon.model.AbstractSpot;
+import org.mastodon.model.HasCovariance;
 import org.mastodon.model.HasLabel;
 import org.mastodon.pool.ByteMappedElement;
 import org.mastodon.views.bdv.overlay.util.JamaEigenvalueDecomposition;
@@ -39,7 +40,7 @@ import org.mastodon.views.bdv.overlay.util.JamaEigenvalueDecomposition;
  *
  * @author Tobias Pietzsch
  */
-public final class Spot extends AbstractSpot< Spot, Link, SpotPool, ByteMappedElement, ModelGraph > implements HasLabel
+public final class Spot extends AbstractSpot< Spot, Link, SpotPool, ByteMappedElement, ModelGraph > implements HasLabel, HasCovariance
 {
 	private final JamaEigenvalueDecomposition eig = new JamaEigenvalueDecomposition( 3 );
 
@@ -145,11 +146,13 @@ public final class Spot extends AbstractSpot< Spot, Link, SpotPool, ByteMappedEl
 		return this;
 	}
 
+	@Override
 	public void getCovariance( final double[][] cov )
 	{
 		getCovarianceInternal( cov );
 	}
 
+	@Override
 	public void setCovariance( final double[][] cov )
 	{
 		pool.covariance.notifyBeforePropertyChange( this );

--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
@@ -188,6 +188,7 @@ public class MamutViewBdv
 						selectionModel,
 						coloring );
 
+		viewer.getDisplay().overlays().add( colorBarOverlay );
 		viewer.getDisplay().overlays().add( tracksOverlay );
 		viewer.renderTransformListeners().add( tracksOverlay );
 		viewer.timePointListeners().add( tracksOverlay );

--- a/src/main/java/org/mastodon/model/HasCovariance.java
+++ b/src/main/java/org/mastodon/model/HasCovariance.java
@@ -1,0 +1,30 @@
+package org.mastodon.model;
+
+/**
+ * Interface for objects that have a 3x3 covariance matrix, that can be set and
+ * accessed.
+ */
+public interface HasCovariance
+{
+
+	/**
+	 * Stores the covariance matrix in the specified <code>double[][]</code>
+	 * arrays.
+	 * 
+	 * @param mat
+	 *            a (at least) 3x3 <code>double[][]</code> array in which the
+	 *            covariance matrix will be written.
+	 */
+	public void getCovariance( final double[][] mat );
+
+	/**
+	 * Sets the covariance matrix of this objects, reading values from the
+	 * specified <code>double[][]</code> arrays.
+	 * 
+	 * @param mat
+	 *            a (at least) 3x3 <code>double[][]</code> array from which
+	 *            covariance values will be read.
+	 */
+	public void setCovariance( final double[][] mat );
+
+}

--- a/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
+++ b/src/main/java/org/mastodon/views/bdv/SharedBigDataViewerData.java
@@ -265,7 +265,7 @@ public class SharedBigDataViewerData
 		return elem;
 	}
 
-	private void restoreFromXmlSetupAssignments( final Element parent )
+	public void restoreFromXmlSetupAssignments( final Element parent )
 	{
 		final Element elemSetupAssignments = parent.getChild( "SetupAssignments" );
 		if ( elemSetupAssignments == null )

--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayNavigation.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayNavigation.java
@@ -31,14 +31,14 @@ package org.mastodon.views.bdv.overlay;
 import org.mastodon.model.NavigationListener;
 import org.mastodon.ui.NavigationEtiquette;
 
-import bdv.viewer.ViewerPanel;
+import bdv.viewer.AbstractViewerPanel;
 import bdv.viewer.animate.TranslationAnimator;
 import net.imglib2.realtransform.AffineTransform3D;
 
 public class OverlayNavigation< V extends OverlayVertex< V, E >, E extends OverlayEdge< E, V > >
 		implements NavigationListener< V, E >
 {
-	private final ViewerPanel panel;
+	private final AbstractViewerPanel panel;
 
 	private final OverlayGraph< V, E > graph;
 
@@ -47,7 +47,7 @@ public class OverlayNavigation< V extends OverlayVertex< V, E >, E extends Overl
 	private NavigationBehaviour< V, E > navigationBehaviour;
 
 	public OverlayNavigation(
-			final ViewerPanel panel,
+			final AbstractViewerPanel panel,
 			final OverlayGraph< V, E > graph )
 	{
 		this.panel = panel;
@@ -84,7 +84,7 @@ public class OverlayNavigation< V extends OverlayVertex< V, E >, E extends Overl
 	{
 		// Always move in T.
 		final int tp = vertex.getTimepoint();
-		panel.setTimepoint( tp );
+		panel.state().setCurrentTimepoint( tp );
 
 		final AffineTransform3D currentTransform = panel.state().getViewerTransform();
 		final double[] target = navigationBehaviour.navigateToVertex( vertex, currentTransform );
@@ -105,7 +105,7 @@ public class OverlayNavigation< V extends OverlayVertex< V, E >, E extends Overl
 		final V ref = graph.vertexRef();
 		final int tp = edge.getTarget( ref ).getTimepoint();
 		graph.releaseRef( ref );
-		panel.setTimepoint( tp );
+		panel.state().setCurrentTimepoint( tp );
 
 		final AffineTransform3D currentTransform = panel.state().getViewerTransform();
 		final double[] target = navigationBehaviour.navigateToEdge( edge, currentTransform );

--- a/src/main/java/org/mastodon/views/bdv/overlay/OverlayVertex.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/OverlayVertex.java
@@ -30,6 +30,7 @@ package org.mastodon.views.bdv.overlay;
 
 import org.mastodon.Ref;
 import org.mastodon.graph.Vertex;
+import org.mastodon.model.HasCovariance;
 import org.mastodon.model.HasLabel;
 import org.mastodon.spatial.HasTimepoint;
 
@@ -37,11 +38,8 @@ import net.imglib2.RealLocalizable;
 import net.imglib2.RealPositionable;
 
 public interface OverlayVertex< O extends OverlayVertex< O, E >, E extends OverlayEdge< E, ? > >
-		extends Vertex< E >, Ref< O >, RealLocalizable, RealPositionable, HasTimepoint, HasLabel
+		extends Vertex< E >, Ref< O >, RealLocalizable, RealPositionable, HasTimepoint, HasLabel, HasCovariance
 {
-	public void getCovariance( final double[][] mat );
-
-	public void setCovariance( final double[][] mat );
 
 	public double getBoundingSphereRadiusSquared();
 


### PR DESCRIPTION
These are small API changes required for building a new view based on Tobi's BVV in Mastodon, displaying the spots with OpenGL.

- An Icon list for BVV views.
- Can listen to vertex covariance changes
- Make some methods and classes working on `ViewerPanel` (specific to BDV) work on `AbstractViewPanel` (ancestor of both `ViewerPanel` and `VolumeViewerPanel`).
- An interface for objects that have a covariance matrix.
