### PR TITLE
Rework spot addition and link toggling in BDV views

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/mamut/views/bdv/MamutViewBdv.java
@@ -222,7 +222,7 @@ public class MamutViewBdv
 
 		BdvSelectionBehaviours.install( viewBehaviours, viewGraph, tracksOverlay, selectionModel, focusModel,
 				navigationHandler );
-		EditBehaviours.install( viewBehaviours, viewer, viewGraph, tracksOverlay, selectionModel, focusModel, model,
+		EditBehaviours.install( viewBehaviours, viewer, viewGraph, tracksOverlay, focusModel, model,
 				getMinRadius( sharedBdvData ) );
 		EditSpecialBehaviours.install( viewBehaviours, frame.getViewerPanel(), viewGraph, tracksOverlay, selectionModel,
 				focusModel, model );

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditBehaviours.java
@@ -81,7 +81,7 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 
 	static final String[] MOVE_SPOT_KEYS = new String[] { "SPACE" };
 
-	static final String[] ADD_SPOT_KEYS = new String[] { "A" };
+	static final String[] ADD_SPOT_KEYS = new String[] { "not mapped" };
 
 	static final String[] TOGGLE_AUTO_LINKING_MODE_KEYS = { "control L" };
 
@@ -100,7 +100,9 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 	/**
 	 * Common (static) flag for the auto-linking mode.
 	 */
-	private static boolean autoLink = false;
+	static boolean autoLink = false;
+
+	static double lastRadius = 5.;
 
 	/*
 	 * Command descriptions for all provided commands
@@ -175,8 +177,6 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 	private final ResizeSpotBehaviour decreaseSpotRadiusBehaviourALot;
 
 	private final ResizeSpotBehaviour decreaseSpotRadiusBehaviourABit;
-
-	private double lastRadius = 5.;
 
 	public static < V extends OverlayVertex< V, E >, E extends OverlayEdge< E, V > > void install(
 			final Behaviours behaviours,

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditBehaviours.java
@@ -30,9 +30,7 @@ package org.mastodon.views.bdv.overlay;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.mastodon.collection.RefSet;
 import org.mastodon.model.FocusModel;
-import org.mastodon.model.SelectionModel;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.ui.keymap.KeyConfigScopes;
 import org.mastodon.undo.UndoPointMarker;
@@ -160,8 +158,6 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 	 */
 	private static final double ALOT_RADIUS_CHANGE = 1.;
 
-	private final AddSpotBehaviour addSpotBehaviour;
-
 	private final ToggleAutoLinkingModeBehaviour toggleAutoLinkingModeBehaviour;
 
 	private final MoveSpotBehaviour moveSpotBehaviour;
@@ -183,16 +179,14 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 			final ViewerPanel viewerPanel,
 			final OverlayGraph< V, E > overlayGraph,
 			final OverlayGraphRenderer< V, E > renderer,
-			final SelectionModel< V, E > selection,
 			final FocusModel< V > focus,
 			final UndoPointMarker undo,
 			final double minRadius )
 	{
-		final EditBehaviours< V, E > eb = new EditBehaviours<>( viewerPanel, overlayGraph, renderer, selection, focus,
+		final EditBehaviours< V, E > eb = new EditBehaviours<>( viewerPanel, overlayGraph, renderer, focus,
 				undo, NORMAL_RADIUS_CHANGE, ABIT_RADIUS_CHANGE, ALOT_RADIUS_CHANGE, minRadius );
 
 		behaviours.namedBehaviour( eb.moveSpotBehaviour, MOVE_SPOT_KEYS );
-		behaviours.namedBehaviour( eb.addSpotBehaviour, ADD_SPOT_KEYS );
 		behaviours.namedBehaviour( eb.toggleAutoLinkingModeBehaviour, TOGGLE_AUTO_LINKING_MODE_KEYS );
 		behaviours.namedBehaviour( eb.increaseSpotRadiusBehaviour, INCREASE_SPOT_RADIUS_KEYS );
 		behaviours.namedBehaviour( eb.increaseSpotRadiusBehaviourABit, INCREASE_SPOT_RADIUS_ABIT_KEYS );
@@ -208,8 +202,6 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 
 	private final OverlayGraphRenderer< V, E > renderer;
 
-	private final SelectionModel< V, E > selection;
-
 	private final FocusModel< V > focus;
 
 	private final UndoPointMarker undo;
@@ -220,7 +212,6 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 			final ViewerPanel viewerPanel,
 			final OverlayGraph< V, E > overlayGraph,
 			final OverlayGraphRenderer< V, E > renderer,
-			final SelectionModel< V, E > selection,
 			final FocusModel< V > focus,
 			final UndoPointMarker undo,
 			final double normalRadiusChange,
@@ -232,12 +223,10 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 		this.overlayGraph = overlayGraph;
 		this.lock = overlayGraph.getLock();
 		this.renderer = renderer;
-		this.selection = selection;
 		this.focus = focus;
 		this.undo = undo;
 
 		moveSpotBehaviour = new MoveSpotBehaviour( MOVE_SPOT );
-		addSpotBehaviour = new AddSpotBehaviour( ADD_SPOT );
 		toggleAutoLinkingModeBehaviour = new ToggleAutoLinkingModeBehaviour( TOGGLE_AUTO_LINKING_MODE );
 		increaseSpotRadiusBehaviour = new ResizeSpotBehaviour( INCREASE_SPOT_RADIUS, normalRadiusChange, minRadius );
 		increaseSpotRadiusBehaviourALot =
@@ -265,91 +254,6 @@ public class EditBehaviours< V extends OverlayVertex< V, E >, E extends OverlayE
 		{
 			autoLink = !autoLink;
 			viewerPanel.showMessage( "Auto-linking mode " + ( autoLink ? "on" : "off" ) );
-		}
-	}
-
-	private class AddSpotBehaviour extends AbstractNamedBehaviour implements ClickBehaviour
-	{
-
-		private final double[] pos;
-
-		public AddSpotBehaviour( final String name )
-		{
-			super( name );
-			pos = new double[ 3 ];
-		}
-
-		@Override
-		public void click( final int x, final int y )
-		{
-			boolean isOutsideExistingSpot = false;
-			lock.readLock().lock();
-			try
-			{
-				final V ref = overlayGraph.vertexRef();
-				isOutsideExistingSpot = renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, ref ) == null;
-				overlayGraph.releaseRef( ref );
-			}
-			finally
-			{
-				lock.readLock().unlock();
-			}
-
-			// Only create a spot if we don't click inside an existing spot.
-			if ( isOutsideExistingSpot )
-			{
-				final int timepoint = renderer.getCurrentTimepoint();
-				renderer.getGlobalPosition( x, y, pos );
-				final V ref = overlayGraph.vertexRef();
-				lock.writeLock().lock();
-				try
-				{
-					final V vertex = overlayGraph.addVertex( ref ).init( timepoint, pos, lastRadius );
-
-					if ( autoLink )
-					{
-						final RefSet< V > selectedVertices = selection.getSelectedVertices();
-						if ( selectedVertices.size() == 1 )
-						{
-							final V previous = selectedVertices.iterator().next();
-							/*
-							 * Careful with directed graphs. We always check and
-							 * create links forward in time.
-							 */
-							final int t1 = vertex.getTimepoint();
-							final int t2 = previous.getTimepoint();
-							if ( t1 != t2 )
-							{
-								final V from = t1 > t2 ? previous : vertex;
-								final V to = t1 > t2 ? vertex : previous;
-								final E eref = overlayGraph.edgeRef();
-								overlayGraph.addEdge( from, to, eref ).init();
-								overlayGraph.releaseRef( eref );
-							}
-						}
-					}
-
-					overlayGraph.notifyGraphChanged();
-
-					undo.setUndoPoint();
-
-					if ( FOCUS_EDITED_SPOT )
-						focus.focusVertex( vertex );
-
-					if ( SELECT_ADDED_SPOT )
-					{
-						selection.pauseListeners();
-						selection.clearSelection();
-						selection.setSelected( vertex, true );
-						selection.resumeListeners();
-					}
-				}
-				finally
-				{
-					overlayGraph.releaseRef( ref );
-					lock.writeLock().unlock();
-				}
-			}
 		}
 	}
 

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
@@ -124,6 +124,8 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 
 	public static final BasicStroke EDIT_GRAPH_OVERLAY_STROKE = new BasicStroke( 2f );
 
+	public static final BasicStroke EDIT_GRAPH_OVERLAY_BIG_STROKE = new BasicStroke( 4f );
+
 	public static final BasicStroke EDIT_GRAPH_OVERLAY_GHOST_STROKE = new BasicStroke(
 			1f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL,
 			1.0f, new float[] { 4f, 10f }, 0f );
@@ -235,6 +237,8 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 
 		public boolean paintGhostTarget;
 
+		public boolean snap;
+
 		public EditSpecialBehavioursOverlay()
 		{
 			from = new double[ 3 ];
@@ -280,7 +284,7 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 			// The link.
 			if ( paintGhostLink )
 			{
-				graphics.setStroke( EDIT_GRAPH_OVERLAY_STROKE );
+				graphics.setStroke( snap ? EDIT_GRAPH_OVERLAY_BIG_STROKE : EDIT_GRAPH_OVERLAY_STROKE );
 				renderer.getViewerPosition( from, vFrom );
 
 				g.drawLine( ( int ) vFrom[ 0 ], ( int ) vFrom[ 1 ],
@@ -379,9 +383,15 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 			if ( editing )
 			{
 				if ( renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, target ) != null )
+				{
+					overlay.snap = true;
 					target.localize( overlay.to );
+				}
 				else
+				{
+					overlay.snap = false;
 					renderer.getGlobalPosition( x, y, overlay.to );
+				}
 			}
 		}
 
@@ -748,6 +758,7 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 						{
 							// No target in the vicinity - paint the future one.
 							overlay.paintGhostTarget = true;
+							overlay.snap = false;
 							System.out.println( "[AddOrLinkSpot] No near target" ); // DEBUG
 							renderer.getGlobalPosition( x, y, pos );
 							LinAlgHelpers.add( pos, start, pos );
@@ -757,6 +768,7 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 						{
 							// Snap ghost link to found target.
 							overlay.paintGhostTarget = false;
+							overlay.snap = true;
 							System.out.println( "[AddOrLinkSpot] Found a close target: " + target ); // DEBUG
 							target.localize( overlay.to );
 						}

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
@@ -657,8 +657,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 
 			if ( creatingNewSpot )
 			{
-				System.out.println( "[AddOrLinkSpot] creating a new spot at " + x + ", " + y ); // DEBUG
-
 				final int timepoint = renderer.getCurrentTimepoint();
 				renderer.getGlobalPosition( x, y, pos );
 				lock.writeLock().lock();
@@ -711,8 +709,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 			}
 			else
 			{
-				System.out.println( "[AddOrLinkSpot] starting from " + source ); // DEBUG
-
 				// Move to next or previous time point and check that we can.
 				final int currentTimepoint = viewer.state().getCurrentTimepoint();
 				if ( forward )
@@ -771,7 +767,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 							// No target in the vicinity - paint the future one.
 							overlay.paintGhostTarget = true;
 							overlay.snap = false;
-							System.out.println( "[AddOrLinkSpot] No near target" ); // DEBUG
 							renderer.getGlobalPosition( x, y, pos );
 							LinAlgHelpers.add( pos, start, pos );
 							System.arraycopy( pos, 0, overlay.to, 0, pos.length );
@@ -781,7 +776,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 							// Snap ghost link to found target.
 							overlay.paintGhostTarget = false;
 							overlay.snap = true;
-							System.out.println( "[AddOrLinkSpot] Found a close target: " + target ); // DEBUG
 							target.localize( overlay.to );
 							/*
 							 * Is there a link between the source and found
@@ -816,7 +810,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 					{
 						lock.readLock().unlock();
 					}
-					System.out.println( targetFound ); // DEBUG
 
 					lock.writeLock().lock();
 					try

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
@@ -108,15 +108,31 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 			descriptions.add( TOGGLE_LINK_BACKWARD, TOGGLE_LINK_BACKWARD_KEYS,
 					"Toggle link from the spot under the mouse, by dragging to a spot in the previous timepoint." );
 			descriptions.add( ADD_OR_LINK_SPOT_FORWARD, ADD_OR_LINK_SPOT_FORWARD_KEYS,
-					"Add or link to a new spot in the next timepoint. If a target spot is found near "
-							+ "the mouse location when the key is released, it is linked to the source spot this "
-							+ "action was started on. If not, a new spot is created at the mouse location and "
-							+ "linked to the source spot." );
+					"Main action to add or link to a new spot."
+							+ "\n"
+							+ "If there are no spots where the mouse is clicked, a new spot is created, which "
+							+ "can be positionned by holding the key and moving the mouse. "
+							+ "\n"
+							+ "If the key is pressed from within a source spot, the viewer moves to the *next* "
+							+ "time point and offers to create a new spot linked to this source. "
+							+ "Hold and drag to position the new spot. A new spot will be created "
+							+ "where the mouse is released, and linked to the source spot. "
+							+ "If a target spot is found near  the mouse location when the key is "
+							+ "released, it is linked to the source spot. If a link already exists "
+							+ "between the two, it is removed." );
 			descriptions.add( ADD_OR_LINK_SPOT_BACKWARD, ADD_OR_LINK_SPOT_BACKWARD_KEYS,
-					"Add or link to a spot in the previous timepoint. If a target spot is found near "
-							+ "the mouse location when the key is released, it is linked to the source spot this "
-							+ "action was started on. If not, a new spot is created at the mouse location and "
-							+ "linked to the source spot." );
+					"Main action to add or link to a new spot."
+							+ "\n"
+							+ "If there are no spots where the mouse is clicked, a new spot is created, which "
+							+ "can be positionned by holding the key and moving the mouse. "
+							+ "\n"
+							+ "If the key is pressed from within a source spot, the viewer moves to the *previous* "
+							+ "time point and offers to create a new spot linked to this source. "
+							+ "Hold and drag to position the new spot. A new spot will be created "
+							+ "where the mouse is released, and linked to the source spot. "
+							+ "If a target spot is found near  the mouse location when the key is "
+							+ "released, it is linked to the source spot. If a link already exists "
+							+ "between the two, it is removed." );
 		}
 	}
 

--- a/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/views/bdv/overlay/EditSpecialBehaviours.java
@@ -61,21 +61,6 @@ import net.imglib2.util.LinAlgHelpers;
 
 public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends OverlayEdge< E, V > >
 {
-	private static final String ADD_SPOT_AND_LINK_IT_FORWARD = "add linked spot";
-
-	private static final String ADD_SPOT_AND_LINK_IT_BACKWARD = "add linked spot backward";
-
-	private static final String TOGGLE_LINK_FORWARD = "toggle link";
-
-	private static final String TOGGLE_LINK_BACKWARD = "toggle link backward";
-
-	private static final String[] ADD_SPOT_AND_LINK_IT_FORWARD_KEYS = new String[] { "not mapped" };
-
-	private static final String[] ADD_SPOT_AND_LINK_IT_BACKWARD_KEYS = new String[] { "not mapped" };
-
-	private static final String[] TOGGLE_LINK_FORWARD_KEYS = new String[] { "L" };
-
-	private static final String[] TOGGLE_LINK_BACKWARD_KEYS = new String[] { "shift L" };
 
 	private static final String ADD_OR_LINK_SPOT_FORWARD = "add or link spot";
 
@@ -99,14 +84,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 		@Override
 		public void getCommandDescriptions( final CommandDescriptions descriptions )
 		{
-			descriptions.add( ADD_SPOT_AND_LINK_IT_FORWARD, ADD_SPOT_AND_LINK_IT_FORWARD_KEYS,
-					"Add a new spot in the next timepoint, linked to the spot under the mouse." );
-			descriptions.add( ADD_SPOT_AND_LINK_IT_BACKWARD, ADD_SPOT_AND_LINK_IT_BACKWARD_KEYS,
-					"Add a new spot in the previous timepoint, linked to the spot under the mouse." );
-			descriptions.add( TOGGLE_LINK_FORWARD, TOGGLE_LINK_FORWARD_KEYS,
-					"Toggle link from the spot under the mouse, by dragging to a spot in the next timepoint." );
-			descriptions.add( TOGGLE_LINK_BACKWARD, TOGGLE_LINK_BACKWARD_KEYS,
-					"Toggle link from the spot under the mouse, by dragging to a spot in the previous timepoint." );
 			descriptions.add( ADD_OR_LINK_SPOT_FORWARD, ADD_OR_LINK_SPOT_FORWARD_KEYS,
 					"Main action to add or link to a new spot."
 							+ "\n"
@@ -150,14 +127,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 			1f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL,
 			1.0f, new float[] { 4f, 10f }, 0f );
 
-	private final AddSpotAndLinkIt addSpotAndLinkItForwardBehaviour;
-
-	private final AddSpotAndLinkIt addSpotAndLinkItBackwardBehaviour;
-
-	private final ToggleLink toggleLinkForwardBehaviour;
-
-	private final ToggleLink toggleLinkBackwardBehaviour;
-
 	private final AddOrLinkSpot addOrLinkSpotForward;
 
 	private final AddOrLinkSpot addOrLinkSpotBackward;
@@ -176,10 +145,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 		final EditSpecialBehaviours< V, E > eb =
 				new EditSpecialBehaviours<>( viewer, overlayGraph, renderer, selection, focus, undo );
 
-		behaviours.namedBehaviour( eb.addSpotAndLinkItForwardBehaviour, ADD_SPOT_AND_LINK_IT_FORWARD_KEYS );
-		behaviours.namedBehaviour( eb.addSpotAndLinkItBackwardBehaviour, ADD_SPOT_AND_LINK_IT_BACKWARD_KEYS );
-		behaviours.namedBehaviour( eb.toggleLinkForwardBehaviour, TOGGLE_LINK_FORWARD_KEYS );
-		behaviours.namedBehaviour( eb.toggleLinkBackwardBehaviour, TOGGLE_LINK_BACKWARD_KEYS );
 		behaviours.namedBehaviour( eb.addOrLinkSpotForward, ADD_OR_LINK_SPOT_FORWARD_KEYS );
 		behaviours.namedBehaviour( eb.addOrLinkSpotBackward, ADD_OR_LINK_SPOT_BACKWARD_KEYS );
 	}
@@ -221,10 +186,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 		viewer.renderTransformListeners().add( overlay );
 
 		// Behaviours.
-		addSpotAndLinkItForwardBehaviour = new AddSpotAndLinkIt( ADD_SPOT_AND_LINK_IT_FORWARD, true );
-		addSpotAndLinkItBackwardBehaviour = new AddSpotAndLinkIt( ADD_SPOT_AND_LINK_IT_BACKWARD, false );
-		toggleLinkForwardBehaviour = new ToggleLink( TOGGLE_LINK_FORWARD, true );
-		toggleLinkBackwardBehaviour = new ToggleLink( TOGGLE_LINK_BACKWARD, false );
 		addOrLinkSpotForward = new AddOrLinkSpot( ADD_OR_LINK_SPOT_FORWARD, true );
 		addOrLinkSpotBackward = new AddOrLinkSpot( ADD_OR_LINK_SPOT_BACKWARD, false );
 	}
@@ -337,283 +298,6 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 				transform.set( renderTransform );
 			}
 			return transform;
-		}
-	}
-
-	// TODO What to do if the user changes the time-point while dragging?
-	// TODO Because the user can move in time currently, always do a sanity
-	// check before inserting the link
-	private class ToggleLink extends AbstractNamedBehaviour implements DragBehaviour
-	{
-		private final V source;
-
-		private final V target;
-
-		private final E edgeRef;
-
-		private boolean editing;
-
-		private final boolean forward;
-
-		public ToggleLink( final String name, final boolean forward )
-		{
-			super( name );
-			this.forward = forward;
-			source = overlayGraph.vertexRef();
-			target = overlayGraph.vertexRef();
-			edgeRef = overlayGraph.edgeRef();
-			editing = false;
-		}
-
-		@Override
-		public void init( final int x, final int y )
-		{
-			lock.readLock().lock();
-
-			// Get vertex we clicked inside.
-			if ( renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, source ) != null )
-			{
-				source.localize( overlay.from );
-				source.localize( overlay.to );
-				overlay.vertex = source;
-
-				// Move to next or previous time point and check that we can.
-				final int currentTimepoint = viewer.state().getCurrentTimepoint();
-				if ( forward )
-					viewer.nextTimePoint();
-				else
-					viewer.previousTimePoint();
-
-				final int newTimepoint = viewer.state().getCurrentTimepoint();
-				if ( currentTimepoint == newTimepoint )
-				{
-					// Refuse to work: we are in the same time-point. We do not
-					// want to create links inside the same time-point.
-					lock.readLock().unlock();
-					return;
-				}
-
-				overlay.paintGhostLink = true;
-				overlay.paintGhostVertex = true;
-				editing = true;
-			}
-			else
-				lock.readLock().unlock();
-		}
-
-		@Override
-		public void drag( final int x, final int y )
-		{
-			if ( editing )
-			{
-				if ( renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, target ) != null )
-				{
-					overlay.snap = true;
-					target.localize( overlay.to );
-					// Is there an existing link?
-					overlay.edgeToRemove =
-							( overlayGraph.getEdge( source, target, edgeRef ) != null )
-							|| ( overlayGraph.getEdge( target, source, edgeRef ) != null );
-				}
-				else
-				{
-					overlay.snap = false;
-					renderer.getGlobalPosition( x, y, overlay.to );
-				}
-			}
-		}
-
-		@Override
-		public void end( final int x, final int y )
-		{
-			if ( editing )
-			{
-				/*
-				 * TODO: The following is a recipe for disaster...
-				 *
-				 * What should be really done is have a special kind of Ref that
-				 * listens for the object its pointing to getting deleted, then
-				 * becomes invalid can be interrogated in this regard.
-				 *
-				 * Then in the write-locked part, if source became invalid,
-				 * abort.
-				 */
-				lock.readLock().unlock();
-				lock.writeLock().lock();
-				try
-				{
-					source.getInternalPoolIndex();
-					if ( renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, target ) != null )
-					{
-						target.localize( overlay.to );
-
-						/*
-						 * Careful with directed graphs. We always check and
-						 * create links forward in time.
-						 */
-						final V from = forward ? source : target;
-						final V to = forward ? target : source;
-						final E edge = overlayGraph.getEdge( from, to, edgeRef );
-						if ( null == edge )
-							overlayGraph.addEdge( from, to, edgeRef ).init();
-						else
-							overlayGraph.remove( edge );
-
-						overlayGraph.notifyGraphChanged();
-						undo.setUndoPoint();
-
-						if ( FOCUS_EDITED_SPOT )
-							focus.focusVertex( target );
-
-						if ( SELECT_ADDED_SPOT )
-						{
-							selection.pauseListeners();
-							selection.clearSelection();
-							selection.setSelected( target, true );
-							selection.resumeListeners();
-						}
-					}
-
-					overlay.paintGhostVertex = false;
-					overlay.paintGhostLink = false;
-					editing = false;
-				}
-				finally
-				{
-					lock.writeLock().unlock();
-				}
-			}
-		}
-	}
-
-	// TODO What to do if the user changes the time-point while dragging?
-	private class AddSpotAndLinkIt extends AbstractNamedBehaviour implements DragBehaviour
-	{
-		private final V source;
-
-		private final V target;
-
-		private final E edge;
-
-		private final double[] start;
-
-		private final double[] pos;
-
-		private boolean moving;
-
-		private final double[][] mat;
-
-		private final boolean forward;
-
-		public AddSpotAndLinkIt( final String name, final boolean forward )
-		{
-			super( name );
-			this.forward = forward;
-			source = overlayGraph.vertexRef();
-			target = overlayGraph.vertexRef();
-			edge = overlayGraph.edgeRef();
-			start = new double[ 3 ];
-			pos = new double[ 3 ];
-			moving = false;
-			mat = new double[ 3 ][ 3 ];
-		}
-
-		@Override
-		public void init( final int x, final int y )
-		{
-			lock.writeLock().lock();
-
-			if ( renderer.getVertexAt( x, y, POINT_SELECT_DISTANCE_TOLERANCE, source ) != null )
-			{
-				// Get vertex we clicked inside.
-				renderer.getGlobalPosition( x, y, start );
-				source.localize( pos );
-				LinAlgHelpers.subtract( pos, start, start );
-
-				// Set it as ghost vertex for the overlay.
-				overlay.vertex = source;
-
-				// Move to next or previous time point and check that we can.
-				final int currentTimepoint = viewer.state().getCurrentTimepoint();
-				if ( forward )
-					viewer.nextTimePoint();
-				else
-					viewer.previousTimePoint();
-
-				final int newTimepoint = viewer.state().getCurrentTimepoint();
-				if ( currentTimepoint == newTimepoint )
-				{
-					// Refuse to work: we are in the same time-point. We do not
-					// want to create links inside the same time-point.
-					lock.writeLock().unlock();
-					return;
-				}
-
-				// Create new vertex under click location.
-				source.getCovariance( mat );
-				final int timepoint = viewer.state().getCurrentTimepoint();
-				final V vertex = overlayGraph.addVertex( target ).init( timepoint, pos, mat );
-
-				// Link it to source vertex. Careful for oriented edge.
-				if ( forward )
-					overlayGraph.addEdge( source, target, edge ).init();
-				else
-					overlayGraph.addEdge( target, source, edge ).init();
-
-				// Set it as ghost link for the overlay.
-				System.arraycopy( pos, 0, overlay.from, 0, pos.length );
-				System.arraycopy( pos, 0, overlay.to, 0, pos.length );
-				overlay.paintGhostLink = true;
-				overlay.paintGhostVertex = true;
-				overlayGraph.notifyGraphChanged();
-				if ( FOCUS_EDITED_SPOT )
-					focus.focusVertex( vertex );
-
-				lock.readLock().lock();
-				lock.writeLock().unlock();
-
-				moving = true;
-			}
-			else
-				lock.writeLock().unlock();
-		}
-
-		@Override
-		public void drag( final int x, final int y )
-		{
-			if ( moving )
-			{
-				renderer.getGlobalPosition( x, y, pos );
-				LinAlgHelpers.add( pos, start, pos );
-				target.setPosition( pos );
-				System.arraycopy( pos, 0, overlay.to, 0, pos.length );
-			}
-		}
-
-		@Override
-		public void end( final int x, final int y )
-		{
-			if ( moving )
-			{
-				overlay.paintGhostVertex = false;
-				overlay.paintGhostLink = false;
-				overlayGraph.notifyGraphChanged();
-				undo.setUndoPoint();
-
-				if ( FOCUS_EDITED_SPOT )
-					focus.focusVertex( target );
-
-				if ( SELECT_ADDED_SPOT )
-				{
-					selection.pauseListeners();
-					selection.clearSelection();
-					selection.setSelected( target, true );
-					selection.resumeListeners();
-				}
-
-				moving = false;
-				lock.readLock().unlock();
-			}
 		}
 	}
 

--- a/src/main/resources/org/mastodon/ui/keymap/keyconf_fullbdv.yaml
+++ b/src/main/resources/org/mastodon/ui/keymap/keyconf_fullbdv.yaml
@@ -352,10 +352,6 @@
   contexts: [bdv]
   triggers: [SPACE]
 - !mapping
-  action: add spot
-  contexts: [bdv]
-  triggers: [not mapped]
-- !mapping
   action: increase spot radius
   contexts: [bdv]
   triggers: [E]
@@ -381,12 +377,8 @@
   triggers: [ctrl Q]
 - !mapping
   action: toggle link
-  contexts: [bdv, ts]
+  contexts: [ts]
   triggers: [L]
-- !mapping
-  action: toggle link backward
-  contexts: [bdv]
-  triggers: [shift L]
 - !mapping
   action: navigate to child
   contexts: [bdv, ts]

--- a/src/main/resources/org/mastodon/ui/keymap/keyconf_fullbdv.yaml
+++ b/src/main/resources/org/mastodon/ui/keymap/keyconf_fullbdv.yaml
@@ -354,7 +354,7 @@
 - !mapping
   action: add spot
   contexts: [bdv]
-  triggers: [A]
+  triggers: [not mapped]
 - !mapping
   action: increase spot radius
   contexts: [bdv]
@@ -379,14 +379,6 @@
   action: decrease spot radius a bit
   contexts: [bdv]
   triggers: [ctrl Q]
-- !mapping
-  action: add linked spot
-  contexts: [bdv]
-  triggers: [A]
-- !mapping
-  action: add linked spot backward
-  contexts: [bdv]
-  triggers: [C]
 - !mapping
   action: toggle link
   contexts: [bdv, ts]

--- a/src/main/resources/org/mastodon/ui/keymap/keyconf_mastodon.yaml
+++ b/src/main/resources/org/mastodon/ui/keymap/keyconf_mastodon.yaml
@@ -4,17 +4,9 @@
   contexts: [mastodon]
   triggers: [ctrl COMMA, meta COMMA]
 - !mapping
-  action: add linked spot
-  contexts: [bdv]
-  triggers: [A]
-- !mapping
-  action: add linked spot backward
-  contexts: [bdv]
-  triggers: [shift A]
-- !mapping
   action: add spot
   contexts: [bdv]
-  triggers: [A]
+  triggers: [not mapped]
 - !mapping
   action: align XY plane
   contexts: [bdv]

--- a/src/main/resources/org/mastodon/ui/keymap/keyconf_mastodon.yaml
+++ b/src/main/resources/org/mastodon/ui/keymap/keyconf_mastodon.yaml
@@ -4,10 +4,6 @@
   contexts: [mastodon]
   triggers: [ctrl COMMA, meta COMMA]
 - !mapping
-  action: add spot
-  contexts: [bdv]
-  triggers: [not mapped]
-- !mapping
   action: align XY plane
   contexts: [bdv]
   triggers: [shift Z]
@@ -301,12 +297,8 @@
   triggers: [I]
 - !mapping
   action: toggle link
-  contexts: [bdv, ts]
+  contexts: [ts]
   triggers: [W, L]
-- !mapping
-  action: toggle link backward
-  contexts: [bdv]
-  triggers: [shift L, shift W]
 - !mapping
   action: toggle settings panel
   contexts: [bdv, ts]


### PR DESCRIPTION
This PR implements adds new `Behaviour` for adding new spots and linking to new spots. It supersedes and implement the behaviour of several actions and behaviours at once, in a single key-stroke:
- the `add spot` action
- the `toggle link` behaviour
- the `add and link to spot` behaviour

A single key (`A` by default, and `C` to go backward in time) is used to implement all their features:

If there are no spots where the mouse is clicked, a new spot is created, which can be positionned by holding the key and moving the mouse. 

If the key is pressed from within a source spot, the viewer moves to the *next*  (or *previous* for its counterpart binding) time point and offers to create a new spot linked to this source. 
Hold and drag to position the new spot. A new spot will be created where the mouse is released, and linked to the source spot. 

If a target spot is found near  the mouse location when the key is released, it is linked to the source spot. If a link already exists between the two, it is removed.
