### PR TITLE
Grapher zoom out bugfix

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -109,7 +109,7 @@ public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSp
 				new FeatureSpecPair( BranchDisplacementDurationFeature.SPEC, displacementSpec, false, false );
 		final FeatureSpecPair featureSpecY =
 				new FeatureSpecPair( BranchDisplacementDurationFeature.SPEC, durationSpec, false, false );
-		return new FeatureGraphConfig( featureSpecX, featureSpecY, GraphDataItemsSource.TRACK_OF_SELECTION, true );
+		return new FeatureGraphConfig( featureSpecX, featureSpecY, GraphDataItemsSource.CONTEXT, false );
 	}
 
 	@SuppressWarnings( "unchecked" )

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -116,7 +116,7 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 				SpotFrameFeature.SPEC.getProjectionSpecs().iterator().next(), false, false );
 		final FeatureSpecPair spvy = new FeatureSpecPair( SpotQuickMeanIntensityFeature.SPEC,
 				SpotQuickMeanIntensityFeature.PROJECTION_SPEC, 0, false, false );
-		return new FeatureGraphConfig( spvx, spvy, FeatureGraphConfig.GraphDataItemsSource.TRACK_OF_SELECTION, true );
+		return new FeatureGraphConfig( spvx, spvy, FeatureGraphConfig.GraphDataItemsSource.CONTEXT, false );
 	}
 
 	@SuppressWarnings( "unchecked" )

--- a/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/views/grapher/display/InertialScreenTransformEventHandler.java
@@ -548,7 +548,7 @@ public class InertialScreenTransformEventHandler
 			{
 				if ( zoomIn )
 				{
-					if ( !hasMinSizeY( transform ) || true )
+					if ( !hasMinSizeY( transform ) )
 						transform.zoomY( dScale, y );
 				}
 				else


### PR DESCRIPTION
This PR contains a fix for this bug description (cf. #212):

> I think there is indeed some bug. After opening a new grapher window, selecting "Spot - X", "Spot - Y", "From context: full graph" and clicking "Plot", the plot window is updated. But it zooms to a location without data points. Giving the impression that there is no data available. The way to zoom out is to first click on the plot and afterwards use Shift+Crtl+Scroll or Z + Z to zoom out. I myself couldn't find how to zoom out, despite knowing the short cuts. So I too got the impression, that the grapher window is buggy. After I successfully zoomed out once, everything worked really nicely. So there seems to be a problem only with the initial state after opening a new grapher window.

* The reason for the bug was: there was fixed timeout before the zoom out to max extent would start after the data had been painted with the current axis settings. In case of changing the axes, it could however (with large datasets) happen that graphchanged() + layout() was not completey finished, before the zoom out was started. In these cases the zoom out would still zoom out to the extent of the previous axes, which leaded to unexpected behaviour. This commit introduces a process that lets the zooming out wait, until the graph was layouted during the paint process once (and by this the max extent was updated).

This PR furthermore introduces a change to the defaults of the Grapher Windows:

* Initialize the grapher windows with full graph context and non-connected mode

  * Reasoning: It is difficult to judge, what is the most often used combination of settings and thus, which should be the default settings for the grapher. For the case of analysing single tracks the item source "track of selection" makes most sense. Also in this case drawing the edges in the grapher between these points makes sense. In other cases, such when inspecting large selections or even the dataset as a whole, showing the edges does not really help and leads to a very confusing plot. For the case of inspecting the full dataset without any selection the setting "track of selection", leads to an empty plot, when the grapher is first show. Thus, with this commit, the defaults are changed to full graph context and non-connected.