### PR TITLE
Maximum number of tags test

### DIFF
--- a/src/test/java/org/mastodon/util/MaxTagSetsDemo.java
+++ b/src/test/java/org/mastodon/util/MaxTagSetsDemo.java
@@ -1,0 +1,49 @@
+package org.mastodon.util;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.mastodon.mamut.feature.branch.exampleGraph.ExampleGraph1;
+import org.mastodon.model.tag.TagSetStructure;
+
+/**
+ * This class is a demo to show that the maximum number of tags that a Mastodon Model can have is 31,619.
+ * Try to increase the number of tags to 31,620 and the program will create a memory related error.
+ */
+public class MaxTagSetsDemo
+{
+	private static final Random random = new Random( 42 );
+
+	private static final int MAX_TAG_SETS = 31_619;
+
+	public static void main( String[] args )
+	{
+		ExampleGraph1 exampleGraph1 = new ExampleGraph1();
+
+		Collection< Pair< String, Integer > > labelColorPairs = new ArrayList<>();
+		for ( int i = 0; i < MAX_TAG_SETS; i++ )
+			labelColorPairs.add( Pair.of( "tag" + i, getRandomColor().getRGB() ) );
+
+		TagSetUtils.addNewTagSetToModel( exampleGraph1.getModel(), "testTagsSet0", labelColorPairs );
+		TagSetStructure.TagSet tagSet = exampleGraph1.getModel().getTagSetModel().getTagSetStructure().getTagSets().get( 0 );
+
+		System.out.println( "Checking tag set..." );
+		System.out.println( "Tag set name: " + tagSet.getName() );
+		System.out.println( "Number of tags: " + tagSet.getTags().size() );
+		System.out.println( "Done." );
+	}
+
+	private static Color getRandomColor()
+	{
+		// Generate random RGB values
+		int red = random.nextInt( 256 );
+		int green = random.nextInt( 256 );
+		int blue = random.nextInt( 256 );
+
+		// Create the color using the RGB values
+		return new Color( red, green, blue );
+	}
+}

--- a/src/test/java/org/mastodon/util/TagSetUtilsTest.java
+++ b/src/test/java/org/mastodon/util/TagSetUtilsTest.java
@@ -50,28 +50,28 @@ import static org.junit.Assert.assertTrue;
 public class TagSetUtilsTest
 {
 
-	private final static String tagSetName = "testTagSet";
+	private static final String TAG_SET_NAME = "testTagSet";
 
-	private final static String tagLabel0 = "tag0";
+	private static final String TAG_LABEL_0 = "tag0";
 
-	private final static String tagLabel1 = "tag1";
+	private static final String TAG_LABEL_1 = "tag1";
 
-	private final static String tagLabel2 = "tag2";
+	private static final String TAG_LABEL_2 = "tag2";
 
-	private final static Color tagColor0 = Color.red;
+	private static final Color tagColor0 = Color.red;
 
-	private final static Color tagColor1 = Color.green;
+	private static final Color tagColor1 = Color.green;
 
-	private final static Color tagColor2 = Color.blue;
+	private static final Color tagColor2 = Color.blue;
 
-	private final static Collection< Pair< String, Integer > > tagsAndColors = initTagsAndColors();
+	private static final Collection< Pair< String, Integer > > tagsAndColors = initTagsAndColors();
 
 	private static Collection< Pair< String, Integer > > initTagsAndColors()
 	{
 		Collection< Pair< String, Integer > > tagsAndColors = new ArrayList<>();
-		tagsAndColors.add( Pair.of( tagLabel0, tagColor0.getRGB() ) );
-		tagsAndColors.add( Pair.of( tagLabel1, tagColor1.getRGB() ) );
-		tagsAndColors.add( Pair.of( tagLabel2, tagColor2.getRGB() ) );
+		tagsAndColors.add( Pair.of( TAG_LABEL_0, tagColor0.getRGB() ) );
+		tagsAndColors.add( Pair.of( TAG_LABEL_1, tagColor1.getRGB() ) );
+		tagsAndColors.add( Pair.of( TAG_LABEL_2, tagColor2.getRGB() ) );
 		return tagsAndColors;
 	}
 
@@ -80,15 +80,15 @@ public class TagSetUtilsTest
 	{
 		ExampleGraph1 exampleGraph1 = new ExampleGraph1();
 
-		TagSetUtils.addNewTagSetToModel( exampleGraph1.getModel(), tagSetName, tagsAndColors );
+		TagSetUtils.addNewTagSetToModel( exampleGraph1.getModel(), TAG_SET_NAME, tagsAndColors );
 
 		TagSetStructure.TagSet tagSet = exampleGraph1.getModel().getTagSetModel().getTagSetStructure().getTagSets().get( 0 );
 
-		assertEquals( tagSetName, tagSet.getName() );
+		assertEquals( TAG_SET_NAME, tagSet.getName() );
 		assertEquals( tagsAndColors.size(), tagSet.getTags().size() );
-		assertEquals( tagLabel0, tagSet.getTags().get( 0 ).label() );
-		assertEquals( tagLabel1, tagSet.getTags().get( 1 ).label() );
-		assertEquals( tagLabel2, tagSet.getTags().get( 2 ).label() );
+		assertEquals( TAG_LABEL_0, tagSet.getTags().get( 0 ).label() );
+		assertEquals( TAG_LABEL_1, tagSet.getTags().get( 1 ).label() );
+		assertEquals( TAG_LABEL_2, tagSet.getTags().get( 2 ).label() );
 		assertEquals( tagColor0.getRGB(), tagSet.getTags().get( 0 ).color() );
 		assertEquals( tagColor1.getRGB(), tagSet.getTags().get( 1 ).color() );
 		assertEquals( tagColor2.getRGB(), tagSet.getTags().get( 2 ).color() );
@@ -100,7 +100,7 @@ public class TagSetUtilsTest
 		ExampleGraph2 exampleGraph2 = new ExampleGraph2();
 		Model model = exampleGraph2.getModel();
 
-		TagSetStructure.TagSet tagSet = TagSetUtils.addNewTagSetToModel( exampleGraph2.getModel(), tagSetName, tagsAndColors );
+		TagSetStructure.TagSet tagSet = TagSetUtils.addNewTagSetToModel( exampleGraph2.getModel(), TAG_SET_NAME, tagsAndColors );
 
 		TagSetStructure.Tag tag0 = tagSet.getTags().get( 0 );
 		TagSetUtils.tagSpotAndOutgoingEdges( exampleGraph2.getModel(), tagSet, tag0, exampleGraph2.spot0 );


### PR DESCRIPTION
This PR adds a demo application that can be used to find out the maximum number of tags supported by a mastodon model.

It seems to be 31619.

Running the application with 31620 produces a memory related error.