### PR TITLE
Facilitate Custom File Formats - Required For Mastodon-Git Project

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/MamutViewStateXMLSerialization.java
+++ b/src/main/java/org/mastodon/mamut/io/MamutViewStateXMLSerialization.java
@@ -72,7 +72,7 @@ import net.imglib2.realtransform.AffineGet;
  * Utility class that can transform a GUI state
  * <code>Map< String, Object ></code> to XML and vice versa.
  */
-class MamutViewStateXMLSerialization
+public class MamutViewStateXMLSerialization
 {
 
 	private static final String WINDOW_TAG = "Window";
@@ -88,7 +88,7 @@ class MamutViewStateXMLSerialization
 	 */
 	private static final String CHOSEN_CONTEXT_PROVIDER_KEY = "ContextProvider";
 
-	static Element toXml( final Map< String, Object > guiState )
+	public static Element toXml( final Map< String, Object > guiState )
 	{
 		final Element element = new Element( WINDOW_TAG );
 		toXml( guiState, element );
@@ -191,7 +191,7 @@ class MamutViewStateXMLSerialization
 	 * @param windowManager
 	 *            the application {@link WindowManager}.
 	 */
-	static void fromXml( final Element windowsEl, final WindowManager windowManager )
+	public static void fromXml( final Element windowsEl, final WindowManager windowManager )
 	{
 		final MamutViews viewFactories = windowManager.getViewFactories();
 		final Collection< Class< ? extends MamutViewI > > classes = viewFactories.getKeys();

--- a/src/main/java/org/mastodon/mamut/model/ModelSerializer.java
+++ b/src/main/java/org/mastodon/mamut/model/ModelSerializer.java
@@ -33,7 +33,7 @@ import org.mastodon.graph.ref.AbstractEdgePool;
 import org.mastodon.graph.ref.AbstractVertexPool;
 import org.mastodon.pool.PoolObjectAttributeSerializer;
 
-class ModelSerializer implements GraphSerializer< Spot, Link >
+public class ModelSerializer implements GraphSerializer< Spot, Link >
 {
 	private ModelSerializer()
 	{}


### PR DESCRIPTION
The ["Mastodon-Git"](mastodon-sc/mastodon-git) plugin aims to efficiently store Mastodon datasets inside a git repository. Unfortunately git performs very poorly when processing a history of large binary files as produced by the default Mastodon file format. Mastodon-Git therefor implements a customized Mastodon file format that can very efficiently be processed with git.

Two classes in the Mastodon core need to be public in order for mastodon-git to implement this custom file format that can still benefit from mastodon core features:
* fast serialization of `Spot` and `Link` into byte arrays (class `ModelSerializer`)
* and serialization of the GUI state into an XML (class `MamutViewStateXMLSerialization`)

(Mastodon-git currently has its own copies of the `ProjectLoader` and `ProjectSaver` classes. In the long term it would be amazing if we could add a plugin API into mastodon core. That supports the implementation of custom file formats. Or at least make the `ProjectLoader` and `-Saver` more reusable. However in the short term it would be great if the `ModelSerializer` and `MamutViewStateXMLSerialization` were public. This would allow us the further experiment with the mastodon-git file format, without the need to use a customized mastodon.jar file.)


