### PR TITLE
Let the DefaultObjTagMap return null as tag, if the given object was …

### DIFF
--- a/src/main/java/org/mastodon/model/tag/DefaultObjTagMap.java
+++ b/src/main/java/org/mastodon/model/tag/DefaultObjTagMap.java
@@ -129,6 +129,8 @@ public class DefaultObjTagMap< O, T > implements ObjTagMap< O, T >
 	@Override
 	public T get( final O object )
 	{
+		if ( object == null )
+			return null;
 		final LabelSet< O, Integer > ref = idLabelSets.createRef();
 		try
 		{


### PR DESCRIPTION
This PR fixes a bug when repainting the branch graph.

It occurred in a very specific situation, when:

1. Spots are deleted in trackscheme, such as that complete tracks disappear
2. The branch graph is not immediately synced in such cases (since otherwise, it would need to be synced too often)
3. This leads to a weird state in the branch graph view
4. The clustering command contains perform a sync on the branch graph, before it is performed
5. The sync on the branch graph leads to a repaint of the branch graph view
6. Since the branch graph view still contains the non-existing branches, it is looking for tags for objects that do actually not exist anymore, which resulted in a nullpointerexception

Visualisation:
![GIF 05 12 2024 11-01-57](https://github.com/user-attachments/assets/91484752-4ac5-4b93-b770-fb5128cf2304)

Solution:
Comparably easy: let the DefaultObjTagMap return `null `as tag, if the object given to it was `null`
