### PR TITLE
Change the location of the Mastodon Launcher within the Fiji plugin menu

### DIFF
--- a/src/main/java/org/mastodon/mamut/launcher/MastodonLauncherCommand.java
+++ b/src/main/java/org/mastodon/mamut/launcher/MastodonLauncherCommand.java
@@ -33,7 +33,7 @@ import org.scijava.command.Command;
 import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Plugin;
 
-@Plugin( type = Command.class, menuPath = "Plugins>Mastodon" )
+@Plugin( type = Command.class, menuPath = "Plugins>Tracking>Mastodon>Mastodon Launcher" )
 public class MastodonLauncherCommand extends ContextCommand
 {
 


### PR DESCRIPTION
This PR changes the location of the Mastodon Launcher within the Fiji menu.

![grafik](https://github.com/user-attachments/assets/d0bc55cd-c496-428c-8cac-b85cf4ce26e6)
