### PR TITLE
More complete restore of grapher gui state

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/MamutViewStateXMLSerialization.java
+++ b/src/main/java/org/mastodon/mamut/io/MamutViewStateXMLSerialization.java
@@ -41,7 +41,16 @@ import static org.mastodon.mamut.views.MamutView.TRACK_COLORING_KEY;
 import static org.mastodon.mamut.views.MamutViewFactory.VIEW_TYPE_KEY;
 import static org.mastodon.mamut.views.bdv.MamutViewBdvFactory.BDV_STATE_KEY;
 import static org.mastodon.mamut.views.bdv.MamutViewBdvFactory.BDV_TRANSFORM_KEY;
-import static org.mastodon.mamut.views.grapher.MamutViewGrapherFactory.GRAPHER_TRANSFORM_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_TRANSFORM_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_X_AXIS_FEATURE_IS_EDGE_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_X_AXIS_FEATURE_SPEC_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_X_AXIS_INCOMING_EDGE_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_X_AXIS_FEATURE_PROJECTION_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_SHOW_EDGES_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_Y_AXIS_FEATURE_IS_EDGE_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_Y_AXIS_FEATURE_SPEC_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_Y_AXIS_INCOMING_EDGE_KEY;
+import static org.mastodon.mamut.views.grapher.GrapherGuiState.GRAPHER_Y_AXIS_FEATURE_PROJECTION_KEY;
 import static org.mastodon.mamut.views.table.MamutViewTableFactory.TABLE_DISPLAYED;
 import static org.mastodon.mamut.views.table.MamutViewTableFactory.TABLE_ELEMENT;
 import static org.mastodon.mamut.views.table.MamutViewTableFactory.TABLE_NAME;
@@ -247,6 +256,10 @@ public class MamutViewStateXMLSerialization
 			case FEATURE_COLOR_MODE_KEY:
 			case VIEW_TYPE_KEY:
 			case CHOSEN_CONTEXT_PROVIDER_KEY:
+			case GRAPHER_X_AXIS_FEATURE_SPEC_KEY:
+			case GRAPHER_X_AXIS_FEATURE_PROJECTION_KEY:
+			case GRAPHER_Y_AXIS_FEATURE_SPEC_KEY:
+			case GRAPHER_Y_AXIS_FEATURE_PROJECTION_KEY:
 				value = el.getTextTrim();
 				break;
 			case TRACKSCHEME_TRANSFORM_KEY:
@@ -266,6 +279,11 @@ public class MamutViewStateXMLSerialization
 			case NO_COLORING_KEY:
 			case SETTINGS_PANEL_VISIBLE_KEY:
 			case COLORBAR_VISIBLE_KEY:
+			case GRAPHER_SHOW_EDGES_KEY:
+			case GRAPHER_X_AXIS_FEATURE_IS_EDGE_KEY:
+			case GRAPHER_X_AXIS_INCOMING_EDGE_KEY:
+			case GRAPHER_Y_AXIS_FEATURE_IS_EDGE_KEY:
+			case GRAPHER_Y_AXIS_INCOMING_EDGE_KEY:
 			case TRACK_COLORING_KEY:
 				value = XmlHelpers.getBoolean( viewEl, key );
 				break;

--- a/src/main/java/org/mastodon/mamut/views/grapher/DataDisplayFrameSupplier.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/DataDisplayFrameSupplier.java
@@ -1,0 +1,13 @@
+package org.mastodon.mamut.views.grapher;
+
+import org.mastodon.Ref;
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.Vertex;
+import org.mastodon.model.HasLabel;
+import org.mastodon.spatial.HasTimepoint;
+import org.mastodon.views.grapher.display.DataDisplayFrame;
+
+public interface DataDisplayFrameSupplier< V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > >
+{
+	DataDisplayFrame< V, E > getFrame();
+}

--- a/src/main/java/org/mastodon/mamut/views/grapher/GrapherGuiState.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/GrapherGuiState.java
@@ -1,0 +1,153 @@
+package org.mastodon.mamut.views.grapher;
+
+import java.util.Map;
+
+import org.mastodon.Ref;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.Vertex;
+import org.mastodon.model.HasLabel;
+import org.mastodon.spatial.HasTimepoint;
+import org.mastodon.views.grapher.datagraph.ScreenTransform;
+import org.mastodon.views.grapher.display.DataDisplayFrame;
+import org.mastodon.views.grapher.display.FeatureGraphConfig;
+import org.mastodon.views.grapher.display.FeatureSpecPair;
+import org.mastodon.views.grapher.display.GrapherSidePanel;
+
+public class GrapherGuiState
+{
+	private GrapherGuiState()
+	{
+		// Prevent instantiation.
+	}
+
+	/**
+	 * Key for the transform in a Grapher view. Value is a Grapher ScreenTransform instance.
+	 */
+	public static final String GRAPHER_TRANSFORM_KEY = "GrapherTransform";
+
+	/**
+	 * Key for the selected feature for the X axis in a Grapher view. Value is a Boolean.
+	 */
+	public static final String GRAPHER_X_AXIS_FEATURE_IS_EDGE_KEY = "GrapherXAxisFeatureIsEdge";
+
+	/**
+	 * Key for the selected feature spec for the X axis in a Grapher view. Value is a string.
+	 */
+	public static final String GRAPHER_X_AXIS_FEATURE_SPEC_KEY = "GrapherXAxisFeatureSpec";
+
+	/**
+	 * Key for the selected projection for the X axis in a Grapher view. Value is a string.
+	 */
+	public static final String GRAPHER_X_AXIS_FEATURE_PROJECTION_KEY = "GrapherXAxisFeatureProjection";
+
+	/**
+	 * Key for the selected incoming edge for the X axis in a Grapher view. Value is a boolean.
+	 */
+	public static final String GRAPHER_X_AXIS_INCOMING_EDGE_KEY = "GrapherXAxisFeatureIsIncomingEdge";
+
+	/**
+	 * Key for the selected feature for the Y axis in a Grapher view. Value is a Boolean.
+	 */
+	public static final String GRAPHER_Y_AXIS_FEATURE_IS_EDGE_KEY = "GrapherYAxisFeatureIsEdge";
+
+	/**
+	 * Key for the selected feature spec for the Y axis in a Grapher view. Value is a string.
+	 */
+	public static final String GRAPHER_Y_AXIS_FEATURE_SPEC_KEY = "GrapherYAxisFeatureSpec";
+
+	/**
+	 * Key for the selected projection for the Y axis in a Grapher view. Value is a string.
+	 */
+	public static final String GRAPHER_Y_AXIS_FEATURE_PROJECTION_KEY = "GrapherYAxisFeatureProjection";
+
+	/**
+	 * Key for the selected incoming edge for the Y axis in a Grapher view. Value is a boolean.
+	 */
+	public static final String GRAPHER_Y_AXIS_INCOMING_EDGE_KEY = "GrapherYAxisFeatureIsIncomingEdge";
+
+	/**
+	 * Key for whether show edges is checked in a Grapher view. Value is a boolean.
+	 */
+	public static final String GRAPHER_SHOW_EDGES_KEY = "GrapherShowEdges";
+
+	static < V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > > void
+			writeGuiState( final DataDisplayFrameSupplier< V, E > frameProvider, final Map< String, Object > guiState )
+	{
+		DataDisplayFrame< V, E > frame = frameProvider.getFrame();
+		// Transform.
+		final ScreenTransform transform = frame.getDataDisplayPanel().getScreenTransform().get();
+		guiState.put( GRAPHER_TRANSFORM_KEY, transform );
+		// Feature graph config.
+		writeFeatureGraphConfig( frame, guiState );
+	}
+
+	static < V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > > void
+			loadGuiState( final DataDisplayFrameSupplier< V, E > frameSupplier, final Map< String, Object > guiState,
+					final FeatureGraphConfig defaultConfig )
+	{
+		DataDisplayFrame< V, E > frame = frameSupplier.getFrame();
+
+		// Read Screen Transform.
+		final ScreenTransform screenTransform = ( ScreenTransform ) guiState.get( GRAPHER_TRANSFORM_KEY );
+		if ( null != screenTransform )
+			frame.getDataDisplayPanel().getScreenTransform().set( screenTransform );
+
+		// Read Feature graph config.
+		FeatureGraphConfig config = loadFeatureGraphConfig( frame, guiState, defaultConfig );
+		frame.getVertexSidePanel().setGraphConfig( config );
+
+		// Plot with loaded transform and config.
+		frame.plot( screenTransform );
+	}
+
+	private static < V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > > void
+			writeFeatureGraphConfig( final DataDisplayFrame< V, E > frame, final Map< String, Object > guiState )
+	{
+		FeatureGraphConfig config = frame.getVertexSidePanel().getGraphConfig();
+		// X-axis feature.
+		FeatureSpecPair featureSpecPairX = config.getXFeature();
+		guiState.put( GRAPHER_X_AXIS_FEATURE_IS_EDGE_KEY, featureSpecPairX.isEdgeFeature() );
+		guiState.put( GRAPHER_X_AXIS_FEATURE_SPEC_KEY, featureSpecPairX.getFeatureSpecKey() );
+		guiState.put( GRAPHER_X_AXIS_FEATURE_PROJECTION_KEY, featureSpecPairX.projectionKey().toString() );
+		guiState.put( GRAPHER_X_AXIS_INCOMING_EDGE_KEY, featureSpecPairX.isIncomingEdge() );
+		// Y-axis feature.
+		FeatureSpecPair featureSpecPairY = config.getYFeature();
+		guiState.put( GRAPHER_Y_AXIS_FEATURE_IS_EDGE_KEY, featureSpecPairY.isEdgeFeature() );
+		guiState.put( GRAPHER_Y_AXIS_FEATURE_SPEC_KEY, featureSpecPairY.getFeatureSpecKey() );
+		guiState.put( GRAPHER_Y_AXIS_FEATURE_PROJECTION_KEY, featureSpecPairY.projectionKey().toString() );
+		guiState.put( GRAPHER_Y_AXIS_INCOMING_EDGE_KEY, featureSpecPairY.isIncomingEdge() );
+		// Show edges.
+		guiState.put( GRAPHER_SHOW_EDGES_KEY, config.drawConnected() );
+	}
+
+	private static < V extends Vertex< E > & HasTimepoint & HasLabel & Ref< V >, E extends Edge< V > & Ref< E > > FeatureGraphConfig
+			loadFeatureGraphConfig( final DataDisplayFrame< V, E > frame, final Map< String, Object > guiState,
+					final FeatureGraphConfig defaultConfig )
+	{
+		GrapherSidePanel sidePanel = frame.getVertexSidePanel();
+		FeatureSpecPair featureSpecPairX = loadFeatureSpecPair( guiState, sidePanel, GRAPHER_X_AXIS_FEATURE_IS_EDGE_KEY,
+				GRAPHER_X_AXIS_FEATURE_SPEC_KEY, GRAPHER_X_AXIS_FEATURE_PROJECTION_KEY, GRAPHER_X_AXIS_INCOMING_EDGE_KEY );
+		FeatureSpecPair featureSpecPairY = loadFeatureSpecPair( guiState, sidePanel, GRAPHER_Y_AXIS_FEATURE_IS_EDGE_KEY,
+				GRAPHER_Y_AXIS_FEATURE_SPEC_KEY, GRAPHER_Y_AXIS_FEATURE_PROJECTION_KEY, GRAPHER_Y_AXIS_INCOMING_EDGE_KEY );
+		Boolean showEdges = ( Boolean ) guiState.get( GRAPHER_SHOW_EDGES_KEY );
+		if ( featureSpecPairX == null || featureSpecPairY == null || showEdges == null )
+			return defaultConfig;
+		return new FeatureGraphConfig( featureSpecPairX, featureSpecPairY, FeatureGraphConfig.GraphDataItemsSource.CONTEXT, showEdges );
+	}
+
+	private static FeatureSpecPair loadFeatureSpecPair( final Map< String, Object > guiState, final GrapherSidePanel sidePanel,
+			final String edgeKey, final String featureSpecKey, final String projectionKey, final String incomingEdgeKey )
+	{
+		Boolean isEdgeFeature = ( Boolean ) guiState.get( edgeKey );
+		final String yFeatureSpecKey = ( String ) guiState.get( featureSpecKey );
+		final String yProjectionKey = ( String ) guiState.get( projectionKey );
+		Boolean incomingEdge = ( Boolean ) guiState.get( incomingEdgeKey );
+		FeatureSpec< ?, ? > featureSpec = sidePanel.getFeatureSpec( yFeatureSpecKey );
+		FeatureProjectionSpec projectionSpec = sidePanel.getFeatureProjectionSpec( yProjectionKey );
+		if ( isEdgeFeature == null || featureSpec == null || projectionSpec == null || incomingEdge == null )
+			return null;
+		return new FeatureSpecPair( featureSpec, projectionSpec, isEdgeFeature, incomingEdge );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
@@ -187,8 +187,8 @@ public class GrapherInitializer< V extends Vertex< E > & HasTimepoint & HasLabel
 		// Label listener
 		appModel.getModel().getGraph().addVertexLabelListener( vertex -> panel.entitiesAttributesChanged() );
 
-		// Add a listener to detect changes in the graph and trigger a re-plot of the Grapher View
-		model.getGraph().addGraphChangeListener( frame::plot );
+		// Add a listener to detect changes in the graph and trigger a re-plot of the Grapher View using the current screen transform.
+		model.getGraph().addGraphChangeListener( () -> frame.plot( true ) );
 	}
 
 	void setOnClose( final MamutViewI view )

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -99,7 +99,7 @@ public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSp
 		grapherInitializer.layout();
 	}
 
-	private static FeatureGraphConfig getFeatureGraphConfig()
+	static FeatureGraphConfig getFeatureGraphConfig()
 	{
 		// If they are available, set some sensible defaults for the feature.
 		Iterator< FeatureProjectionSpec > projections = BranchDisplacementDurationFeature.SPEC.getProjectionSpecs().iterator();

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -59,7 +59,7 @@ import java.util.Iterator;
 import java.util.function.BiConsumer;
 
 public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSpot, BranchLink >, DataVertex, DataEdge >
-		implements HasContextChooser< BranchSpot >, HasColoringModel, HasColorBarOverlay
+		implements HasContextChooser< BranchSpot >, HasColoringModel, HasColorBarOverlay, DataDisplayFrameSupplier< BranchSpot, BranchLink >
 {
 
 	private final GrapherInitializer< BranchSpot, BranchLink > grapherInitializer;

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapherFactory.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapherFactory.java
@@ -28,6 +28,8 @@
  */
 package org.mastodon.mamut.views.grapher;
 
+import java.util.Map;
+
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.views.AbstractMamutViewFactory;
 import org.mastodon.mamut.views.MamutViewFactory;
@@ -43,6 +45,21 @@ public class MamutBranchViewGrapherFactory extends AbstractMamutViewFactory< Mam
 	public MamutBranchViewGrapher create( final ProjectModel projectModel )
 	{
 		return new MamutBranchViewGrapher( projectModel );
+	}
+
+	@Override
+	public Map< String, Object > getGuiState( final MamutBranchViewGrapher view )
+	{
+		final Map< String, Object > guiState = super.getGuiState( view );
+		GrapherGuiState.writeGuiState( view, guiState );
+		return guiState;
+	}
+
+	@Override
+	public void restoreGuiState( final MamutBranchViewGrapher view, final Map< String, Object > guiState )
+	{
+		super.restoreGuiState( view, guiState );
+		GrapherGuiState.loadGuiState( view, guiState, MamutBranchViewGrapher.getFeatureGraphConfig() );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -109,7 +109,7 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 		cf.getDialog().setTitle( cf.getDialog().getTitle() + " - " + frame.getTitle() );
 	}
 
-	private static FeatureGraphConfig getFeatureGraphConfig()
+	static FeatureGraphConfig getFeatureGraphConfig()
 	{
 		// If they are available, set some sensible defaults for the feature.
 		final FeatureSpecPair spvx = new FeatureSpecPair( SpotFrameFeature.SPEC,

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -58,7 +58,7 @@ import org.mastodon.views.grapher.display.FeatureSpecPair;
 import net.imglib2.loops.LoopBuilder;
 
 public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVertex, DataEdge >
-		implements HasContextChooser< Spot >, HasColoringModel, HasColorBarOverlay
+		implements HasContextChooser< Spot >, HasColoringModel, HasColorBarOverlay, DataDisplayFrameSupplier< Spot, Link >
 {
 
 	private final GrapherInitializer< Spot, Link > grapherInitializer;

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapherFactory.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapherFactory.java
@@ -34,7 +34,6 @@ import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.views.AbstractMamutViewFactory;
 import org.mastodon.mamut.views.MamutViewFactory;
 import org.mastodon.ui.coloring.ColorBarOverlay.Position;
-import org.mastodon.views.grapher.datagraph.ScreenTransform;
 import org.scijava.Priority;
 import org.scijava.plugin.Plugin;
 
@@ -73,12 +72,6 @@ public class MamutViewGrapherFactory extends AbstractMamutViewFactory< MamutView
 
 	public static final String NEW_GRAPHER_VIEW = "new grapher view";
 
-	/**
-	 * Key for the transform in a Grapher view. Value is a Grapher
-	 * ScreenTransform instance.
-	 */
-	public static final String GRAPHER_TRANSFORM_KEY = "GrapherTransform";
-
 	@Override
 	public MamutViewGrapher create( final ProjectModel projectModel )
 	{
@@ -89,10 +82,7 @@ public class MamutViewGrapherFactory extends AbstractMamutViewFactory< MamutView
 	public Map< String, Object > getGuiState( final MamutViewGrapher view )
 	{
 		final Map< String, Object > guiState = super.getGuiState( view );
-		// Transform.
-		final ScreenTransform t = view.getFrame().getDataDisplayPanel().getScreenTransform().get();
-		guiState.put( GRAPHER_TRANSFORM_KEY, t );
-
+		GrapherGuiState.writeGuiState( view, guiState );
 		return guiState;
 	}
 
@@ -101,11 +91,7 @@ public class MamutViewGrapherFactory extends AbstractMamutViewFactory< MamutView
 	public void restoreGuiState( final MamutViewGrapher view, final Map< String, Object > guiState )
 	{
 		super.restoreGuiState( view, guiState );
-
-		// Transform.
-		final ScreenTransform tLoaded = ( ScreenTransform ) guiState.get( GRAPHER_TRANSFORM_KEY );
-		if ( null != tLoaded )
-			view.getFrame().getDataDisplayPanel().getScreenTransform().set( tLoaded );
+		GrapherGuiState.loadGuiState( view, guiState, MamutViewGrapher.getFeatureGraphConfig() );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/views/grapher/display/DataDisplayFrame.java
+++ b/src/main/java/org/mastodon/views/grapher/display/DataDisplayFrame.java
@@ -60,6 +60,7 @@ import org.mastodon.views.grapher.datagraph.DataEdge;
 import org.mastodon.views.grapher.datagraph.DataGraph;
 import org.mastodon.views.grapher.datagraph.DataGraphLayout;
 import org.mastodon.views.grapher.datagraph.DataVertex;
+import org.mastodon.views.grapher.datagraph.ScreenTransform;
 import org.scijava.ui.behaviour.MouseAndKeyHandler;
 
 public class DataDisplayFrame< V extends Vertex< E > & HasTimepoint & HasLabel, E extends Edge< V > > extends ViewFrame
@@ -116,7 +117,7 @@ public class DataDisplayFrame< V extends Vertex< E > & HasTimepoint & HasLabel, 
 		 */
 
 		sidePanel = new GrapherSidePanel( nSources, contextChooser );
-		sidePanel.getBtnPlot().addActionListener( e -> plot() );
+		sidePanel.getBtnPlot().addActionListener( e -> plot( false ) );
 
 		final FeatureModelListener featureModelListener = () -> sidePanel.setFeatures(
 				FeatureUtils.collectFeatureMap( featureModel, vertexClass ),
@@ -187,8 +188,18 @@ public class DataDisplayFrame< V extends Vertex< E > & HasTimepoint & HasLabel, 
 		return sidePanel;
 	}
 
-	public void plot()
+	/**
+	 * Plots the grapher view.
+	 * @param keepCurrentScreenTransform if {@code true}, the current screen transform is kept, otherwise it zoomed out fully.
+	 */
+	public void plot( boolean keepCurrentScreenTransform )
 	{
-		dataDisplayPanel.plot( sidePanel.getGraphConfig(), featureModel );
+		dataDisplayPanel.plot( sidePanel.getGraphConfig(), featureModel,
+				keepCurrentScreenTransform ? dataDisplayPanel.getScreenTransform().get() : null );
+	}
+
+	public void plot( final ScreenTransform transform )
+	{
+		dataDisplayPanel.plot( sidePanel.getGraphConfig(), featureModel, transform );
 	}
 }

--- a/src/main/java/org/mastodon/views/grapher/display/DataDisplayPanel.java
+++ b/src/main/java/org/mastodon/views/grapher/display/DataDisplayPanel.java
@@ -871,7 +871,7 @@ public class DataDisplayPanel< V extends Vertex< E > & HasTimepoint & HasLabel, 
 		}
 	}
 
-	void plot( final FeatureGraphConfig gc, final FeatureModel featureModel )
+	void plot( final FeatureGraphConfig gc, final FeatureModel featureModel, final ScreenTransform transform )
 	{
 		trackContext = false;
 
@@ -948,9 +948,12 @@ public class DataDisplayPanel< V extends Vertex< E > & HasTimepoint & HasLabel, 
 		graphOverlay.setYLabel( ylabel );
 
 		graphChanged();
-		Executors.newSingleThreadScheduledExecutor()
-				.schedule( () -> transformEventHandler.zoomOutFully(),
-						100, TimeUnit.MILLISECONDS );
+		Executors.newSingleThreadScheduledExecutor().schedule( () -> {
+			if ( transform == null )
+				transformEventHandler.zoomOutFully();
+			else
+				transformEventHandler.zoomTo( transform.getMinX(), transform.getMaxX(), transform.getMinY(), transform.getMaxY() );
+		}, 100, TimeUnit.MILLISECONDS );
 	}
 
 	private RefSet< DataVertex > fromContext()

--- a/src/main/java/org/mastodon/views/grapher/display/FeatureSpecPair.java
+++ b/src/main/java/org/mastodon/views/grapher/display/FeatureSpecPair.java
@@ -199,4 +199,13 @@ public class FeatureSpecPair implements Comparable< FeatureSpecPair >
 		final FeatureProjection< O > projection = ( FeatureProjection< O > ) feature.project( key );
 		return projection;
 	}
+
+	/**
+	 * Returns the key of the feature spec this instance is specifying.
+	 * @return the key of the feature spec.
+	 */
+	public String getFeatureSpecKey()
+	{
+		return featureSpec.getKey();
+	}
 }

--- a/src/main/java/org/mastodon/views/grapher/display/GrapherSidePanel.java
+++ b/src/main/java/org/mastodon/views/grapher/display/GrapherSidePanel.java
@@ -405,6 +405,26 @@ public class GrapherSidePanel extends JPanel
 		repaint();
 	}
 
+	public FeatureSpec< ?, ? > getFeatureSpec( final String featureSpecKey )
+	{
+		for ( final FeatureSpecPair featureSpecPair : specs )
+		{
+			if ( featureSpecPair.getFeatureSpecKey().equals( featureSpecKey ) )
+				return featureSpecPair.featureSpec;
+		}
+		return null;
+	}
+
+	public FeatureProjectionSpec getFeatureProjectionSpec( final String projectionKey )
+	{
+		for ( final FeatureSpecPair featureSpecPair : specs )
+		{
+			if ( featureSpecPair.projectionKey().toString().equals( projectionKey ) )
+				return featureSpecPair.projectionKey().getSpec();
+		}
+		return null;
+	}
+
 	private static final FeatureModel demoFM()
 	{
 		final Model model = new Model();


### PR DESCRIPTION
This PR makes the following changes:

* Only zoom out to full data extent in Grapher after Button "Plot" has been pressed
* In cases, when the grapher is redrawn after changes, the screen transform will stay the same. This includes cases, when the Grapher is redrawn after opening a project
* Add serialization of the GUI state of the grapher views. The following things are restored additionally the window size+position:
  * Selected X-Axis Feature + Projection
  * Selected Y-Axis Feature + Projection
  * The ScreenTransform that was used during saving the project
  * Whether or not to connect edges

The context chosen by the user can unfortunately not be restored, since the BDV View Windows have no unique ID. However, this is consistent to other views (e.g. TrackScheme), where the context can also not be restored.


![grafik](https://github.com/user-attachments/assets/0a0c9dda-9d17-4884-b2bf-6654e7689cb2)
