### PR TITLE
Remove context chooser from MamutBranchViewGrapher

### DIFF
--- a/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/GrapherInitializer.java
@@ -129,7 +129,7 @@ public class GrapherInitializer< V extends Vertex< E > & HasTimepoint & HasLabel
 	GrapherInitializer( final DataGraph< V, E > graph, final ProjectModel appModel,
 			final SelectionModel< DataVertex, DataEdge > selectionModel, final NavigationHandler< DataVertex, DataEdge > navigationHandler,
 			final FocusModel< DataVertex > focusModel, final HighlightModel< DataVertex, DataEdge > highlightModel,
-			final GroupHandle groupHandle
+			final GroupHandle groupHandle, final DataContextListener< V > contextListener
 	)
 	{
 		this.viewGraph = graph;
@@ -143,8 +143,7 @@ public class GrapherInitializer< V extends Vertex< E > & HasTimepoint & HasLabel
 		layout = new DataGraphLayout<>( viewGraph, selectionModel );
 
 		// ContextChooser
-		final DataContextListener< V > contextListener = new DataContextListener<>( viewGraph );
-		contextChooser = new ContextChooser<>( contextListener );
+		this.contextChooser = contextListener == null ? null : new ContextChooser<>( contextListener );
 
 		// Style
 		final DataDisplayStyleManager dataDisplayStyleManager = appModel.getWindowManager().getManager( DataDisplayStyleManager.class );
@@ -178,7 +177,8 @@ public class GrapherInitializer< V extends Vertex< E > & HasTimepoint & HasLabel
 
 		// Panel
 		this.panel = frame.getDataDisplayPanel();
-		contextListener.setContextListener( panel );
+		if ( contextListener != null )
+			contextListener.setContextListener( panel );
 
 		// Style listener
 		styleUpdateListener = panel::repaint;

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutBranchViewGrapher.java
@@ -43,8 +43,6 @@ import org.mastodon.ui.coloring.GraphColorGeneratorAdapter;
 import org.mastodon.ui.coloring.HasColorBarOverlay;
 import org.mastodon.ui.coloring.HasColoringModel;
 import org.mastodon.ui.keymap.KeyConfigContexts;
-import org.mastodon.views.context.ContextChooser;
-import org.mastodon.views.context.HasContextChooser;
 import org.mastodon.views.grapher.datagraph.DataEdge;
 import org.mastodon.views.grapher.datagraph.DataGraph;
 import org.mastodon.views.grapher.datagraph.DataVertex;
@@ -59,7 +57,7 @@ import java.util.Iterator;
 import java.util.function.BiConsumer;
 
 public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSpot, BranchLink >, DataVertex, DataEdge >
-		implements HasContextChooser< BranchSpot >, HasColoringModel, HasColorBarOverlay, DataDisplayFrameSupplier< BranchSpot, BranchLink >
+		implements HasColoringModel, HasColorBarOverlay, DataDisplayFrameSupplier< BranchSpot, BranchLink >
 {
 
 	private final GrapherInitializer< BranchSpot, BranchLink > grapherInitializer;
@@ -74,7 +72,7 @@ public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSp
 				new String[] { KeyConfigContexts.GRAPHER } );
 
 		grapherInitializer = new GrapherInitializer<>( viewGraph, appModel, selectionModel, navigationHandler, focusModel, highlightModel,
-				getGroupHandle() );
+				getGroupHandle(), null );
 		grapherInitializer.getFrame().setTitle( "Grapher Branch" );
 		InertialScreenTransformEventHandler handler = grapherInitializer.getFrame().getDataDisplayPanel().getTransformEventHandler();
 		handler.setMinScaleX( 0.1d );
@@ -117,12 +115,6 @@ public class MamutBranchViewGrapher extends MamutBranchView< DataGraph< BranchSp
 	public DataDisplayFrame< BranchSpot, BranchLink > getFrame()
 	{
 		return ( DataDisplayFrame< BranchSpot, BranchLink > ) super.getFrame();
-	}
-
-	@Override
-	public ContextChooser< BranchSpot > getContextChooser()
-	{
-		return grapherInitializer.getContextChooser();
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
+++ b/src/main/java/org/mastodon/mamut/views/grapher/MamutViewGrapher.java
@@ -47,6 +47,7 @@ import org.mastodon.ui.commandfinder.CommandFinder;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.mastodon.views.context.ContextChooser;
 import org.mastodon.views.context.HasContextChooser;
+import org.mastodon.views.grapher.datagraph.DataContextListener;
 import org.mastodon.views.grapher.datagraph.DataEdge;
 import org.mastodon.views.grapher.datagraph.DataGraph;
 import org.mastodon.views.grapher.datagraph.DataVertex;
@@ -74,8 +75,9 @@ public class MamutViewGrapher extends MamutView< DataGraph< Spot, Link >, DataVe
 				new String[] { KeyConfigContexts.GRAPHER } );
 
 
+		final DataContextListener< Spot > contextListener = new DataContextListener<>( viewGraph );
 		grapherInitializer = new GrapherInitializer<>( viewGraph, appModel, selectionModel, navigationHandler, focusModel, highlightModel,
-				getGroupHandle() );
+				getGroupHandle(), contextListener );
 		grapherInitializer.setOnClose( this );
 		grapherInitializer.initFeatureConfig( getFeatureGraphConfig() );
 		setFrame( grapherInitializer.getFrame() ); // this creates viewActions and viewBehaviours thus must be called before installActions

--- a/src/main/java/org/mastodon/views/grapher/display/GrapherSidePanel.java
+++ b/src/main/java/org/mastodon/views/grapher/display/GrapherSidePanel.java
@@ -201,23 +201,36 @@ public class GrapherSidePanel extends JPanel
 		rdbtnKeepCurrent.setFont( rdbtnKeepCurrent.getFont().deriveFont( rdbtnKeepCurrent.getFont().getSize() - 2f ) );
 		btngrp.add( rdbtnKeepCurrent );
 
-		rdbtnContext = new JRadioButton( "From context:" );
+		rdbtnContext = new JRadioButton();
+		rdbtnContext.setText( "Full graph" );
+		btngrp.add( rdbtnContext );
+
 		final GridBagConstraints gbcRdbtnContext = new GridBagConstraints();
 		gbcRdbtnContext.anchor = GridBagConstraints.WEST;
 		gbcRdbtnContext.insets = new Insets( 0, 5, 0, 5 );
 		gbcRdbtnContext.gridx = 0;
 		gbcRdbtnContext.gridy = 9;
-		add( rdbtnContext, gbcRdbtnContext );
 		rdbtnContext.setFont( rdbtnContext.getFont().deriveFont( rdbtnContext.getFont().getSize() - 2f ) );
-		btngrp.add( rdbtnContext );
+		add( rdbtnContext, gbcRdbtnContext );
 
-		final ContextChooserPanel< ? > chooserPanel = new ContextChooserPanel<>( contextChooser );
-		final GridBagConstraints gbcChooserPanel = new GridBagConstraints();
-		gbcChooserPanel.fill = GridBagConstraints.BOTH;
-		gbcChooserPanel.insets = new Insets( 0, 5, 5, 5 );
-		gbcChooserPanel.gridx = 0;
-		gbcChooserPanel.gridy = 10;
-		add( chooserPanel, gbcChooserPanel );
+		if ( contextChooser != null )
+		{
+			rdbtnContext.setText( "From context:" );
+			final ContextChooserPanel< ? > chooserPanel = new ContextChooserPanel<>( contextChooser );
+			final GridBagConstraints gbcChooserPanel = new GridBagConstraints();
+			gbcChooserPanel.fill = GridBagConstraints.BOTH;
+			gbcChooserPanel.insets = new Insets( 0, 5, 5, 5 );
+			gbcChooserPanel.gridx = 0;
+			gbcChooserPanel.gridy = 10;
+			add( chooserPanel, gbcChooserPanel );
+			for ( final Component c : chooserPanel.getComponents() )
+				c.setFont( c.getFont().deriveFont( c.getFont().getSize2D() - 2f ) );
+			// show context box only if the right button is selected.
+			final EverythingDisablerAndReenabler contextEnabler =
+					new EverythingDisablerAndReenabler( chooserPanel, new Class[] { Label.class } );
+			contextEnabler.setEnabled( rdbtnContext.isSelected() );
+			rdbtnContext.addChangeListener( e -> contextEnabler.setEnabled( rdbtnContext.isSelected() ) );
+		}
 
 		chkboxConnect = new JCheckBox( "Show edges" );
 		final GridBagConstraints gbcChkboxConnect = new GridBagConstraints();
@@ -228,9 +241,6 @@ public class GrapherSidePanel extends JPanel
 		add( chkboxConnect, gbcChkboxConnect );
 		chkboxConnect.setSelected( true );
 		chkboxConnect.setFont( chkboxConnect.getFont().deriveFont( chkboxConnect.getFont().getSize() - 2f ) );
-
-		for ( final Component c : chooserPanel.getComponents() )
-			c.setFont( c.getFont().deriveFont( c.getFont().getSize2D() - 2f ) );
 
 		btnPlot = new JButton( "Plot" );
 		final GridBagConstraints gbcBtnPlot = new GridBagConstraints();
@@ -247,11 +257,6 @@ public class GrapherSidePanel extends JPanel
 			if ( !rdbtnContext.isSelected() )
 				rdbtnKeepCurrent.setSelected( true );
 		} );
-		// show context box only if the right button is selected.
-		final EverythingDisablerAndReenabler contextEnabler =
-				new EverythingDisablerAndReenabler( chooserPanel, new Class[] { Label.class } );
-		contextEnabler.setEnabled( rdbtnContext.isSelected() );
-		rdbtnContext.addChangeListener( e -> contextEnabler.setEnabled( rdbtnContext.isSelected() ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR removes the context chooser from the MamutBranchViewGrapher.

With the current implementation, it produces errors, when contexts other the "full graph" are chose.

Similarly to the MamutBranchViewTrackScheme, the context chooser can currently not really be used in MamutBranchView(s), since the context chooser / the context provider can provide spots, but in the branch view branch spots are required and translation between them is with the current architecture not possible