### PR TITLE
Support more than 23 million spots in Mastodon

### DIFF
--- a/src/main/java/org/mastodon/mamut/model/SpotPool.java
+++ b/src/main/java/org/mastodon/mamut/model/SpotPool.java
@@ -31,7 +31,7 @@ package org.mastodon.mamut.model;
 import org.mastodon.model.AbstractSpotPool;
 import org.mastodon.pool.ByteMappedElement;
 import org.mastodon.pool.ByteMappedElementArray;
-import org.mastodon.pool.SingleArrayMemPool;
+import org.mastodon.pool.MultiArrayMemPool;
 import org.mastodon.pool.attributes.DoubleArrayAttribute;
 import org.mastodon.pool.attributes.DoubleAttribute;
 import org.mastodon.properties.ObjPropertyMap;
@@ -62,7 +62,7 @@ public class SpotPool extends AbstractSpotPool< Spot, Link, ByteMappedElement, M
 
 	SpotPool( final int initialCapacity )
 	{
-		super( initialCapacity, layout, Spot.class, SingleArrayMemPool.factory( ByteMappedElementArray.factory ) );
+		super( initialCapacity, layout, Spot.class, MultiArrayMemPool.factory( ByteMappedElementArray.factory ) );
 		label = new ObjPropertyMap<>( this );
 		registerPropertyMap( label );
 	}


### PR DESCRIPTION
Using the MultiArrayMemPool rather than SingleArrayMemPool eliminates the upper bound for the number of Spots in Mastodon. Without this change Mastodon is limited to approx. 23.3 million spots. Reason for that is that the SingleArrayMemPool limits the available space for spots to 2 GB. MultiArrayMemPool removes this limitation.
