### PR TITLE
Highlight preferably spot at current timepoint

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/MamutBranchView.java
+++ b/src/main/java/org/mastodon/mamut/views/MamutBranchView.java
@@ -157,12 +157,6 @@ public class MamutBranchView<
 		final ModelBranchGraph branchGraph = appModel.getModel().getBranchGraph();
 		final ModelGraph graph = appModel.getModel().getGraph();
 
-		// Highlight.
-		final HighlightModel< Spot, Link > graphHighlightModel = appModel.getHighlightModel();
-		final HighlightModel< BranchSpot, BranchLink > branchHighlightModel =
-				new BranchGraphHighlightAdapter<>( branchGraph, graph, graph.getGraphIdBimap(), graphHighlightModel );
-		this.highlightModel = new HighlightModelAdapter<>( branchHighlightModel, vertexMap, edgeMap );
-
 		// Focus
 		final FocusModel< Spot > graphFocusModel = appModel.getFocusModel();
 		final FocusModel< BranchSpot > branchFocusfocusModel =
@@ -184,6 +178,12 @@ public class MamutBranchView<
 
 		// Time-point.
 		this.timepointModel = new TimepointModelAdapter( groupHandle.getModel( appModel.TIMEPOINT ) );
+
+		// Highlight.
+		final HighlightModel< Spot, Link > graphHighlightModel = appModel.getHighlightModel();
+		final HighlightModel< BranchSpot, BranchLink > branchHighlightModel =
+				new BranchGraphHighlightAdapter<>( branchGraph, graph, graph.getGraphIdBimap(), graphHighlightModel, timepointModel );
+		this.highlightModel = new HighlightModelAdapter<>( branchHighlightModel, vertexMap, edgeMap );
 
 		// Tag-set.
 		this.tagSetModel = branchTagSetModel( appModel );

--- a/src/main/java/org/mastodon/mamut/views/table/MamutViewTable.java
+++ b/src/main/java/org/mastodon/mamut/views/table/MamutViewTable.java
@@ -67,6 +67,7 @@ import org.mastodon.model.FocusModel;
 import org.mastodon.model.HighlightModel;
 import org.mastodon.model.NavigationHandler;
 import org.mastodon.model.SelectionModel;
+import org.mastodon.model.TimepointModel;
 import org.mastodon.model.branch.BranchGraphEdgeBimap;
 import org.mastodon.model.branch.BranchGraphFocusAdapter;
 import org.mastodon.model.branch.BranchGraphHighlightAdapter;
@@ -162,7 +163,7 @@ public class MamutViewTable extends MamutView< ViewGraph< Spot, Link, Spot, Link
 					.featureModel( featureModel )
 					.tagSetModel( branchTagSetModel( projectModel ) )
 					.selectionModel( branchSelectionModel( projectModel ) )
-					.highlightModel( branchHighlightModel( projectModel ) )
+				.highlightModel( branchHighlightModel( projectModel, this.timepointModel ) )
 					.coloring( branchColoringAdapter )
 					.focusModel( branchFocusfocusModel( projectModel ) )
 					.navigationHandler( branchGraphNavigation( projectModel, navigationHandler ) )
@@ -337,13 +338,14 @@ public class MamutViewTable extends MamutView< ViewGraph< Spot, Link, Spot, Link
 		return branchGraphNavigation;
 	}
 
-	private static HighlightModel< BranchSpot, BranchLink > branchHighlightModel( final ProjectModel appModel )
+	private static HighlightModel< BranchSpot, BranchLink > branchHighlightModel( final ProjectModel appModel,
+			final TimepointModel timepointModel )
 	{
 		final ModelGraph graph = appModel.getModel().getGraph();
 		final ModelBranchGraph branchGraph = appModel.getModel().getBranchGraph();
 		final HighlightModel< Spot, Link > graphHighlightModel = appModel.getHighlightModel();
 		final HighlightModel< BranchSpot, BranchLink > branchHighlightModel =
-				new BranchGraphHighlightAdapter<>( branchGraph, graph, graph.getGraphIdBimap(), graphHighlightModel );
+				new BranchGraphHighlightAdapter<>( branchGraph, graph, graph.getGraphIdBimap(), graphHighlightModel, timepointModel );
 		return branchHighlightModel;
 	}
 


### PR DESCRIPTION
This PR suggests the following change:

In case the highlighting is triggered from a branch view, try to highlight the spot in the branch at the current timepoint instead of the always the last spot in graph

* In coupled views this allows to show the highlighted spot in the BDV

Highlighting before this PR:
![current highlighting](https://github.com/user-attachments/assets/7a3c7525-8b82-483e-adbc-1d97eb72ce4b)



Highlight after this PR:
![adapted highlighting](https://github.com/user-attachments/assets/19fa2865-a1a4-4e84-ae4e-4f006044047d)

