### PR TITLE
Fix bug when loading project after deleting spots

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/ProjectSaver.java
+++ b/src/main/java/org/mastodon/mamut/io/ProjectSaver.java
@@ -261,7 +261,10 @@ public class ProjectSaver
 		try (final MamutProject.ProjectWriter writer = project.openForWriting())
 		{
 			MamutProjectIO.save( project, writer );
+			// Synchronize branch graph with main graph before saving. This is required to make saved state consistent.
+			appModel.getBranchGraphSync().sync();
 			final Model model = appModel.getModel();
+			// Save Raw Graph Model
 			final GraphToFileIdMap< Spot, Link > idmap = model.saveRaw( writer );
 			// Serialize feature model.
 			MamutRawFeatureModelIO.serialize( appModel.getContext(), model, idmap, writer );


### PR DESCRIPTION
This PR fixes a bug that occurred, when loading a project from which points had been deleted immediatly before project saving. 

* With https://github.com/mastodon-sc/mastodon/commit/8642393640cdca1b2dfe76d90457b31bca095593 the branch graph is not necessarily rebuilt on project loading.
* In order to achieve a consistent situation the branch graph is synced before saving. It is actually only synced, if it was found to be outdated (e.g. if points have been deleted, since the last sync of the graph).
* The PR contains a unit test to examplify the situation. The unit test would have failed before this PR.
