### PR TITLE
Change recent projects panel layout

### DIFF
--- a/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
@@ -80,7 +80,7 @@ public class RecentProjectsPanel extends JPanel
 		scrollPane.setHorizontalScrollBarPolicy( ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER );
 		add( scrollPane, "span, wrap" );
 
-		if ( recentProjects != null && !recentProjects.isempty() )
+		if ( !recentProjects.isempty() )
 		{
 			final JLabel lblTitleHint = new JLabel( "Double-click to open the containing folder." );
 			lblTitleHint.setFont( lblTitleHint.getFont().deriveFont( lblTitleHint.getFont().getStyle() | Font.ITALIC ) );

--- a/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
+++ b/src/main/java/org/mastodon/mamut/launcher/RecentProjectsPanel.java
@@ -96,10 +96,7 @@ public class RecentProjectsPanel extends JPanel
 				listPanel.add( ta, "" );
 
 				final JButton btnOpen = new JButton( MastodonIcons.LOAD_ICON_SMALL );
-				btnOpen.addActionListener( l -> {
-					projectOpener.accept( ta.getText() );
-					// Recent projects will be updated in the launcher method.
-				} );
+				btnOpen.addActionListener( l -> projectOpener.accept( ta.getText() ) ); // Recent projects will be updated in the launcher method.
 				add( btnOpen );
 
 				final JButton btnClear = new JButton( MastodonIcons.REMOVE_ICON );

--- a/src/main/java/org/mastodon/ui/util/RecentProjects.java
+++ b/src/main/java/org/mastodon/ui/util/RecentProjects.java
@@ -50,7 +50,7 @@ public class RecentProjects implements Iterable< String >
 	private static final String RECENT_PROJECTS_FILE =
 			System.getProperty( "user.home" ) + "/.mastodon/recentprojects.yaml";
 
-	private static final int MAX_N_RECENT_PROJECTS = 10;
+	private static final int MAX_N_RECENT_PROJECTS = 20;
 
 	private final List< String > recent;
 


### PR DESCRIPTION
This PR fixes a layout bug that could occur, if the max number of recent projects (before this PR 10) was reached.

The Recent Projects Panel then looked like this (at least under Windows and Ubuntu) and did not show the option anymore to "open another project". This was only possible after at least one project was removed from the recent projects list, which was a bit inconvenient for users.

![grafik](https://github.com/user-attachments/assets/3cf827e1-2055-48a6-a30e-88eea327fefb)

The Recent Projects Panel now uses a different layout, allowing to show a scrollbar, if more recent projects are in the list that can be shown. This change also allows it to increase the number of recent projects to be shown to 20.

![grafik](https://github.com/user-attachments/assets/b64aef3a-efe2-4ab2-a7d2-52df0f0ccecc)

Resolves #350 