### PR TITLE
Rework import / export menus

### DIFF
--- a/src/main/java/org/mastodon/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/mamut/MainWindow.java
@@ -38,6 +38,7 @@ import static org.mastodon.app.MastodonIcons.TABLE_ICON_MEDIUM;
 import static org.mastodon.app.MastodonIcons.TAGS_ICON_MEDIUM;
 import static org.mastodon.app.MastodonIcons.TRACKSCHEME_ICON_MEDIUM;
 import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.menu;
 import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.mamut.MamutMenuBuilder.fileMenu;
 
@@ -319,6 +320,9 @@ public class MainWindow extends JFrame
 						// item( ProjectActions.LOAD_PROJECT ),
 						item( ProjectActions.SAVE_PROJECT ),
 						item( ProjectActions.SAVE_PROJECT_AS ),
+						separator(),
+						menu( "Import" ),
+						menu( "Export" ),
 						separator(),
 						item( ProjectActions.FIX_DATASET_PATH ),
 						separator(),

--- a/src/main/java/org/mastodon/mamut/io/exporter/mamut/MamutExporterPlugin.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/mamut/MamutExporterPlugin.java
@@ -35,7 +35,7 @@ import java.awt.Component;
 import java.awt.Image;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +45,7 @@ import javax.swing.JOptionPane;
 import org.mastodon.app.MastodonIcons;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.MamutMenuBuilder;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.io.importer.trackmate.MamutExporter;
 import org.mastodon.mamut.plugin.MamutPlugin;
@@ -92,8 +93,8 @@ public class MamutExporterPlugin implements MamutPlugin
 	@Override
 	public List< ViewMenuBuilder.MenuItem > getMenuItems()
 	{
-		return Arrays.asList(
-				menu( "Plugins", menu( "Exports", item( EXPORT_MAMUT ) ) ) );
+		return Collections.singletonList(
+				MamutMenuBuilder.fileMenu( menu( "Export", item( EXPORT_MAMUT ) ) ) );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPlugin.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/graphml/GraphMLImporterPlugin.java
@@ -33,7 +33,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.menu;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +43,7 @@ import javax.swing.JOptionPane;
 import org.mastodon.app.MastodonIcons;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.MamutMenuBuilder;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.plugin.MamutPlugin;
 import org.mastodon.ui.keymap.KeyConfigContexts;
@@ -91,8 +92,8 @@ public class GraphMLImporterPlugin implements MamutPlugin
 	@Override
 	public List< ViewMenuBuilder.MenuItem > getMenuItems()
 	{
-		return Arrays.asList(
-				menu( "Plugins", menu( "Imports", item( IMPORT_GRAPHML ) ) ) );
+		return Collections.singletonList(
+				MamutMenuBuilder.fileMenu( menu( "Import", item( IMPORT_GRAPHML ) ) ) );
 	}
 
 	@Override


### PR DESCRIPTION
There are now two submenus in the `File` main menu that are made for plugins that import or export data in the current mastodon session. 
With this PR, the `Plugins` menu of a 'naked' mastodon application (with no other artifact present) is empty and not shown.

![Screenshot 2024-10-09 at 15 47 38](https://github.com/user-attachments/assets/51a30e46-2d2d-417b-8fbd-34bffc2ae8a8)
