### PR TITLE
Add Geff importer and exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ Mastodon is a Java software that relies on several technologies to achieve these
 
 ## Usage.
 
+### Geff exporter CLI.
+
+A standalone command-line tool is provided to export a Mastodon project to the [Geff](https://github.com/litt-lab/geff) Zarr format.
+
+#### Build
+
+```bash
+mvn package -P geff-cli -DskipTests
+```
+
+This produces `target/geff-exporter-cli-<version>.jar`.
+
+#### Run
+
+```bash
+java -jar target/geff-exporter-cli-<version>.jar <input.mastodon> <output.geff>
+```
+
+**Example:**
+
+```bash
+java -jar target/geff-exporter-cli-1.0.0-beta-36-SNAPSHOT.jar /path/to/project.mastodon /path/to/output.geff
+```
+
+> **Note:** The following warnings are expected and harmless:
+> - `SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"` — no logging backend is bundled; output is suppressed.
+> - `WARNING: Blosc compression is unavailable` — install [c-blosc](https://github.com/Blosc/c-blosc) to enable compressed Zarr output; the export still succeeds using raw (uncompressed) chunks.
+
+---
+
 ### Actions and keyboard shortcuts.
 
 The keyboard shortcuts listed below are valid for the _default_ key-map.

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,52 @@
 		</pluginManagement>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>geff-cli</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.5.1</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<outputFile>${project.build.directory}/geff-exporter-cli-${project.version}.jar</outputFile>
+									<createDependencyReducedPom>false</createDependencyReducedPom>
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<mainClass>org.mastodon.mamut.io.exporter.geff.GeffExporterCLI</mainClass>
+										</transformer>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+											<resource>META-INF/json/org.scijava.plugin.Plugin</resource>
+										</transformer>
+									</transformers>
+									<filters>
+										<filter>
+											<artifact>*:*</artifact>
+											<excludes>
+												<exclude>META-INF/*.SF</exclude>
+												<exclude>META-INF/*.DSA</exclude>
+												<exclude>META-INF/*.RSA</exclude>
+											</excludes>
+										</filter>
+									</filters>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<mailingLists>
 		<mailingList>
 			<name>Image.sc Forum</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
 
 	<dependencies>
 		
+		<!-- Geff dependencies -->
+		<dependency>
+			<groupId>org.litt</groupId>
+			<artifactId>geff</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		
 		<!-- Mastodon dependencies -->
 		<dependency>
 			<groupId>org.mastodon</groupId>

--- a/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
@@ -45,7 +45,6 @@ import org.mastodon.geff.GeffAxis;
 import org.mastodon.geff.GeffEdge;
 import org.mastodon.geff.GeffMetadata;
 import org.mastodon.geff.GeffNode;
-import org.mastodon.geff.GeffUtils;
 
 public class GeffExporter
 {
@@ -123,7 +122,7 @@ public class GeffExporter
 			final GeffMetadata metadata = new GeffMetadata( "1.0.0", true, axes );
 
 			GeffNode.writeToZarr( nodes, zarrPath, metadata );
-			GeffEdge.writeToZarr( edges, zarrPath, GeffUtils.DEFAULT_CHUNK_SIZE, metadata );
+			GeffEdge.writeToZarr( edges, zarrPath, metadata );
 			GeffMetadata.writeToZarr( metadata, zarrPath );
 		}
 		finally

--- a/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
@@ -1,0 +1,149 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.exporter.geff;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+
+import org.mastodon.geff.GeffAxis;
+import org.mastodon.geff.GeffEdge;
+import org.mastodon.geff.GeffMetadata;
+import org.mastodon.geff.GeffNode;
+import org.mastodon.geff.GeffUtils;
+
+public class GeffExporter
+{
+
+	/**
+	 * Exports the model of {@code projectModel} to a Geff Zarr directory at
+	 * {@code zarrPath}.
+	 */
+	public static void exportGeff( final ProjectModel projectModel, final String zarrPath ) throws IOException
+	{
+		exportGeff( projectModel.getModel(), zarrPath );
+	}
+
+	/**
+	 * Exports {@code model} to a Geff Zarr directory at {@code zarrPath}.
+	 */
+	public static void exportGeff( final Model model, final String zarrPath ) throws IOException
+	{
+		final ModelGraph graph = model.getGraph();
+
+		// Build GeffNodes from Spots
+		final List< GeffNode > nodes = new ArrayList<>();
+		final Map< Spot, Integer > spotToGeffId = new HashMap<>();
+		int geffId = 0;
+		final double[][] cov = new double[ 3 ][ 3 ];
+		final Spot vRef = graph.vertexRef();
+		try
+		{
+			for ( final Spot spot : graph.vertices() )
+			{
+				spot.getCovariance( cov );
+				final double radius = Math.sqrt( spot.getBoundingSphereRadiusSquared() );
+				final GeffNode node = new GeffNode.Builder()
+						.id( geffId )
+						.timepoint( spot.getTimepoint() )
+						.x( spot.getDoublePosition( 0 ) )
+						.y( spot.getDoublePosition( 1 ) )
+						.z( spot.getDoublePosition( 2 ) )
+						.radius( radius )
+						.covariance3d( matrixToFlat3x3( cov ) )
+						.build();
+				nodes.add( node );
+				// Use a copy of the spot reference as the map key
+				final Spot copy = graph.vertexRef();
+				copy.refTo( spot );
+				spotToGeffId.put( copy, geffId++ );
+			}
+
+			// Build GeffEdges from Links
+			final List< GeffEdge > edges = new ArrayList<>();
+			int edgeId = 0;
+			for ( final Link link : graph.edges() )
+			{
+				final Integer srcId = spotToGeffId.get( link.getSource( vRef ) );
+				final Integer tgtId = spotToGeffId.get( link.getTarget( vRef ) );
+				if ( srcId == null || tgtId == null )
+					continue;
+
+				final GeffEdge edge = new GeffEdge.Builder()
+						.setId( edgeId++ )
+						.setSourceNodeId( srcId )
+						.setTargetNodeId( tgtId )
+						.build();
+				edges.add( edge );
+			}
+
+			// Build metadata with axes derived from model units
+			final List< GeffAxis > axes = buildAxes( model.getTimeUnits(), model.getSpaceUnits() );
+			final GeffMetadata metadata = new GeffMetadata( "1.0.0", true, axes );
+
+			GeffNode.writeToZarr( nodes, zarrPath, metadata );
+			GeffEdge.writeToZarr( edges, zarrPath, GeffUtils.DEFAULT_CHUNK_SIZE, metadata );
+			GeffMetadata.writeToZarr( metadata, zarrPath );
+		}
+		finally
+		{
+			// Release all copied spot refs used as map keys
+			for ( final Spot s : spotToGeffId.keySet() )
+				graph.releaseRef( s );
+			graph.releaseRef( vRef );
+		}
+	}
+
+	private static List< GeffAxis > buildAxes( final String timeUnit, final String spaceUnit )
+	{
+		return Arrays.asList(
+				GeffAxis.createTimeAxis( GeffAxis.NAME_TIME, timeUnit, null, null ),
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_X, spaceUnit, null, null ),
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Y, spaceUnit, null, null ),
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Z, spaceUnit, null, null ) );
+	}
+
+	/**
+	 * Flattens a symmetric 3×3 covariance matrix to the upper-triangular
+	 * 6-element vector {@code [m00, m01, m02, m11, m12, m22]} used by Geff.
+	 */
+	static double[] matrixToFlat3x3( final double[][] m )
+	{
+		return new double[] { m[ 0 ][ 0 ], m[ 0 ][ 1 ], m[ 0 ][ 2 ], m[ 1 ][ 1 ], m[ 1 ][ 2 ], m[ 2 ][ 2 ] };
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporter.java
@@ -71,7 +71,8 @@ public class GeffExporter
 		final Map< Spot, Integer > spotToGeffId = new HashMap<>();
 		int geffId = 0;
 		final double[][] cov = new double[ 3 ][ 3 ];
-		final Spot vRef = graph.vertexRef();
+		final Spot srcRef = graph.vertexRef();
+		final Spot tgtRef = graph.vertexRef();
 		try
 		{
 			for ( final Spot spot : graph.vertices() )
@@ -99,15 +100,20 @@ public class GeffExporter
 			int edgeId = 0;
 			for ( final Link link : graph.edges() )
 			{
-				final Integer srcId = spotToGeffId.get( link.getSource( vRef ) );
-				final Integer tgtId = spotToGeffId.get( link.getTarget( vRef ) );
+				link.getSource( srcRef );
+				link.getTarget( tgtRef );
+				final Integer srcId = spotToGeffId.get( srcRef );
+				final Integer tgtId = spotToGeffId.get( tgtRef );
 				if ( srcId == null || tgtId == null )
 					continue;
 
+				// Geff convention: source is the earlier spot (smaller timepoint).
+				// Swap if mastodon stored the link in reverse temporal order.
+				final boolean swap = srcRef.getTimepoint() > tgtRef.getTimepoint();
 				final GeffEdge edge = new GeffEdge.Builder()
 						.setId( edgeId++ )
-						.setSourceNodeId( srcId )
-						.setTargetNodeId( tgtId )
+						.setSourceNodeId( swap ? tgtId : srcId )
+						.setTargetNodeId( swap ? srcId : tgtId )
 						.build();
 				edges.add( edge );
 			}
@@ -125,7 +131,8 @@ public class GeffExporter
 			// Release all copied spot refs used as map keys
 			for ( final Spot s : spotToGeffId.keySet() )
 				graph.releaseRef( s );
-			graph.releaseRef( vRef );
+			graph.releaseRef( srcRef );
+			graph.releaseRef( tgtRef );
 		}
 	}
 
@@ -133,9 +140,44 @@ public class GeffExporter
 	{
 		return Arrays.asList(
 				GeffAxis.createTimeAxis( GeffAxis.NAME_TIME, timeUnit, null, null ),
-				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_X, spaceUnit, null, null ),
-				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Y, spaceUnit, null, null ),
-				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Z, spaceUnit, null, null ) );
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_X, normalizeSpaceUnit( spaceUnit ), null, null ),
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Y, normalizeSpaceUnit( spaceUnit ), null, null ),
+				GeffAxis.createSpaceAxis( GeffAxis.NAME_SPACE_Z, normalizeSpaceUnit( spaceUnit ), null, null ) );
+	}
+
+	/**
+	 * Maps common unit abbreviations to OME-Zarr compliant names.
+	 * See https://ngff.openmicroscopy.org/latest/#axes-md for the valid set.
+	 */
+	static String normalizeSpaceUnit( final String unit )
+	{
+		if ( unit == null || unit.isEmpty() )
+			return "pixel";
+		switch ( unit.trim() )
+		{
+		case "um":
+		case "µm":
+		case "μm":
+		case "micron":
+		case "microns":
+			return "micrometer";
+		case "nm":
+			return "nanometer";
+		case "mm":
+			return "millimeter";
+		case "cm":
+			return "centimeter";
+		case "m":
+			return "meter";
+		case "km":
+			return "kilometer";
+		case "pm":
+			return "picometer";
+		case "Å":
+			return "angstrom";
+		default:
+			return unit;
+		}
 	}
 
 	/**

--- a/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporterCLI.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporterCLI.java
@@ -1,0 +1,80 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.exporter.geff;
+
+import java.io.IOException;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.ProjectLoader;
+import org.scijava.Context;
+
+import mpicbg.spim.data.SpimDataException;
+
+/**
+ * Command-line interface for exporting a Mastodon project to a Geff Zarr file.
+ * <p>
+ * Usage: {@code GeffExporterCLI <input.mastodon> <output.geff>}
+ */
+public class GeffExporterCLI
+{
+
+	public static void main( final String[] args )
+	{
+		if ( args.length != 2 )
+		{
+			System.err.println( "Usage: GeffExporterCLI <input.mastodon> <output.geff>" );
+			System.exit( 1 );
+		}
+
+		final String mastodonFile = args[ 0 ];
+		final String geffPath = args[ 1 ];
+
+		try ( final Context context = new Context() )
+		{
+			System.out.println( "Loading project: " + mastodonFile );
+			final ProjectModel projectModel = ProjectLoader.open( mastodonFile, context, false, true );
+
+			System.out.println( "Exporting to Geff: " + geffPath );
+			GeffExporter.exportGeff( projectModel, geffPath );
+
+			System.out.println( "Done." );
+		}
+		catch ( final IOException e )
+		{
+			System.err.println( "I/O error: " + e.getMessage() );
+			System.exit( 1 );
+		}
+		catch ( final SpimDataException e )
+		{
+			System.err.println( "Failed to load image data: " + e.getMessage() );
+			System.exit( 1 );
+		}
+		System.exit( 0 );
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporterPlugin.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/geff/GeffExporterPlugin.java
@@ -1,0 +1,141 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.exporter.geff;
+
+import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.menu;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+
+import org.mastodon.app.ui.ViewMenuBuilder;
+import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.MamutMenuBuilder;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.plugin.MamutPlugin;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionProvider;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptions;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.RunnableAction;
+
+@Plugin( type = MamutPlugin.class )
+public class GeffExporterPlugin implements MamutPlugin
+{
+
+	private static final String EXPORT_GEFF = "export geff";
+
+	private static final String[] EXPORT_GEFF_KEYS = new String[] { "not mapped" };
+
+	private ProjectModel projectModel;
+
+	private final RunnableAction exportGeffAction;
+
+	public GeffExporterPlugin()
+	{
+		this.exportGeffAction = new RunnableAction( EXPORT_GEFF, this::exportGeff );
+	}
+
+	@Override
+	public void setAppPluginModel( final ProjectModel projectModel )
+	{
+		this.projectModel = projectModel;
+	}
+
+	@Override
+	public Map< String, String > getMenuTexts()
+	{
+		final Map< String, String > menuTexts = new HashMap<>();
+		menuTexts.put( EXPORT_GEFF, "Export to Geff" );
+		return menuTexts;
+	}
+
+	@Override
+	public List< ViewMenuBuilder.MenuItem > getMenuItems()
+	{
+		return Collections.singletonList(
+				MamutMenuBuilder.fileMenu( menu( "Export", item( EXPORT_GEFF ) ) ) );
+	}
+
+	@Override
+	public void installGlobalActions( final Actions actions )
+	{
+		actions.namedAction( exportGeffAction, EXPORT_GEFF_KEYS );
+	}
+
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigScopes.MAMUT, KeyConfigContexts.MASTODON );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add(
+					EXPORT_GEFF,
+					EXPORT_GEFF_KEYS,
+					"Export the current tracking data to a Geff Zarr directory." );
+		}
+	}
+
+	private void exportGeff()
+	{
+		final JFileChooser chooser = new JFileChooser();
+		chooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
+		chooser.setSelectedFile( new File( projectModel.getProjectName() + ".zarr" ) );
+		chooser.setDialogTitle( "Export to Geff Zarr directory" );
+		if ( chooser.showSaveDialog( null ) != JFileChooser.APPROVE_OPTION )
+			return;
+
+		final String zarrPath = chooser.getSelectedFile().getAbsolutePath();
+		try
+		{
+			GeffExporter.exportGeff( projectModel, zarrPath );
+		}
+		catch ( final IOException e )
+		{
+			JOptionPane.showMessageDialog(
+					null,
+					"Problem exporting to Geff at " + zarrPath + "\n" + e.getMessage(),
+					"Geff exporter",
+					JOptionPane.ERROR_MESSAGE );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImportedLinkFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImportedLinkFeatures.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.geff;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.Multiplicity;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeatures;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+import org.scijava.plugin.Plugin;
+
+public class GeffImportedLinkFeatures extends TrackMateImportedFeatures< Link >
+{
+
+	public static final String KEY = "Geff Link features";
+
+	private static final String HELP_STRING =
+			"Stores the link feature values imported from a Geff file.";
+
+	private final Spec spec = new Spec();
+
+	@Plugin( type = FeatureSpec.class )
+	public static class Spec extends FeatureSpec< GeffImportedLinkFeatures, Link >
+	{
+		public Spec()
+		{
+			super(
+					KEY,
+					HELP_STRING,
+					GeffImportedLinkFeatures.class,
+					Link.class,
+					Multiplicity.SINGLE );
+		}
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Link > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Link > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureSpec< ? extends Feature< Link >, Link > getSpec()
+	{
+		return spec;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImportedSpotFeatures.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImportedSpotFeatures.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.geff;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.Feature;
+import org.mastodon.feature.FeatureProjectionKey;
+import org.mastodon.feature.FeatureProjectionSpec;
+import org.mastodon.feature.FeatureSpec;
+import org.mastodon.feature.Multiplicity;
+import org.mastodon.mamut.io.importer.trackmate.TrackMateImportedFeatures;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+import org.scijava.plugin.Plugin;
+
+public class GeffImportedSpotFeatures extends TrackMateImportedFeatures< Spot >
+{
+
+	public static final String KEY = "Geff Spot features";
+
+	private static final String HELP_STRING =
+			"Stores the spot feature values imported from a Geff file.";
+
+	private final Spec spec = new Spec();
+
+	@Plugin( type = FeatureSpec.class )
+	public static class Spec extends FeatureSpec< GeffImportedSpotFeatures, Spot >
+	{
+		public Spec()
+		{
+			super(
+					KEY,
+					HELP_STRING,
+					GeffImportedSpotFeatures.class,
+					Spot.class,
+					Multiplicity.SINGLE );
+		}
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final DoublePropertyMap< Spot > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureProjectionKey store( final String key, final Dimension dimension, final String units, final IntPropertyMap< Spot > values )
+	{
+		final FeatureProjectionKey projectionKey = super.store( key, dimension, units, values );
+		spec.getProjectionSpecs().add( new FeatureProjectionSpec( key, dimension ) );
+		return projectionKey;
+	}
+
+	@Override
+	public FeatureSpec< ? extends Feature< Spot >, Spot > getSpec()
+	{
+		return spec;
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImporter.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImporter.java
@@ -1,0 +1,194 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.geff;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mastodon.feature.Dimension;
+import org.mastodon.feature.FeatureModel;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.importer.ModelImporter;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+
+import org.mastodon.geff.GeffEdge;
+import org.mastodon.geff.GeffMetadata;
+import org.mastodon.geff.GeffNode;
+
+public class GeffImporter extends ModelImporter
+{
+
+	/**
+	 * Imports the Geff Zarr dataset at {@code zarrPath} into the model of
+	 * {@code projectModel}.
+	 */
+	public static void importGeff( final String zarrPath, final ProjectModel projectModel ) throws IOException
+	{
+		importGeff( zarrPath, projectModel.getModel() );
+	}
+
+	/**
+	 * Imports the Geff Zarr dataset at {@code zarrPath} into {@code model}.
+	 */
+	public static void importGeff( final String zarrPath, final Model model ) throws IOException
+	{
+		new GeffImporter( model ).read( zarrPath );
+	}
+
+	private final Model model;
+
+	private GeffImporter( final Model model )
+	{
+		super( model );
+		this.model = model;
+	}
+
+	private void read( final String zarrPath ) throws IOException
+	{
+		final ModelGraph graph = model.getGraph();
+		final FeatureModel featureModel = model.getFeatureModel();
+
+		final Spot vRef1 = graph.vertexRef();
+		final Spot vRef2 = graph.vertexRef();
+		final Link eRef = graph.edgeRef();
+
+		startImport();
+		try
+		{
+			final GeffMetadata metadata = GeffMetadata.readFromZarr( zarrPath );
+			final List< GeffNode > nodes = GeffNode.readFromZarr( zarrPath, metadata );
+			final List< GeffEdge > edges = GeffEdge.readFromZarr( zarrPath, metadata.getGeffVersion() );
+
+			// Feature storage
+			final GeffImportedSpotFeatures spotFeatures = new GeffImportedSpotFeatures();
+			final GeffImportedLinkFeatures linkFeatures = new GeffImportedLinkFeatures();
+			final String noUnits = Dimension.NONE.getUnits( model.getSpaceUnits(), model.getTimeUnits() );
+			final IntPropertyMap< Spot > segmentIdMap = new IntPropertyMap<>( graph.vertices(), Integer.MIN_VALUE );
+			final DoublePropertyMap< Link > scoreMap = new DoublePropertyMap<>( graph.edges(), Double.NaN );
+			final DoublePropertyMap< Link > distanceMap = new DoublePropertyMap<>( graph.edges(), Double.NaN );
+
+			// Import nodes → Spots
+			final Map< Integer, Spot > spotMap = new HashMap<>( nodes.size() );
+			final double[] pos = new double[ 3 ];
+			for ( final GeffNode node : nodes )
+			{
+				pos[ 0 ] = node.getX();
+				pos[ 1 ] = node.getY();
+				pos[ 2 ] = node.getZ();
+
+				final Spot spot;
+				final double[] cov3d = node.getCovariance3d();
+				if ( cov3d != null )
+				{
+					final double[][] cov = flatToMatrix3x3( cov3d );
+					spot = graph.addVertex( vRef1 ).init( node.getT(), pos, cov );
+				}
+				else if ( node.getRadius() > 0 )
+				{
+					spot = graph.addVertex( vRef1 ).init( node.getT(), pos, node.getRadius() );
+				}
+				else
+				{
+					spot = graph.addVertex( vRef1 ).init( node.getT(), pos, GeffNode.DEFAULT_RADIUS );
+				}
+
+				// Store segmentId as feature if set
+				if ( node.getSegmentId() != 0 )
+					segmentIdMap.set( spot, node.getSegmentId() );
+
+				// Keep a copy of the Spot reference for link creation
+				final Spot copy = graph.vertexRef();
+				copy.refTo( spot );
+				spotMap.put( node.getId(), copy );
+			}
+
+			// Import edges → Links
+			for ( final GeffEdge edge : edges )
+			{
+				final Spot source = spotMap.get( edge.getSourceNodeId() );
+				final Spot target = spotMap.get( edge.getTargetNodeId() );
+				if ( source == null || target == null )
+					continue;
+
+				final Link link = graph.addEdge( source, target, eRef ).init();
+
+				if ( edge.getScore() != GeffEdge.DEFAULT_SCORE )
+					scoreMap.set( link, edge.getScore() );
+				if ( edge.getDistance() != GeffEdge.DEFAULT_DISTANCE )
+					distanceMap.set( link, edge.getDistance() );
+			}
+
+			// Release copied vertex refs
+			for ( final Spot s : spotMap.values() )
+				graph.releaseRef( s );
+
+			// Register features
+			spotFeatures.store( "Segment ID", Dimension.NONE, noUnits, segmentIdMap );
+			linkFeatures.store( "Score", Dimension.NONE, noUnits, scoreMap );
+			linkFeatures.store( "Distance", Dimension.NONE, noUnits, distanceMap );
+
+			featureModel.pauseListeners();
+			featureModel.declareFeature( spotFeatures );
+			featureModel.declareFeature( linkFeatures );
+		}
+		finally
+		{
+			graph.releaseRef( vRef1 );
+			graph.releaseRef( vRef2 );
+			graph.releaseRef( eRef );
+			model.getFeatureModel().resumeListeners();
+			finishImport();
+		}
+	}
+
+	/**
+	 * Converts a flat 6-element upper-triangular covariance vector
+	 * {@code [c0,c1,c2,c3,c4,c5]} (row-major) to a symmetric 3×3 matrix:
+	 * <pre>
+	 * [[c0, c1, c2],
+	 *  [c1, c3, c4],
+	 *  [c2, c4, c5]]
+	 * </pre>
+	 */
+	static double[][] flatToMatrix3x3( final double[] c )
+	{
+		return new double[][] {
+				{ c[ 0 ], c[ 1 ], c[ 2 ] },
+				{ c[ 1 ], c[ 3 ], c[ 4 ] },
+				{ c[ 2 ], c[ 4 ], c[ 5 ] }
+		};
+	}
+}

--- a/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImporterPlugin.java
+++ b/src/main/java/org/mastodon/mamut/io/importer/geff/GeffImporterPlugin.java
@@ -1,0 +1,141 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2025 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.mamut.io.importer.geff;
+
+import static org.mastodon.app.ui.ViewMenuBuilder.item;
+import static org.mastodon.app.ui.ViewMenuBuilder.menu;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+
+import org.mastodon.app.MastodonIcons;
+import org.mastodon.app.ui.ViewMenuBuilder;
+import org.mastodon.mamut.KeyConfigScopes;
+import org.mastodon.mamut.MamutMenuBuilder;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.plugin.MamutPlugin;
+import org.mastodon.ui.keymap.KeyConfigContexts;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionProvider;
+import org.scijava.ui.behaviour.io.gui.CommandDescriptions;
+import org.scijava.ui.behaviour.util.Actions;
+import org.scijava.ui.behaviour.util.RunnableAction;
+
+@Plugin( type = MamutPlugin.class )
+public class GeffImporterPlugin implements MamutPlugin
+{
+
+	private static final String IMPORT_GEFF = "import geff";
+
+	private static final String[] IMPORT_GEFF_KEYS = new String[] { "not mapped" };
+
+	private ProjectModel projectModel;
+
+	private final RunnableAction importGeffAction;
+
+	public GeffImporterPlugin()
+	{
+		this.importGeffAction = new RunnableAction( IMPORT_GEFF, this::importGeff );
+	}
+
+	@Override
+	public void setAppPluginModel( final ProjectModel projectModel )
+	{
+		this.projectModel = projectModel;
+	}
+
+	@Override
+	public Map< String, String > getMenuTexts()
+	{
+		final Map< String, String > menuTexts = new HashMap<>();
+		menuTexts.put( IMPORT_GEFF, "Import Geff" );
+		return menuTexts;
+	}
+
+	@Override
+	public List< ViewMenuBuilder.MenuItem > getMenuItems()
+	{
+		return Collections.singletonList(
+				MamutMenuBuilder.fileMenu( menu( "Import", item( IMPORT_GEFF ) ) ) );
+	}
+
+	@Override
+	public void installGlobalActions( final Actions actions )
+	{
+		actions.namedAction( importGeffAction, IMPORT_GEFF_KEYS );
+	}
+
+	@Plugin( type = Descriptions.class )
+	public static class Descriptions extends CommandDescriptionProvider
+	{
+		public Descriptions()
+		{
+			super( KeyConfigScopes.MAMUT, KeyConfigContexts.MASTODON );
+		}
+
+		@Override
+		public void getCommandDescriptions( final CommandDescriptions descriptions )
+		{
+			descriptions.add(
+					IMPORT_GEFF,
+					IMPORT_GEFF_KEYS,
+					"Import a Geff Zarr directory into the current model." );
+		}
+	}
+
+	private void importGeff()
+	{
+		final JFileChooser chooser = new JFileChooser();
+		chooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
+		chooser.setDialogTitle( "Select Geff Zarr directory" );
+		if ( chooser.showOpenDialog( null ) != JFileChooser.APPROVE_OPTION )
+			return;
+
+		final String zarrPath = chooser.getSelectedFile().getAbsolutePath();
+		try
+		{
+			GeffImporter.importGeff( zarrPath, projectModel );
+		}
+		catch ( final IOException e )
+		{
+			JOptionPane.showMessageDialog(
+					null,
+					"Problem importing Geff from " + zarrPath + "\n" + e.getMessage(),
+					"Geff importer",
+					JOptionPane.ERROR_MESSAGE,
+					MastodonIcons.MASTODON_ICON_MEDIUM );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GeffImporter` and `GeffExporter` to read/write Mastodon tracking data in the [Geff](http://liveimagetrackingtools.org/geff/) Zarr format
- Registers both as Mastodon plugins (`GeffImporterPlugin`, `GeffExporterPlugin`) accessible from the UI
- Imports edge and node properties (distance, score, custom props) as Mastodon link/spot features via `GeffImportedLinkFeatures` and `GeffImportedSpotFeatures`
- Adds a standalone CLI tool (`GeffExporterCLI`) buildable via `mvn package -P geff-cli`
- Adds `org.litt:geff:1.0.0-SNAPSHOT` dependency and a `geff-cli` Maven profile for the shaded CLI jar
