### PR TITLE
Better track coloring

### DIFF
--- a/src/main/java/org/mastodon/ui/coloring/GlasbeyLut.java
+++ b/src/main/java/org/mastodon/ui/coloring/GlasbeyLut.java
@@ -36,7 +36,7 @@ import java.awt.Color;
 public class GlasbeyLut
 {
 
-	private static final Color[] colors = new Color[] {
+	public static final Color[] colors = new Color[] {
 			new Color( 255, 255, 255 ),
 			new Color( 20, 20, 255 ),
 			new Color( 255, 20, 20 ),
@@ -295,7 +295,7 @@ public class GlasbeyLut
 			new Color( 189, 117, 101 )
 	};
 
-	private static final int[] intColors;
+	public static final int[] intColors;
 	static
 	{
 		intColors = new int[ colors.length ];

--- a/src/main/java/org/mastodon/ui/coloring/TrackGraphColorGenerator.java
+++ b/src/main/java/org/mastodon/ui/coloring/TrackGraphColorGenerator.java
@@ -37,7 +37,6 @@ import org.mastodon.graph.ListenableReadOnlyGraph;
 import org.mastodon.graph.Vertex;
 import org.mastodon.graph.algorithm.traversal.InverseDepthFirstIterator;
 import org.mastodon.model.HasLabel;
-import org.mastodon.views.trackscheme.util.AlphanumCompare;
 
 public class TrackGraphColorGenerator< V extends Vertex< E > & HasLabel, E extends Edge< V > >
 		implements GraphColorGenerator< V, E >
@@ -45,7 +44,7 @@ public class TrackGraphColorGenerator< V extends Vertex< E > & HasLabel, E exten
 
 	private final RefIntMap< V > cache;
 
-	private final GlasbeyLut lut;
+	private final int[] lut;
 
 	private final InverseDepthFirstIterator< V, E > iterator;
 
@@ -62,7 +61,7 @@ public class TrackGraphColorGenerator< V extends Vertex< E > & HasLabel, E exten
 		this.rootsProvider = new RootProvider<>( graph );
 		this.graph = graph;
 		this.cache = RefMaps.createRefIntMap( graph.vertices(), 0 );
-		this.lut = GlasbeyLut.create();
+		this.lut = GlasbeyLut.intColors;
 		this.iterator = new InverseDepthFirstIterator<>( graph );
 		this.toUpdate = RefCollections.createRefList( graph.vertices() );
 
@@ -137,12 +136,8 @@ public class TrackGraphColorGenerator< V extends Vertex< E > & HasLabel, E exten
 		if ( rootsUpToDate )
 			return;
 
-		final RefList< V > sortedRoots = RefCollections.createRefList( graph.vertices() );
-		sortedRoots.addAll( rootsProvider.get() );
-		sortedRoots.sort( ( v1, v2 ) -> AlphanumCompare.compare( v1.getLabel(), v2.getLabel() ) );
 		cache.clear();
-		lut.reset();
-		sortedRoots.forEach( r -> cache.put( r, lut.next() ) );
+		rootsProvider.get().forEach( r -> cache.put( r, lut[ Math.abs( r.getLabel().hashCode() ) % lut.length ] ) );
 		rootsUpToDate = true;
 	}
 


### PR DESCRIPTION
Prior to this PR, the track color was determined by the position of a track in the sorted track array, based on the root labels.

In practice, for large number of tracks, this was not so great when editing tracks a lot. Indeed, the slightest track addition of link removal could completely change the order, hence the track coloring.

Here we simply use the hash of the root label of a track to determine its color, making it independent of the other ones. The color of a track now only depends on the label of its root.