### PR TITLE
Cosmetic change in MainWindow

### DIFF
--- a/src/main/java/org/mastodon/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/mamut/MainWindow.java
@@ -111,7 +111,7 @@ public class MainWindow extends JFrame
 
 		// Main Panel
 		final JPanel buttonsPanel = new JPanel();
-		buttonsPanel.setLayout( new MigLayout( "wrap 2", "[150px!]10[150px!]" ) );
+		buttonsPanel.setLayout( new MigLayout( "wrap 2", "[190px!]10[190px!]" ) );
 
 		// Project:
 		final JPanel titlePanel = new JPanel();


### PR DESCRIPTION
The MainWindow layout appears a bit ugly in Linux environments. I suggest to make the window a bit wider to overcome this issue.

Before (Linux): 

![grafik](https://github.com/user-attachments/assets/d2fb8a23-56d8-48b2-9566-6b96e2b64082)

After (Linux):

![grafik](https://github.com/user-attachments/assets/6e1f891f-2676-4f6a-858b-1628651cc84e)

Before (Windows):

![grafik](https://github.com/user-attachments/assets/d973fef8-801b-412c-9454-9598c6b220c0)

After (Windows):

![grafik](https://github.com/user-attachments/assets/274d4255-475b-49a1-841f-e2df5f09e923)

