### PR TITLE
Let help button open the online docs in LauncherGUI

### DIFF
--- a/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
+++ b/src/main/java/org/mastodon/mamut/launcher/LauncherGUI.java
@@ -198,6 +198,8 @@ class LauncherGUI extends JPanel
 		c.gridwidth = 1;
 		c.gridy++;
 		btnHelp = new JButton( HELP_ICON_MEDIUM );
+		btnHelp.addActionListener( e -> openDocs() );
+		btnHelp.setToolTipText( "Open online documentation" );
 		sidePanel.add( btnHelp, c );
 
 		centralPanel = new JPanel();
@@ -363,14 +365,7 @@ class LauncherGUI extends JPanel
 				@Override
 				public void mouseClicked( final java.awt.event.MouseEvent e )
 				{
-					try
-					{
-						Desktop.getDesktop().browse( new URI( DOCUMENTATION_URL ) );
-					}
-					catch ( IOException | URISyntaxException e1 )
-					{
-						e1.printStackTrace();
-					}
+					openDocs();
 				}
 			} );
 			final GridBagConstraints gbcHyperlilnk = new GridBagConstraints();
@@ -387,6 +382,19 @@ class LauncherGUI extends JPanel
 			super.paintComponent( g );
 			final int x = getWidth() - MAINWINDOW_BG.getWidth( null );
 			g.drawImage( MAINWINDOW_BG, x, 0, this );
+		}
+	}
+
+	private static void openDocs()
+	{
+		try
+		{
+			System.out.println( DOCUMENTATION_URL );
+			Desktop.getDesktop().browse( new URI( DOCUMENTATION_URL ) );
+		}
+		catch ( IOException | URISyntaxException e1 )
+		{
+			e1.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
I accidentally discovered that the help / question mark button in the launcher GUI has no function.

I am not sure what the initial intention for this button was, but this PR at least lets this button open the online docs as well.

![grafik](https://github.com/user-attachments/assets/0f15af0b-6ac6-4607-b0e8-b46b3931f8dd)
