### PR TITLE
Add project name to MainWindow

### DIFF
--- a/src/main/java/org/mastodon/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/mamut/MainWindow.java
@@ -106,11 +106,19 @@ public class MainWindow extends JFrame
 		// component.
 		ProjectActions.installAppActions( appModel.getProjectActions(), appModel, this );
 
-		// Views:
+		// Main Panel
 		final JPanel buttonsPanel = new JPanel();
 		buttonsPanel.setLayout( new MigLayout() );
 		final ActionMap projectActionMap = appModel.getProjectActions().getActionMap();
 
+		// Project:
+		final JLabel projectLabel = new JLabel( "Project:" );
+		projectLabel.setFont( buttonsPanel.getFont().deriveFont( Font.BOLD ) );
+		buttonsPanel.add( projectLabel );
+		final JLabel projectNameLabel = new JLabel( appModel.getProjectName() );
+		buttonsPanel.add( projectNameLabel, "wrap" );
+
+		// Views:
 		final JLabel viewsLabel = new JLabel( "Views:" );
 		viewsLabel.setFont( buttonsPanel.getFont().deriveFont( Font.BOLD ) );
 		buttonsPanel.add( viewsLabel, "span, wrap" );


### PR DESCRIPTION
The current MainWindow is too small to show the project name in its title (at least so in Windows OS)

cf.:

![grafik](https://github.com/user-attachments/assets/7f1489de-955b-4882-b988-49a18c6d5247)

This makes it difficult in settings where multiple Mastodon projects are open simultaneously to identify to which open project the main window belongs.

There are 3 alternatives how to solve this:

1. Make the MainWindow wider
2. Make the MainWindow resizable
3. Show the project name not only in the title, but also inside the MainWindow

This PR implements option 3 (not claiming that it is the best out of these options).

After PR: 
![grafik](https://github.com/user-attachments/assets/69c277f7-c477-496b-b844-769be25cef19)

