### PR TITLE
Change the default visibility of the color bar to true

### DIFF
--- a/src/main/java/org/mastodon/ui/coloring/ColorBarOverlay.java
+++ b/src/main/java/org/mastodon/ui/coloring/ColorBarOverlay.java
@@ -55,7 +55,7 @@ public class ColorBarOverlay implements OverlayRenderer
 
 	public static final Position DEFAULT_POSITION = Position.BOTTOM_RIGHT;
 
-	public static final boolean DEFAULT_VISIBLE = false;
+	public static final boolean DEFAULT_VISIBLE = true;
 
 	private static final int DEFAULT_WIDTH = 70;
 


### PR DESCRIPTION
By chance I recently found out that a feature that I was always missing does actually exist: a legend for the Grapher views

![grafik](https://github.com/user-attachments/assets/be9b0e4c-80a0-49c2-90d1-2ee555f71125)

Since, I think this feature is so super important and perhaps I am not the only one for whom it is too well hidden how to activate it (it is actually not hidden at all, but Mastodon has grown so powerful with so many options that for newbees, it might be hard to find the relevant stuff), I would like to suggest to change the default such that it is activated, which is done in this PR.